### PR TITLE
Install system fonts

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -164,7 +164,8 @@ let package_show p () =
   compatibility_optin ();
   Registory.directory reg p
     |> Package.read_dir
-    |> [%derive.show: Package.t]
+    |> [%sexp_of: Package.t]
+    |> Sexp.to_string_hum
     |> print_endline
 let package_show_command =
   package_show_command_g package_show
@@ -186,7 +187,8 @@ let package_opam_show p () =
   compatibility_optin ();
   SatysfiRegistory.directory reg_opam p
     |> Package.read_dir
-    |> [%derive.show: Package.t]
+    |> [%sexp_of: Package.t]
+    |> Sexp.to_string_hum
     |> print_endline
 let package_opam_show_command =
   package_show_command_g package_opam_show
@@ -239,9 +241,13 @@ let install d () =
     FileUtil.(rm ~force:Force ~recurse:true [d]);
     Package.mark_managed_dir d;
     Printf.printf "Loaded packages\n";
-    [%derive.show: Package.t list] packages |> print_endline;
+    [%sexp_of: Package.t list] packages
+    |> Sexp.to_string_hum
+    |> print_endline;
     Printf.printf "Installing to %s\n" d;
-    [%derive.show: Package.t] merged |> print_endline;
+    [%sexp_of: Package.t] merged
+    |> Sexp.to_string_hum
+    |> print_endline;
     Package.write_dir d merged;
     Printf.printf "Installation completed!\n";
     List.iter ~f:(Printf.printf "(WARNING) %s") (Package.validate merged)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -248,7 +248,7 @@ let install d () =
     [%sexp_of: Package.t] merged
     |> Sexp.to_string_hum
     |> print_endline;
-    Package.write_dir d merged;
+    Package.write_dir ~symlink:true d merged;
     Printf.printf "Installation completed!\n";
     List.iter ~f:(Printf.printf "(WARNING) %s") (Package.validate merged)
 

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -25,6 +25,6 @@ depends: [
   "ppx_inline_test" {build}
   "ppx_jane" {build}
   "satysfi" {>= "0.0.3" & < "0.0.4"}
-  "uri"
+  "uri" {>= "2.0.0"}
   "yojson"
 ]

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -20,6 +20,7 @@ depends: [
   "core"
   "dune" {build}
   "fileutils"
+  "json-derivers"
   "ppx_deriving" {build}
   "ppx_inline_test" {build}
   "ppx_jane" {build}

--- a/src/dune
+++ b/src/dune
@@ -3,4 +3,4 @@
  (synopsis "Internal Satyrographos Library, do not use!")
  (inline_tests)
  (preprocess (staged_pps ppx_deriving.std ppx_jane))
- (libraries core fileutils uri uri.sexp yojson))
+ (libraries core fileutils json-derivers uri uri.sexp yojson))

--- a/src/package.ml
+++ b/src/package.ml
@@ -132,7 +132,7 @@ let read_dir d =
   then FileUtil.(find ~follow:Follow Is_file d add empty)
   else failwith (d ^ " is not a package directory")
 
-let write_dir ?(symlink=false) d p =
+let write_dir ?(verbose=false) ?(symlink=false) d p =
   let p = normalize p in
   FileUtil.mkdir ~parent:true d;
   PackageFiles.iteri ~f:(fun ~key:path ~data:fullpath ->
@@ -141,7 +141,9 @@ let write_dir ?(symlink=false) d p =
       then "Linking"
       else "Copying"
     in
-    Printf.printf "%s %s to %s\n" action fullpath file_dst;
+    begin if verbose
+      then Printf.printf "%s %s to %s\n" action fullpath file_dst
+    end;
     FileUtil.mkdir ~parent:true (FilePath.dirname file_dst);
     if symlink
     then Unix.symlink ~src:fullpath ~dst:file_dst
@@ -149,7 +151,9 @@ let write_dir ?(symlink=false) d p =
   ) p.files;
   PackageFiles.iteri ~f:(fun ~key:path ~data:(_, h) ->
     let file_dst = FilePath.concat d path in
-    Printf.printf "Generating %s\n" file_dst;
+    begin if verbose
+      then Printf.printf "Generating %s\n" file_dst
+    end;
     FileUtil.mkdir ~parent:true (FilePath.dirname file_dst);
     Json.to_file file_dst h
   ) p.hashes

--- a/src/registory.ml
+++ b/src/registory.ml
@@ -30,7 +30,7 @@ let build_package reg name =
     (* TODO properly build the package *)
     let dir = Repository.directory reg.repository name in
     let package = Package.read_dir dir in
-    [%derive.show: Package.t] package |> print_endline;
+    Package.to_string package |> print_endline;
     Store.remove reg.registory name;
     Store.add_package reg.registory name package
 

--- a/src/repository.ml
+++ b/src/repository.ml
@@ -37,7 +37,7 @@ let update reg name =
     | Some "file" ->
       let dir = Uri.path metadata.url in
       let package = Package.read_dir dir in
-      [%derive.show: Package.t] package |> print_endline;
+      Package.to_string package |> print_endline;
       Store.remove reg.cache name;
       Store.add_package reg.cache name package
     | None ->

--- a/src/systemFontPackage.ml
+++ b/src/systemFontPackage.ml
@@ -87,7 +87,6 @@ let font_to_json_and_hash prefix f =
       let value = `Assoc ["src-dist", `String (filename f)] in
       [(name f, `Variant ("Single", Some value)), (filepath f, f.file)]
     | `Collection fs ->
-      [%sexp_of: Font.t list] fs |> Sexp.to_string |> print_endline;
       List.map fs ~f:(fun f ->
         let value = `Assoc [
           "src-dist", `String (filename f);
@@ -116,7 +115,7 @@ let fonts_to_package prefix fonts =
     hashes = PackageFiles.singleton hash_filename_fonts ([hash_path_fonts], `Assoc hash);
     files = PackageFiles.of_alist_reduce files ~f:(fun f1 f2 ->
       begin if not (String.equal f1 f2)
-        then Printf.printf "%s and %s have conflicting filename.\n" f1 f2
+        then Printf.printf "WARNING: %s and %s have conflicting filename.\n" f1 f2
       end;
       f1
     )

--- a/src/systemFontPackage.ml
+++ b/src/systemFontPackage.ml
@@ -1,0 +1,126 @@
+open Core
+
+module StringSet = Set.Make(String)
+
+let blacklist = StringSet.of_list [
+  (* Each SanFranciso font has several weights with the same postscriptname *)
+  "/System/Library/Fonts/SFNSDisplay.ttf";
+  "/System/Library/Fonts/SFNSText.ttf";
+  "/System/Library/Fonts/SFNSTextItalic.ttf";
+]
+
+module Font = struct
+  type t = {
+    file: string;
+    postscriptname: string;
+    index: int;
+    fontformat: string
+  } [@@deriving sexp, compare]
+end
+
+module DistinctFont = struct
+  type t = {
+    file: string;
+    index: int;
+  } [@@deriving sexp, compare]
+
+  let of_font (f: Font.t) = {
+    file = f.file;
+    index = f.index;
+  }
+end
+
+let font_fields =
+  ["file"; "postscriptname"; "index"; "fontformat"]
+
+let fc_format_data_field field =
+  Printf.sprintf "(%s \"%%{%s|cescape}\")" field field
+
+let fc_format_data =
+  List.map ~f:fc_format_data_field font_fields
+  |> String.concat ~sep:" "
+  |> Printf.sprintf "(%s)"
+
+module DistinctFontMap = Map.Make(DistinctFont)
+
+let font_list () =
+  Printf.sprintf "fc-list -f '%s'" fc_format_data (* TODO escape quotes *)
+  |> Unix.open_process_in
+  |> In_channel.input_all
+  |> Printf.sprintf "(%s)"
+  |> Sexp.of_string
+  |> [%of_sexp: Font.t list] (* Use Parsexp.Many *)
+  |> List.filter ~f:(fun f -> not (StringSet.mem blacklist f.file))
+  |> List.map ~f:(fun f -> DistinctFont.of_font f, f)
+  |> DistinctFontMap.of_alist_reduce ~f:(fun f1 f2 ->
+      let sf1 = [%sexp_of: Font.t] f1 |> Sexp.to_string in
+      let sf2 = [%sexp_of: Font.t] f2 |> Sexp.to_string in
+      begin if not ([%compare.equal: Font.t] f1 f2)
+        then Printf.printf "WARNING: the following fonts look the same.\n%s\n%s\n\n" sf1 sf2
+      end;
+      f1
+    )
+  |> DistinctFontMap.data
+
+let satysfi_name (font: Font.t) =
+  font.postscriptname
+
+module FileMap = Map.Make(String)
+module Json = struct
+  include Yojson.Safe
+  include Json_derivers.Yojson
+end
+
+let font_dir = "fonts/"
+let font_filename_prefix = "system-"
+
+(* TODO handle filename collision *)
+let font_to_json_and_hash prefix f =
+  let filename (f: Font.t) = font_filename_prefix ^ FilePath.basename f.file in
+  let filepath (f: Font.t) = font_dir ^ filename f in
+  let name (f: Font.t) = prefix ^ match f.postscriptname with
+    | "" -> FilePath.basename f.file
+    | psname -> psname
+  in
+  match f with
+    | `Single f ->
+      let value = `Assoc ["src-dist", `String (filename f)] in
+      [(name f, `Variant ("Single", Some value)), (filepath f, f.file)]
+    | `Collection fs ->
+      [%sexp_of: Font.t list] fs |> Sexp.to_string |> print_endline;
+      List.map fs ~f:(fun f ->
+        let value = `Assoc [
+          "src-dist", `String (filename f);
+          "index", `Int f.index
+        ] in
+        (name f, `Variant ("Collection", Some value)), (filepath f, f.file)
+      )
+
+let fonts_to_package prefix fonts =
+  let add_variant = function
+    | [] -> failwith "BUG: fonts_to_package"
+    | [f] -> `Single f
+    | fs -> `Collection fs
+  in
+  (* let stored_font_name font = FilePath.basename font.file in *)
+  let (hash, files) = List.map ~f:(fun (f: Font.t) -> f.file, f) fonts
+    |> FileMap.of_alist_multi
+    |> FileMap.map ~f:add_variant
+    |> FileMap.data
+    |> List.concat_map ~f:(font_to_json_and_hash prefix)
+    |> List.unzip
+  in
+  let hash_filename_fonts = "hash/fonts.satysfi-hash" in
+  let hash_path_fonts = "#Automatically generated from the system fonts#" in
+  Package.{
+    hashes = PackageFiles.singleton hash_filename_fonts ([hash_path_fonts], `Assoc hash);
+    files = PackageFiles.of_alist_reduce files ~f:(fun f1 f2 ->
+      begin if not (String.equal f1 f2)
+        then Printf.printf "%s and %s have conflicting filename.\n" f1 f2
+      end;
+      f1
+    )
+  }
+
+let get_package prefix () =
+  font_list () |> fonts_to_package prefix


### PR DESCRIPTION
This PR makes it possible to
- install system fonts with command line option `-system-font-prefix <system-font-name-prefix>`, and
- control verbosity of messages with command line option `-verbose`.

This only works on Mac and Linux Desktop Environments because it assumes the system has `fc-list` in PATH, which means [fontconfig](https://www.freedesktop.org/wiki/Software/fontconfig/) has been installed there. This should work on Cygwin as well, while I have no idea about Windows Subsystem of Linux (WSL).

Currently, it does not handle fonts with the same filename. I will work on that later.

Resolves #2.