### PR TITLE
Fix bug where packages installed in opam are ignored

### DIFF
--- a/src/satysfiDirs.ml
+++ b/src/satysfiDirs.ml
@@ -25,11 +25,12 @@ let opam_share_dir () =
 
 let satysfi_dist_dir () =
   let shares = [opam_share_dir (); "/usr/local/share"; "/usr/share"] in
+  let dist_dirs = List.map shares ~f:(fun d -> Filename.concat d "satysfi" |> (fun d -> Filename.concat d "dist")) in
   let rec f = function
     | [] -> failwith "Can't find SATySFi lib. Please install it."
     | (d :: ds) ->
-      if Filename.concat d "satysfi" |> (fun d -> Filename.concat d "dist") |> is_runtime_dir
+      if is_runtime_dir d
         then d
         else f ds
   in
-  f shares
+  f dist_dirs


### PR DESCRIPTION
This bug was introduced by #11 .

This correctly implements #9 