### PR TITLE
Core v0.12 support

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -277,7 +277,7 @@ let install_command =
     ~readme
     [%map_open
       let system_font_prefix = flag "system-font-prefix" (optional string) ~doc:"FONT_NAME_PREFIX Installing system fonts with names with the given prefix"
-      and target_dir = anon (maybe_with_default default_target_dir ("DIR" %: file))
+      and target_dir = anon (maybe_with_default default_target_dir ("DIR" %: string))
       and verbose = flag "verbose" no_arg ~doc:"Make verbose"
       and copy = flag "copy" no_arg ~doc:"Copy files instead of making symlinks"
       in

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -16,7 +16,6 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "cmdliner"
   "core" {< "v0.13"}
   "dune" {build}
   "fileutils"

--- a/src/package.ml
+++ b/src/package.ml
@@ -150,7 +150,13 @@ let write_dir ?(verbose=false) ?(symlink=false) d p =
     end;
     FileUtil.mkdir ~parent:true (FilePath.dirname file_dst);
     if symlink
-    then Unix.symlink ~src:fullpath ~dst:file_dst
+    then (* Breaking change in Core v0.11 and v0.12. Use Core v0.12 notation when the OCaml 4.06 support is dropped.
+      Core v0.11:
+        Unix.symlink ~src:fullpath ~dst:file_dst
+      Core v0.12:
+        Unix.symlink ~target:fullpath ~link_name:file_dst
+      *)
+      UnixLabels.symlink ~to_dir:false ~src:fullpath ~dst:file_dst
     else FileUtil.cp [fullpath] file_dst
   ) p.files;
   PackageFiles.iteri ~f:(fun ~key:path ~data:(_, h) ->


### PR DESCRIPTION
Unfortunately, breaking changes introduced in v0.12 actually do break Satyrographos.

- The type of `Unix.symlink` has been changed.
- Command.Param.file has been removed.

This PR fixes them and make it compatible with the both versions.