### PR TITLE
Support opam-free environment

### DIFF
--- a/src/package.ml
+++ b/src/package.ml
@@ -128,7 +128,8 @@ let%test "union: p + empty = empty" =
 let read_dir d =
   let add acc f =
     let rel_f = FilePath.make_relative d f in
-    if FilePath.is_subdir rel_f "hash"
+    if String.equal rel_f ".satyrographos" then acc
+    else if FilePath.is_subdir rel_f "hash"
     then add_hash rel_f f acc
     else add_file rel_f f acc
   in

--- a/src/satysfiDirs.ml
+++ b/src/satysfiDirs.ml
@@ -19,12 +19,26 @@ let is_runtime_dir dir =
   FileUtil.(test Is_dir) (Filename.concat dir "packages")
 
 let opam_share_dir () =
-  Unix.open_process_in "opam var share"
-  |> In_channel.input_all
-  |> String.strip
+  try
+    Unix.open_process_in "opam var share"
+    |> In_channel.input_all
+    |> String.strip
+    |> begin function
+      | "" -> None
+      | x -> Some x
+    end
+  with
+    Failure x ->
+      print_endline "Failed to get opam directory.";
+      print_endline x;
+      None
+
+let option_to_list = function
+  | Some x -> [x]
+  | None -> []
 
 let satysfi_dist_dir () =
-  let shares = [opam_share_dir (); "/usr/local/share"; "/usr/share"] in
+  let shares = option_to_list (opam_share_dir ()) @ ["/usr/local/share"; "/usr/share"] in
   let dist_dirs = List.map shares ~f:(fun d -> Filename.concat d "satysfi" |> (fun d -> Filename.concat d "dist")) in
   let rec f = function
     | [] -> failwith "Can't find SATySFi lib. Please install it."


### PR DESCRIPTION
This PR introduces the following changes.

- When the environment lacks an OPAM executable, `package-opam` commands does not anything, and `install` uses `/usr/local/share/satysfi/dist` or `/usr/share/satysfi/dist` as  .
- Even when a package, including the satysfi dist source, contains file `/.satyrographos`, it is simply ignored not to cause any error.

Addresses #20 