### PR TITLE
Bump url library version to 3 series

### DIFF
--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -22,7 +22,8 @@ depends: [
   "json-derivers"
   "ppx_deriving"
   "ppx_jane" {< "v0.13"}
-  "uri" {>= "2.0.0"}
+  "uri" {>= "3.0.0"}
+  "uri-sexp" {>= "3.0.0"}
   "yojson"
 ]
 synopsis: "A package manager for SATySFi"

--- a/src/dune
+++ b/src/dune
@@ -3,4 +3,4 @@
  (synopsis "Internal Satyrographos Library, do not use!")
  (inline_tests)
  (preprocess (staged_pps ppx_deriving.std ppx_jane))
- (libraries core fileutils json-derivers uri uri.sexp yojson))
+ (libraries core fileutils json-derivers uri uri-sexp yojson))


### PR DESCRIPTION
Url library has been divided into url and url-sexp.