### PR TITLE
Add -package option

### DIFF
--- a/bin/commandInstall.ml
+++ b/bin/commandInstall.ml
@@ -3,8 +3,46 @@ open Core
 
 open Setup
 
+module StringSet = Set.Make(String)
 
-let install d ~system_font_prefix ~verbose ~copy () =
+let get_packages ~reg ~reg_opam ~packages =
+  let dist_package = SatysfiDirs.satysfi_dist_dir () in
+  Printf.printf "Reading runtime dist: %s\n" dist_package;
+  let user_package_names = Registry.list reg |> StringSet.of_list in
+  let opam_package_names = match reg_opam with
+    | None -> StringSet.empty
+    | Some reg_opam ->
+      SatysfiRegistry.list reg_opam
+        |> StringSet.of_list
+        |> (fun names -> StringSet.diff names user_package_names)
+        |> (fun names -> StringSet.remove names "dist")
+  in
+  let all_package_names = (StringSet.union user_package_names opam_package_names) in
+  let packages = match packages with
+    | None -> all_package_names
+    | Some ps -> StringSet.remove (StringSet.of_list ps) "dist"
+  in
+  if StringSet.is_subset packages ~of_:all_package_names |> not
+  then failwithf "Packages %s are not found\n" (StringSet.diff packages all_package_names |> [%sexp_of: StringSet.t] |> Sexp.to_string_hum) ();
+  let user_package_names = StringSet.inter user_package_names packages in
+  let opam_package_names = StringSet.inter opam_package_names packages in
+  Printf.printf "Reading user packages: %s\n" (user_package_names |> [%sexp_of: StringSet.t] |> Sexp.to_string_hum);
+  let user_packages = StringSet.inter user_package_names packages
+    |> StringSet.to_list
+    |> List.map ~f:(Registry.directory reg)
+  in
+  Printf.printf "Reading opam packages: %s\n" (opam_package_names |> [%sexp_of: StringSet.t] |> Sexp.to_string_hum);
+  let opam_packages = match reg_opam with
+    | None -> []
+    | Some reg_opam ->
+      StringSet.inter opam_package_names packages
+        |> StringSet.to_list
+        |> List.map ~f:(SatysfiRegistry.directory reg_opam)
+  in
+  dist_package :: List.append user_packages opam_packages
+  |> List.map ~f:Package.read_dir
+
+let install d ~system_font_prefix ~packages ~verbose ~copy () =
   (* TODO build all *)
   Printf.printf "Updating packages\n";
   begin match Repository.update_all repo with
@@ -24,21 +62,7 @@ let install d ~system_font_prefix ~verbose ~copy () =
   | None ->
     Printf.printf "No packages built\n"
   end;
-  let dist_package = SatysfiDirs.satysfi_dist_dir () in
-  Printf.printf "Reading runtime dist: %s\n" dist_package;
-  let user_packages = Registry.list reg
-    |> List.map ~f:(Registry.directory reg)
-  in
-  let opam_packages = match reg_opam with
-    | None -> []
-    | Some reg_opam ->
-      SatysfiRegistry.list reg_opam
-        |> List.filter ~f:(fun name -> String.equal "dist" name |> not)
-        |> List.map ~f:(SatysfiRegistry.directory reg_opam)
-  in
-  let packages = dist_package :: List.append user_packages opam_packages
-    |> List.map ~f:Package.read_dir
-  in
+  let packages = get_packages ~reg ~reg_opam ~packages in
   let packages = match system_font_prefix with
     | None -> Printf.printf "Not gathering system fonts\n"; packages
     | Some(prefix) ->
@@ -74,10 +98,6 @@ let install d ~system_font_prefix ~verbose ~copy () =
 
 let install_command =
   let open Command.Let_syntax in
-  let default_target_dir =
-    Sys.getenv "SATYSFI_RUNTIME"
-    |> Option.value ~default:target_dist_dir
-    |> (fun dir -> Filename.concat dir "dist") in
   let readme () =
     sprintf "Install SATySFi Libraries to a directory environmental variable SATYSFI_RUNTIME has or %s. Currently it accepts an argument DIR, but this is experimental." default_target_dir
   in
@@ -86,10 +106,14 @@ let install_command =
     ~readme
     [%map_open
       let system_font_prefix = flag "system-font-prefix" (optional string) ~doc:"FONT_NAME_PREFIX Installing system fonts with names with the given prefix"
+      and package_list = flag "package" (listed string) ~doc:"PACKAGE Package"
       and target_dir = anon (maybe_with_default default_target_dir ("DIR" %: string))
       and verbose = flag "verbose" no_arg ~doc:"Make verbose"
       and copy = flag "copy" no_arg ~doc:"Copy files instead of making symlinks"
       in
       fun () ->
-        install target_dir ~system_font_prefix ~verbose ~copy ()
+        let packages = match package_list with
+          | [] -> None
+          | xs -> Some xs in
+        install target_dir ~system_font_prefix ~packages ~verbose ~copy ()
     ]

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -38,3 +38,8 @@ let reg_opam =
   |> Option.map ~f:(fun opam_share_dir ->
       Printf.printf "opam share dir: %s\n" opam_share_dir;
       {SatysfiRegistry.package_dir=Filename.concat opam_share_dir "satysfi"})
+
+let default_target_dir =
+  Sys.getenv "SATYSFI_RUNTIME"
+  |> Option.value ~default:target_dist_dir
+  |> (fun dir -> Filename.concat dir "dist")


### PR DESCRIPTION
Add `-package PACKAGE` option to `install` subcommand.

Without any `-package` options, it installs all the package to keep backward compatibility.

Specifying `dist` package is no-op, therefore can skip installing third-party libraries.