### PR TITLE
Support build script

### DIFF
--- a/bin/commandInstall.ml
+++ b/bin/commandInstall.ml
@@ -5,6 +5,7 @@ open Setup
 
 module StringSet = Set.Make(String)
 
+(* TODO Install transitive dependencies *)
 let get_packages ~reg ~reg_opam ~packages =
   let dist_package = SatysfiDirs.satysfi_dist_dir () in
   Printf.printf "Reading runtime dist: %s\n" dist_package;

--- a/bin/commandOpam.ml
+++ b/bin/commandOpam.ml
@@ -86,9 +86,26 @@ let opam_buildfile_command =
         buildfile f ()
     ]
 
+let export f () =
+  Compatibility.optin ();
+  let s = BuildScript.from_file f in
+  s |> BuildScript.export_opam
+
+let opam_export_command =
+  let open Command.Let_syntax in
+  Command.basic
+    ~summary:"Export build file (experimental)"
+    [%map_open
+      let f = anon ("BUILD_FILE" %: string) (* ToDo: Remove this *)
+      in
+      fun () ->
+        export f ()
+    ]
+
 let opam_command =
   Command.group ~summary:"OPAM related functionalities (experimental)"
     [ "install", opam_install_command;
       "uninstall", opam_uninstall_command;
       "buildfile", opam_buildfile_command;
+      "export", opam_export_command;
     ]

--- a/bin/commandOpam.ml
+++ b/bin/commandOpam.ml
@@ -1,0 +1,94 @@
+open Satyrographos
+open Core
+
+
+module StringMap = Map.Make(String)
+
+let package_dir prefix buildscript =
+  let libdir = Filename.concat prefix "share/satysfi" in
+  Filename.concat libdir buildscript.BuildScript.name
+
+let install_dir verbose dir files =
+  FileUtil.(mkdir ~parent:true dir);
+  List.iter files ~f:(fun (dst, src) ->
+    if FileUtil.(test Exists src)
+    then let dst = (Filename.concat dir dst) in
+      if verbose then Printf.printf "Copying %s to %s\n" src dst;
+      FileUtil.(cp ~follow:Follow ~recurse:true ~force:Force [src] dst)
+    else failwithf "%s does not exist\n" src ()
+  )
+
+let install_dir_if_exists verbose dir files =
+  if not (List.is_empty files)
+  then install_dir verbose dir files
+
+let install_opam verbose prefix buildscript =
+  let dir = package_dir prefix buildscript in
+  FileUtil.(rm ~force:Force ~recurse:true [dir]);
+  install_dir_if_exists verbose (Filename.concat dir "fonts") buildscript.sources.fonts;
+  install_dir_if_exists verbose (Filename.concat dir "hash") buildscript.sources.hashes;
+  install_dir_if_exists verbose (Filename.concat dir "package") buildscript.sources.packages;
+  install_dir_if_exists verbose (Filename.concat dir "files") buildscript.sources.files
+
+let uninstall_opam _ prefix buildscript =
+  let dir = package_dir prefix buildscript in
+  FileUtil.(rm ~force:Force ~recurse:true [dir])
+
+let default_script_path () =
+  Filename.concat (FileUtil.pwd ()) "Satyristes"
+
+let opam_with_build_module_command f =
+  let open Command.Let_syntax in
+  Command.basic
+    ~summary:"Install module into OPAM registory (experimental)"
+    [%map_open
+      let prefix = flag "prefix" (required string) ~doc:"PREFIX Install destination"
+      and script = flag "script" (optional string) ~doc:"SCRIPT Install script"
+      and name = flag "name" (optional string) ~doc:"MODULE_NAME Module name"
+      and verbose = flag "verbose" no_arg ~doc:"Make verbose"
+      in
+      fun () ->
+        let bs = Option.value ~default:(default_script_path ()) script
+          |> BuildScript.from_file
+        in
+        match name with
+        | None -> begin
+          if StringMap.length bs = 1
+          then f verbose prefix (StringMap.nth_exn bs 0 |> snd)
+          else failwith "Please specify module name with -name option"
+        end
+        | Some name ->
+          StringMap.find bs name
+          |> Option.value_exn ~message:"Build file does not contains modules with the given name"
+          |> f verbose prefix
+    ]
+
+let opam_install_command =
+  opam_with_build_module_command install_opam
+
+let opam_uninstall_command =
+  opam_with_build_module_command uninstall_opam
+
+let buildfile f () =
+  Compatibility.optin ();
+  let s = BuildScript.from_file f in
+  s |> [%sexp_of: BuildScript.t] |> Sexp.to_string_hum
+  |> Printf.printf "Build file: %s\n"
+
+let opam_buildfile_command =
+  let open Command.Let_syntax in
+  Command.basic
+    ~summary:"Inspect build file (experimental)"
+    [%map_open
+      let f = anon ("BUILD_FILE" %: string) (* ToDo: Remove this *)
+      in
+      fun () ->
+        buildfile f ()
+    ]
+
+let opam_command =
+  Command.group ~summary:"OPAM related functionalities (experimental)"
+    [ "install", opam_install_command;
+      "uninstall", opam_uninstall_command;
+      "buildfile", opam_buildfile_command;
+    ]

--- a/bin/dune
+++ b/bin/dune
@@ -3,4 +3,4 @@
  (public_name satyrographos)
  (preprocess (pps ppx_deriving.std ppx_jane))
  (libraries core satyrographos uri)
- (modules setup compatibility commandInstall commandPackage commandPin commandStatus main))
+ (modules setup compatibility commandInstall commandOpam commandPackage commandPin commandStatus main))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4,6 +4,7 @@ open Core
 let total_command =
   Command.group ~summary:"Simple SATySFi Package Manager"
     [
+      "opam", CommandOpam.opam_command;
       "package", CommandPackage.package_command;
       "package-opam", CommandPackage.package_opam_command;
       "status", CommandStatus.status_command;

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -36,7 +36,6 @@ let reg = Registry.read package_dir repo metadata_file
 let reg_opam =
   SatysfiDirs.opam_share_dir ()
   |> Option.map ~f:(fun opam_share_dir ->
-      Printf.printf "opam share dir: %s\n" opam_share_dir;
       {SatysfiRegistry.package_dir=Filename.concat opam_share_dir "satysfi"})
 
 let default_target_dir =

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -22,6 +22,7 @@ depends: [
   "json-derivers"
   "ppx_deriving"
   "ppx_jane" {< "v0.13"}
+  "opam-format" {>= "2.0" & < "2.1"}
   "uri" {>= "3.0.0"}
   "uri-sexp" {>= "3.0.0"}
   "yojson"

--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -95,3 +95,16 @@ let input ch =
 let from_file f =
   Unix.(with_file f ~mode:[O_RDONLY] ~f:(fun fd ->
     input (in_channel_of_descr fd)))
+
+let package_to_opam_file p =
+  let name = OpamPackage.Name.of_string ("satysfi-" ^ p.name) in
+  OpamFile.OPAM.empty
+  |> OpamFile.OPAM.with_name name
+
+let export_opam_package p =
+  let file = OpamFilename.raw p.opam in
+  package_to_opam_file p
+  |> OpamFile.OPAM.write (OpamFile.make file)
+
+let export_opam bs =
+  StringMap.iter bs ~f:export_opam_package

--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -1,0 +1,97 @@
+open Core
+
+type sources = {
+  files: (string * string) list
+    [@sexp.omit_nil];
+  fonts: (string * string) list
+    [@sexp.omit_nil];
+  hashes: (string * string) list
+    [@sexp.omit_nil];
+  packages: (string * string) list
+    [@sexp.omit_nil];
+}
+[@@deriving sexp]
+
+let empty_sources = {
+  files=[];
+  fonts=[];
+  hashes=[];
+  packages=[];
+}
+
+let add_files dst src acc = {acc with files=(dst, src) :: acc.files}
+let add_fonts dst src acc = {acc with fonts=(dst, src) :: acc.fonts}
+let add_hashes dst src acc = {acc with hashes=(dst, src) :: acc.hashes}
+let add_packages dst src acc = {acc with packages=(dst, src) :: acc.packages}
+
+type source =
+  | File of string * string
+  | Font of string * string
+  | Hash of string * string
+  | Package of string * string
+[@@deriving sexp]
+
+(*
+let sexp_of_source = function
+  | File (dst, src) ->
+    ["file"; dst; src] |> [%sexp_of: string list]
+  | Font (dst, src) ->
+    ["font"; dst; src] |> [%sexp_of: string list]
+  | Hash (dst, src) ->
+    ["hash"; dst; src] |> [%sexp_of: string list]
+  | Package (dst, src) ->
+    ["package"; dst; src] |> [%sexp_of: string list]
+
+let source_of_source sexp =
+  let list = [%of_sexp: string list] sexp in
+  match list with
+  | ["file"; dst; src] -> File (dst, src)
+  | ["font"; dst; src] -> Font (dst, src)
+  | ["hash"; dst; src] -> Hash (dst, src)
+  | ["package"; dst; src] -> Package (dst, src)
+  | _ -> Error.create "Source must be (<type> <dst> <src>) where <type> is either file, font, hash, or package" sexp ident
+      |> Error.raise
+*)
+
+type package = {
+  name: string;
+  opam: string;
+  sources: sources [@sexp.omit_nil];
+} [@@deriving sexp]
+
+type section = Package of {
+  name: string;
+  opam: string;
+  sources: source list [@sexp.list] [@sexp.omit_nil];
+  (*
+    sources: source list [@sexp.omit_nil];
+  *)
+  (* sources: source sexp_list; *)
+} [@sexpr.list]
+[@@deriving sexp]
+
+module StringMap = Map.Make(String)
+
+type t = package StringMap.t [@@deriving sexp]
+
+(*
+*)
+let input ch =
+  let sexp = Sexp.input_sexps ch in
+  let modules = sexp |> List.concat_map ~f:(fun sexp ->
+    match [%of_sexp: section] sexp with
+    | Package {name; opam; sources} ->
+      let sources = List.fold_left ~init:empty_sources ~f:begin fun acc -> function
+        | File (dst, src) -> add_files dst src acc
+        | Font (dst, src) -> add_fonts dst src acc
+        | Hash (dst, src) -> add_hashes dst src acc
+        | Package (dst, src) -> add_packages dst src acc
+      end sources in
+      [{name; opam; sources}]
+  ) in
+  List.map ~f:(fun m -> m.name, m) modules
+  |> StringMap.of_alist_exn
+
+let from_file f =
+  Unix.(with_file f ~mode:[O_RDONLY] ~f:(fun fd ->
+    input (in_channel_of_descr fd)))

--- a/src/dune
+++ b/src/dune
@@ -3,4 +3,4 @@
  (synopsis "Internal Satyrographos Library, do not use!")
  (inline_tests)
  (preprocess (staged_pps ppx_deriving.std ppx_jane))
- (libraries core fileutils json-derivers uri uri-sexp yojson))
+ (libraries core fileutils json-derivers opam-format uri uri-sexp yojson))

--- a/src/systemFontPackage.ml
+++ b/src/systemFontPackage.ml
@@ -114,7 +114,8 @@ let fonts_to_package prefix fonts =
         then Printf.printf "WARNING: %s and %s have conflicting filename.\n" f1 f2
       end;
       f1
-    )
+    );
+    dependencies = Package.Dependency.empty;
   }
 
 let get_package prefix () =


### PR DESCRIPTION
Now Satyrographos reads a build file, typically named `Satyristes`, to install/uninstall files into OPAM prefix. This functionarity is to replace Makefile.

Note: `satyrographos install` does not yet respect dependencies!