### PR TITLE
Implement compatibility warnings

### DIFF
--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -99,8 +99,16 @@ let compatibility_treatment p l =
   match CompatibilityIdents.to_list p.compatibility with
     | [] -> l
     | ["satyrographos-0.0.1"] -> begin
+      let rename_packages = List.map p.sources.packages ~f:(fun (name, _) ->
+        let old_package_name = name in
+        let new_package_name = p.name ^ "/" ^ name in
+        (old_package_name, new_package_name)
+      ) in
       { Library.empty with
-        compatibility = p.compatibility }
+        compatibility = Library.Compatibility.{
+          rename_packages
+        }
+      }
       |> Library.union l
     end
     | _ -> begin

--- a/src/library.ml
+++ b/src/library.ml
@@ -19,9 +19,21 @@ module Json = struct
 end
 
 module Dependency = Set.Make(String)
-module Compatibility = Set.Make(String)
 module StringMap = Map.Make(String)
 module JsonSet = Set.Make(Json)
+module Compatibility = struct
+  type t = {
+    rename_packages: (string * string) list
+  }
+  [@@deriving sexp, compare]
+  let empty = {
+    rename_packages = []
+  }
+  let union c1 c2 = {
+    rename_packages = c1.rename_packages @ c2.rename_packages
+  }
+end
+
 
 type t = {
   hashes: (string list * Json.t) LibraryFiles.t;

--- a/src/systemFontLibrary.ml
+++ b/src/systemFontLibrary.ml
@@ -107,7 +107,7 @@ let fonts_to_library prefix fonts =
   in
   let hash_filename_fonts = "hash/fonts.satysfi-hash" in
   let hash_path_fonts = "#Automatically generated from the system fonts#" in
-  Library.{
+  Library.{ empty with
     hashes = LibraryFiles.singleton hash_filename_fonts ([hash_path_fonts], `Assoc hash);
     files = LibraryFiles.of_alist_reduce files ~f:(fun f1 f2 ->
       begin if not (String.equal f1 f2)
@@ -115,7 +115,6 @@ let fonts_to_library prefix fonts =
       end;
       f1
     );
-    dependencies = Library.Dependency.empty;
   }
 
 let get_library prefix () =


### PR DESCRIPTION
Add field `compatibility` and `satyrographos-0.0.1` tag to Satyristes.
```
(library
  (name "grcnum")
  (sources
    ((package "grcnum.satyh" "./grcnum.satyh")))
  (opam "satysfi-grcnum.opam")
  (dependencies ((fonts-theano ())))
  (compatibility (satyrographos-0.0.1)))
```

The tag will have `satyrographos install` output compatibility notices.

```
$ satyrographos install -library grcnum

...
Installation completed!

Compatibility notice for library grcnum:

  Packages have been renamed.
  
    package grcnum.satyh -> package grcnum/grcnum.satyh.
```

Closes #37