### PR TITLE
Build Librady Doc

### DIFF
--- a/bin/commandOpam.ml
+++ b/bin/commandOpam.ml
@@ -1,6 +1,8 @@
 open Satyrographos
 open Core
 
+module Process = Shexp_process
+module P = Process
 
 module StringMap = Map.Make(String)
 
@@ -8,14 +10,52 @@ let library_dir prefix (buildscript: BuildScript.m) =
   let libdir = Filename.concat prefix "share/satysfi" in
   Filename.concat libdir (BuildScript.get_name buildscript)
 
-let install_opam ~verbose ~prefix ~build_module ~buildscript_path =
+let read_module ~verbose ~build_module ~buildscript_path =
   let src_dir = Filename.dirname buildscript_path in
   let p = BuildScript.read_module ~src_dir build_module in
-
-  if verbose
+  begin if verbose
   then Format.printf "Read library:@.";
     [%sexp_of: Library.t] p |> Sexp.pp_hum Format.std_formatter;
-    Format.printf "@.";
+    Format.printf "@."
+  end;
+  (src_dir, p)
+
+let run_build_commands ~verbose ~libraries ~workingDir buildCommands =
+  let commands = P.List.iter buildCommands ~f:(function
+    | "make" :: args -> P.run "make" args
+    | "satysfi" :: args -> P.run "satysfi" args
+    | cmd -> failwithf "command %s is not yet supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()
+  ) in
+  let with_env c =
+    let open P in
+    let open P.Infix in
+    with_temp_dir ~prefix:"Satyrographos" ~suffix:"build_opam" (fun d ->
+      return (Format.printf "Setting up SATySFi env at %s @." d;) >>
+      return (CommandInstall.install d ~system_font_prefix:None ~libraries ~verbose ~copy:false ()) >>
+      c)
+  in
+  P.(chdir workingDir (with_env commands))
+
+let build_opam ~verbose ~prefix:_ ~build_module ~buildscript_path =
+  let src_dir, p = read_module ~verbose ~build_module ~buildscript_path in
+
+  match build_module with
+  | BuildScript.LibraryDoc build_module ->
+    let context = Process.Context.create() in
+    let workingDir = Filename.concat src_dir build_module.workingDirectory in
+    let libraries = Library.Dependency.to_list p.dependencies |> Some in
+    let _, trace =
+      run_build_commands ~verbose ~workingDir ~libraries build_module.build
+      |> P.Traced.eval_exn ~context in
+    if verbose
+    then Format.printf "Executed commands:@.";
+      Sexp.pp_hum_indent 2 Format.std_formatter trace;
+      Format.printf "@."
+  | BuildScript.Library _ ->
+    Format.printf "Building modules is not yet supported"
+
+let install_opam ~verbose ~prefix ~build_module ~buildscript_path =
+  let _, p = read_module ~verbose ~build_module ~buildscript_path in
   let dir = library_dir prefix build_module in
   Library.write_dir ~verbose ~symlink:false dir p
 
@@ -26,12 +66,12 @@ let uninstall_opam ~verbose:_ ~prefix ~build_module ~buildscript_path:_ =
 let default_script_path () =
   Filename.concat (FileUtil.pwd ()) "Satyristes"
 
-let opam_with_build_module_command f =
+let opam_with_build_module_command ~prefix_optionality f =
   let open Command.Let_syntax in
   Command.basic
     ~summary:"Install module into OPAM registory (experimental)"
     [%map_open
-      let prefix = flag "prefix" (required string) ~doc:"PREFIX Install destination"
+      let prefix = flag "prefix" (prefix_optionality string) ~doc:"PREFIX Install destination"
       and script = flag "script" (optional string) ~doc:"SCRIPT Install script"
       and name = flag "name" (optional string) ~doc:"MODULE_NAME Module name"
       and verbose = flag "verbose" no_arg ~doc:"Make verbose"
@@ -53,11 +93,14 @@ let opam_with_build_module_command f =
               failwithf "Build file does not contains library %s" name ()
     ]
 
+let opam_build_command =
+  opam_with_build_module_command ~prefix_optionality:Command.Param.optional build_opam
+
 let opam_install_command =
-  opam_with_build_module_command install_opam
+  opam_with_build_module_command ~prefix_optionality:Command.Param.required install_opam
 
 let opam_uninstall_command =
-  opam_with_build_module_command uninstall_opam
+  opam_with_build_module_command ~prefix_optionality:Command.Param.required uninstall_opam
 
 let buildfile ~process f () =
   Compatibility.optin ();
@@ -105,7 +148,8 @@ let opam_export_command =
 
 let opam_command =
   Command.group ~summary:"OPAM related functionalities (experimental)"
-    [ "install", opam_install_command;
+    [ "build", opam_build_command;
+      "install", opam_install_command;
       "uninstall", opam_uninstall_command;
       "buildfile", opam_buildfile_command;
       "export", opam_export_command;

--- a/bin/dune
+++ b/bin/dune
@@ -2,5 +2,5 @@
  (name main)
  (public_name satyrographos)
  (preprocess (pps ppx_deriving.std ppx_jane))
- (libraries core satyrographos uri)
+ (libraries core satyrographos shexp.process uri)
  (modules setup compatibility commandInstall commandLibrary commandOpam commandPin commandStatus main))

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -25,6 +25,7 @@ depends: [
   "opam-format" {>= "2.0" & < "2.1"}
   "uri" {>= "3.0.0"}
   "uri-sexp" {>= "3.0.0"}
+  "shexp" {< "v0.13"}
   "yojson"
 ]
 synopsis: "A package manager for SATySFi"


### PR DESCRIPTION
Added a new section `LibraryDoc` to Satyristes.

### Example 1: [satysfi-fonts-theano](https://github.com/na4zagin3/SATySFi-fonts-theano)
```lisp
;;; Satyristes 
(version 1)
(library
  (name "fonts-theano")
  (sources
    ((hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
     (font "TheanoDidot-Regular.otf" "./theano/TheanoDidot-Regular.otf")
     (font "TheanoModern-Regular.otf" "./theano/TheanoModern-Regular.otf")
     (font "TheanoOldStyle-Regular.otf" "./theano/TheanoOldStyle-Regular.otf")))
  (opam "satysfi-fonts-theano.opam"))
(libraryDoc
  (name "fonts-theano-doc")
  (build
    ((satysfi "doc-fonts-theano-ja.saty" "-o" "doc-fonts-theano-ja.pdf" )))
  (sources
    ((doc "doc-fonts-theano-ja.pdf" "./doc-fonts-theano-ja.pdf")))
  (opam "satysfi-fonts-theano-doc.opam")
  (dependencies ((fonts-theano ()))))
```

```sh
$ satyrographos opam build -name fonts-theano-doc -verbose
```

### Example 2: [satysfi-grcnum](https://github.com/na4zagin3/SATySFi-grcnum)

```lisp
;;; Satyristes for satysfi-grcnum
(version 1)
(library
  (name "grcnum")
  (sources
    ((package "grcnum.satyh" "./grcnum.satyh")))
  (opam "satysfi-grcnum.opam")
  (dependencies ((fonts-theano ())))
  (compatibility (satyrographos-0.0.1)))
(libraryDoc
  (name "grcnum-doc")
  (build
    ((satysfi "doc-grcnum.saty" "-o" "doc-grcnum-ja.pdf")))
  (sources
    ((doc "doc-grcnum-ja.pdf" "./doc-grcnum-ja.pdf")))
  (opam "satysfi-grcnum-doc.opam")
  (dependencies ((grcnum ())
                 (fonts-theano ()))))
```

```sh
$ satyrographos opam build -name grcnum-doc -verbose
```