### PR TITLE
Add font/package compatibility notices

### DIFF
--- a/bin/commandInstall.ml
+++ b/bin/commandInstall.ml
@@ -61,13 +61,13 @@ let get_libraries ~reg ~reg_opam ~libraries =
 
 let show_compatibility_warnings ~libraries =
   Map.iteri libraries ~f:(fun ~key:library_name ~data:library ->
-    let renames = (library: Library.t).compatibility.rename_packages in
+    let renames = (library: Library.t).compatibility.rename_packages |> Library.RenameSet.to_list in
     if List.is_empty renames |> not
     then begin
       Format.printf "\n\027[1;33mCompatibility notice\027[0m for library %s:" library_name;
       Format.printf "@[<v 2>@,Packages have been renamed.@,@[<v 2>";
-      List.iter renames ~f:(fun (from, to_) ->
-        Format.printf "@,package %s -> package %s." from to_;
+      List.iter renames ~f:(fun { old_name; new_name } ->
+        Format.printf "@,package %s -> package %s." old_name new_name;
       );
       Format.printf "@]@]@,";
       Format.print_newline ();

--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -90,10 +90,9 @@ module StringSet = Set.Make(String)
 
 type t = m StringMap.t [@@deriving sexp]
 
-let input ch =
-  let sexp = Sexp.input_sexps ch in
-  let modules = sexp |> List.concat_map ~f:(fun sexp ->
-    match [%of_sexp: Section.t] sexp with
+let from_file f =
+  let sections = Sexp.load_sexps_conv_exn f [%of_sexp: Section.t] in
+  let modules = sections |> List.concat_map ~f:(function
     | Version "1" -> []
     | Version v ->
       failwithf "This Saytorgraphos only supports build script version 1, but got %s" v ()
@@ -114,10 +113,6 @@ let input ch =
   ) in
   modules
   |> StringMap.of_alist_exn
-
-let from_file f =
-  Unix.(with_file f ~mode:[O_RDONLY] ~f:(fun fd ->
-    input (in_channel_of_descr fd)))
 
 let library_to_opam_file name =
   let name = OpamPackage.Name.of_string ("satysfi-" ^ name) in

--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -146,17 +146,18 @@ let compatibility_treatment (p: library) l =
   match CompatibilityIdents.to_list p.compatibility with
     | [] -> l
     | ["satyrographos-0.0.1"] -> begin
+      let open Library in
       let rename_packages = List.map p.sources.packages ~f:(fun (name, _) ->
         let old_package_name = name in
         let new_package_name = p.name ^ "/" ^ name in
-        (old_package_name, new_package_name)
-      ) in
-      { Library.empty with
-        compatibility = Library.Compatibility.{
+        Rename.{ old_name = old_package_name; new_name = new_package_name }
+      ) |> RenameSet.of_list in
+      { empty with
+        compatibility = Compatibility.{
           rename_packages
         }
       }
-      |> Library.union l
+      |> union l
     end
     | _ -> begin
       let unknown_symbols =

--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -36,7 +36,7 @@ module Compatibility = struct
   type t =
     | Satyrographos of string
     | RenamePackage of string * string
-    (* | RenameFont of string * string *)
+    | RenameFont of string * string
     [@@deriving sexp, compare]
 end
 module CompatibilitySet = Set.Make(Compatibility)
@@ -154,8 +154,15 @@ let get_name = function
 let compatibility_treatment (p: library) (l: Library.t) =
   let f = function
     | Compatibility.RenamePackage (n, o) ->
-      Library.Compatibility.{
+      Library.Compatibility.{ empty with
         rename_packages = Library.RenameSet.singleton Library.Rename.{
+          new_name = n;
+          old_name = o;
+        }
+      }
+    | Compatibility.RenameFont (n, o) ->
+      Library.Compatibility.{ empty with
+        rename_fonts = Library.RenameSet.singleton Library.Rename.{
           new_name = n;
           old_name = o;
         }
@@ -167,7 +174,7 @@ let compatibility_treatment (p: library) (l: Library.t) =
         let new_package_name = p.name ^ "/" ^ name in
         Rename.{ old_name = old_package_name; new_name = new_package_name }
       ) |> RenameSet.of_list in
-      Compatibility.{
+      Compatibility.{ empty with
         rename_packages
       }
     | unknown_symbol -> begin

--- a/src/library.ml
+++ b/src/library.ml
@@ -21,16 +21,24 @@ end
 module Dependency = Set.Make(String)
 module StringMap = Map.Make(String)
 module JsonSet = Set.Make(Json)
+module Rename = struct
+  type t = {
+    new_name: string;
+    old_name: string;
+  }
+  [@@deriving sexp, compare]
+end
+module RenameSet = Set.Make(Rename)
 module Compatibility = struct
   type t = {
-    rename_packages: (string * string) list
+    rename_packages: RenameSet.t
   }
   [@@deriving sexp, compare]
   let empty = {
-    rename_packages = []
+    rename_packages = RenameSet.empty
   }
   let union c1 c2 = {
-    rename_packages = c1.rename_packages @ c2.rename_packages
+    rename_packages = RenameSet.union c1.rename_packages c2.rename_packages
   }
 end
 

--- a/src/library.ml
+++ b/src/library.ml
@@ -31,14 +31,20 @@ end
 module RenameSet = Set.Make(Rename)
 module Compatibility = struct
   type t = {
-    rename_packages: RenameSet.t
+    rename_packages: RenameSet.t;
+    rename_fonts: RenameSet.t;
   }
   [@@deriving sexp, compare]
   let empty = {
-    rename_packages = RenameSet.empty
+    rename_packages = RenameSet.empty;
+    rename_fonts = RenameSet.empty;
   }
+  let is_empty c =
+    RenameSet.is_empty c.rename_packages
+    && RenameSet.is_empty c.rename_fonts
   let union c1 c2 = {
-    rename_packages = RenameSet.union c1.rename_packages c2.rename_packages
+    rename_packages = RenameSet.union c1.rename_packages c2.rename_packages;
+    rename_fonts = RenameSet.union c1.rename_fonts c2.rename_fonts;
   }
   let union_list = List.fold ~init:empty ~f:union
 end

--- a/src/library.ml
+++ b/src/library.ml
@@ -40,6 +40,7 @@ module Compatibility = struct
   let union c1 c2 = {
     rename_packages = RenameSet.union c1.rename_packages c2.rename_packages
   }
+  let union_list = List.fold ~init:empty ~f:union
 end
 
 


### PR DESCRIPTION
Changed compatibility field so that it can convey arbitrary compatibility notices.

Examples:

```lisp
(version 1)
(library
  (name "fonts-theano")
  (sources
    ((hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
     (font "TheanoDidot-Regular.otf" "./theano/TheanoDidot-Regular.otf")
     (font "TheanoModern-Regular.otf" "./theano/TheanoModern-Regular.otf")
     (font "TheanoOldStyle-Regular.otf" "./theano/TheanoOldStyle-Regular.otf")))
  ;;; Here
  (compatibility ((renameFont fonts-theano:TheanoDidot TheanoDidot)
                  (renameFont fonts-theano:TheanoModern TheanoModern)
                  (renameFont fonts-TheanoOldStyle TheanoOldStyle)))
  (opam "satysfi-fonts-theano.opam"))
(libraryDoc
  (name "fonts-theano-doc")
  (build
    ((satysfi "doc-fonts-theano-ja.saty" "-o" "doc-fonts-theano-ja.pdf")))
  (sources
    ((doc "doc-fonts-theano-ja.pdf" "./doc-fonts-theano-ja.pdf")))
  (opam "satysfi-fonts-theano-doc.opam")
  (dependencies ((fonts-theano ()))))
```

and

```lisp
(version 1)
(library
  (name "grcnum")
  (sources
    ((package "grcnum.satyh" "./grcnum.satyh")))
  (opam "satysfi-grcnum.opam")
  (dependencies ((fonts-theano ())))
  (compatibility ((satyrographos 0.0.1)))) ;; <-- here
(libraryDoc
  (name "grcnum-doc")
  (build
    ((satysfi "doc-grcnum.saty" "-o" "doc-grcnum-ja.pdf")))
  (sources
    ((doc "doc-grcnum-ja.pdf" "./doc-grcnum-ja.pdf")))
  (opam "satysfi-grcnum-doc.opam")
  (dependencies ((grcnum ())
                 (fonts-theano ()))))
```

then gets

```
$ satyrographos opam build -name fonts-theano-doc


...

Removing destination /tmp/Satyrographos28bf35build_opam/dist
Installation completed!

Compatibility notice for library fonts-theano:

  Fonts have been renamed.
  
    TheanoDidot -> fonts-theano:TheanoDidot
    TheanoModern -> fonts-theano:TheanoModern

Setting up SATySFi env at /tmp/Satyrographos28bf35build_opam 
  SATySFi version 0.0.3
 ---- ---- ---- ----
  target file: 'doc-fonts-theano-ja.pdf'
  dump file: 'doc-fonts-theano-ja.satysfi-aux' (already exists)
  parsing 'doc-fonts-theano-ja.saty' ...
```

Closes #34