### PR TITLE
Refactoring: Output every lines to the given formatter

### DIFF
--- a/bin/commandInstall.ml
+++ b/bin/commandInstall.ml
@@ -23,5 +23,5 @@ let install_command =
           | [] -> None
           | xs -> Some xs in
         let env = Setup.read_environment () in
-        CommandInstall.install target_dir ~system_font_prefix ~libraries ~verbose ~copy ~env ()
+        CommandInstall.install target_dir ~outf:Format.std_formatter ~system_font_prefix ~libraries ~verbose ~copy ~env ()
     ]

--- a/bin/commandOpam.ml
+++ b/bin/commandOpam.ml
@@ -6,11 +6,15 @@ module P = Process
 
 module StringMap = Map.Make(String)
 
+let outf = Format.std_formatter
+
+
 let default_script_path () =
   Filename.concat (FileUtil.pwd ()) "Satyristes"
 
 let opam_with_build_module_command ~prefix_optionality f =
   let open Command.Let_syntax in
+  let outf = Format.std_formatter in
   Command.basic
     ~summary:"Install module into OPAM registory (experimental)"
     [%map_open
@@ -26,12 +30,12 @@ let opam_with_build_module_command ~prefix_optionality f =
         | None -> begin
           if StringMap.length builsscript = 1
           then let build_module = StringMap.nth_exn builsscript 0 |> snd in
-            f ~verbose ~prefix ~build_module ~buildscript_path ~opam_reg:Setup.reg_opam
+            f ~outf ~verbose ~prefix ~build_module ~buildscript_path ~opam_reg:Setup.reg_opam
           else failwith "Please specify module name with -name option"
         end
         | Some name ->
           match StringMap.find builsscript name with
-            | Some build_module -> f ~verbose ~prefix ~build_module ~buildscript_path ~opam_reg:Setup.reg_opam
+            | Some build_module -> f ~outf ~verbose ~prefix ~build_module ~buildscript_path ~opam_reg:Setup.reg_opam
             | _ ->
               failwithf "Build file does not contains library %s" name ()
     ]
@@ -55,7 +59,7 @@ let opam_buildfile_command =
       in
       fun () ->
         Compatibility.optin ();
-        CommandOpam.buildfile ~process f ()
+        CommandOpam.buildfile ~outf:Format.std_formatter ~process f ()
     ]
 
 let opam_export_command =

--- a/bin/commandPin.ml
+++ b/bin/commandPin.ml
@@ -1,6 +1,7 @@
 open Satyrographos
 open Core
 
+let outf = Format.std_formatter
 
 let pin_list () =
   Compatibility.optin ();
@@ -39,9 +40,9 @@ let pin_add p url () =
   let Environment.{ repo; reg; } = Setup.read_repo () in
   let (_: string list option) =
   Uri.of_string url
-  |> Repository.add repo p in
+  |> Repository.add ~outf repo p in
   Printf.printf "Added %s (%s)\n" p url;
-  Registry.update_all reg
+  Registry.update_all ~outf reg
   |> [%derive.show: string list option]
   |> Printf.printf "Built libraries: %s\n"
 let pin_add_command =

--- a/bin/commandStatus.ml
+++ b/bin/commandStatus.ml
@@ -2,6 +2,8 @@ open Satyrographos
 open Core
 
 
+let outf = Format.std_formatter
+
 let status () =
   printf "Scheme version: ";
   [%derive.show: int option] Setup.current_scheme_version |> print_endline;
@@ -14,7 +16,7 @@ let status () =
   [%derive.show: string list] (SatysfiDirs.runtime_dirs ()) |> print_endline;
   printf "SATySFi user directory: ";
   [%derive.show: string option] (SatysfiDirs.user_dir ()) |> print_endline;
-  printf "Selected SATySFi runtime distribution: %s\n" (SatysfiDirs.satysfi_dist_dir ())
+  printf "Selected SATySFi runtime distribution: %s\n" (SatysfiDirs.satysfi_dist_dir ~outf)
 
 let status_command =
   let open Command.Let_syntax in

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -35,7 +35,7 @@ let initialize () =
   end
 
 let reg_opam =
-  SatysfiDirs.opam_share_dir ()
+  SatysfiDirs.opam_share_dir ~outf:Format.std_formatter
   |> Option.map ~f:(fun opam_share_dir ->
       OpamSatysfiRegistry.read (Filename.concat opam_share_dir "satysfi"))
 

--- a/src/commandInstall.ml
+++ b/src/commandInstall.ml
@@ -19,15 +19,15 @@ let transitive_closure map =
 
 
 (* TODO Install transitive dependencies *)
-let get_libraries ~maybe_reg ~opam_reg ~libraries =
-  let dist_library_dir = SatysfiDirs.satysfi_dist_dir () in
-  Format.printf "Reading runtime dist: %s\n" dist_library_dir;
+let get_libraries ~outf ~maybe_reg ~opam_reg ~libraries =
+  let dist_library_dir = SatysfiDirs.satysfi_dist_dir ~outf in
+  Format.fprintf outf "Reading runtime dist: %s\n" dist_library_dir;
   let dist_library = Library.read_dir dist_library_dir in
   let user_libraries = Option.map maybe_reg ~f:(fun reg -> Registry.list reg
     |> StringSet.of_list
     |> StringSet.to_map ~f:(Registry.directory reg))
   in
-  Format.printf "Read user libraries: %s\n"
+  Format.fprintf outf "Read user libraries: %s\n"
     (Option.value_map ~default:[] ~f:Map.keys user_libraries
     |> [%sexp_of: string list] |> Sexp.to_string_hum);
   let opam_libraries = match opam_reg with
@@ -37,14 +37,14 @@ let get_libraries ~maybe_reg ~opam_reg ~libraries =
         |> StringSet.of_list
         |> StringSet.to_map ~f:(OpamSatysfiRegistry.directory reg_opam)
   in
-  Format.printf "Reading opam libraries: %s\n" (opam_libraries |> Map.keys |> [%sexp_of: string list] |> Sexp.to_string_hum);
+  Format.fprintf outf "Reading opam libraries: %s\n" (opam_libraries |> Map.keys |> [%sexp_of: string list] |> Sexp.to_string_hum);
   let all_libraries =
     Option.value ~default:(Map.empty (module StringSet.Elt)) user_libraries
     |> Map.merge opam_libraries ~f:(fun ~key -> function
       | `Left x -> Library.read_dir x |> Some
       | `Right x -> Library.read_dir x |> Some
       | `Both (_, x) ->
-        Format.printf "Library %s is provided by both the user local and opam repositories\n" key;
+        Format.fprintf outf "Library %s is provided by both the user local and opam repositories\n" key;
         Library.read_dir x |> Some) in
   let required_libraries = match libraries with
     | None -> all_libraries
@@ -56,10 +56,10 @@ let get_libraries ~maybe_reg ~opam_reg ~libraries =
   match Map.add required_libraries ~key:"dist" ~data:dist_library with
     | `Ok result -> result
     | `Duplicate ->
-      Format.printf "Overriding dist with user installed one\n";
+      Format.fprintf outf "Overriding dist with user installed one\n";
       required_libraries
 
-let show_compatibility_warnings ~libraries =
+let show_compatibility_warnings ~outf ~libraries =
   Map.iteri libraries ~f:(fun ~key:library_name ~data:(library: Library.t) ->
     let open Library in
     let compatibility = library.compatibility in
@@ -68,82 +68,82 @@ let show_compatibility_warnings ~libraries =
       let print_rename t renames =
         if RenameSet.is_empty renames |> not
         then begin
-          Format.printf "@[<v 2>@,%s have been renamed.@,@[<v 2>" t;
+          Format.fprintf outf "@[<v 2>@,%s have been renamed.@,@[<v 2>" t;
           RenameSet.iter renames ~f:(fun { old_name; new_name } ->
-            Format.printf "@,%s -> %s" old_name new_name;
+            Format.fprintf outf "@,%s -> %s" old_name new_name;
           );
-          Format.printf "@]@]@,";
+          Format.fprintf outf "@]@]@,";
         end
       in
-      Format.printf "\n\027[1;33mCompatibility notice\027[0m for library %s:" library_name;
+      Format.fprintf outf "\n\027[1;33mCompatibility notice\027[0m for library %s:" library_name;
       print_rename "Packages" compatibility.rename_packages;
       print_rename "Fonts" compatibility.rename_fonts;
-      Format.print_newline ();
+      Format.fprintf outf "@.";
     end
   )
 
-let install_libraries d ~library_map  ~verbose ~copy () =
+let install_libraries d ~outf ~library_map  ~verbose ~copy () =
   let libraries = library_map |> Map.data in
   Map.keys library_map |> [%sexp_of: string list] |> Sexp.to_string_hum
-  |> Format.printf "Installing libraries: %s@,";
+  |> Format.fprintf outf "Installing libraries: %s@,";
   let merged = libraries
     |> List.fold_left ~f:Library.union ~init:Library.empty
   in
   begin match FileUtil.test FileUtil.Is_dir d, Library.is_managed_dir d with
   | true, false ->
-    Format.printf "Directory %s is not managed by Satyrographos.\n" d;
-    Format.printf "Please remove %s first.\n" d
+    Format.fprintf outf "Directory %s is not managed by Satyrographos.\n" d;
+    Format.fprintf outf "Please remove %s first.\n" d
   | _, _ ->
-    Format.printf "Removing destination %s\n" d;
+    Format.fprintf outf "Removing destination %s\n" d;
     FileUtil.(rm ~force:Force ~recurse:true [d]);
     Library.mark_managed_dir d;
     if verbose
     then begin
       [%sexp_of: Library.t list] libraries
       |> Sexp.to_string_hum
-      |> Format.printf "Loaded libraries@,%s";
+      |> Format.fprintf outf "Loaded libraries@,%s";
       [%sexp_of: Library.t] merged
       |> Sexp.to_string_hum
-      |> Format.printf "Installing %s@,";
+      |> Format.fprintf outf "Installing %s@,";
     end;
-    Library.write_dir ~symlink:(not copy) d merged;
-    List.iter ~f:(Format.printf "WARNING: %s") (Library.validate merged);
-    Format.printf "Installation completed!\n";
-    show_compatibility_warnings ~libraries:library_map;
+    Library.write_dir ~outf ~symlink:(not copy) d merged;
+    List.iter ~f:(Format.fprintf outf "WARNING: %s") (Library.validate merged);
+    Format.fprintf outf "Installation completed!\n";
+    show_compatibility_warnings ~outf ~libraries:library_map;
   end
 
 
-let install d ~system_font_prefix ~libraries ~verbose ~copy ~(env: Environment.t) () =
+let install d ~outf ~system_font_prefix ~libraries ~verbose ~copy ~(env: Environment.t) () =
   (* TODO build all *)
   Format.open_vbox 0;
   let maybe_repo = env.repo in
   Option.iter maybe_repo ~f:(fun {repo; reg} ->
-    Format.printf "Updating libraries@,";
-    begin match Repository.update_all repo with
+    Format.fprintf outf "Updating libraries@,";
+    begin match Repository.update_all ~outf repo with
     | Some updated_libraries -> begin
       [%derive.show: string list] updated_libraries
-      |> Format.printf "Updated libraries: %s@,";
+      |> Format.fprintf outf "Updated libraries: %s@,";
     end
     | None ->
-      Format.printf "No libraries updated@,"
+      Format.fprintf outf "No libraries updated@,"
     end;
-    Format.printf "Building updated libraries@,";
-    begin match Registry.update_all reg with
+    Format.fprintf outf "Building updated libraries@,";
+    begin match Registry.update_all ~outf reg with
     | Some updated_libraries -> begin
       [%derive.show: string list] updated_libraries
-      |> Format.printf "Built libraries: %s@,";
+      |> Format.fprintf outf "Built libraries: %s@,";
     end
     | None ->
-      Format.printf "No libraries built@,"
+      Format.fprintf outf "No libraries built@,"
     end);
   let maybe_reg = Option.map maybe_repo ~f:(fun p -> p.reg) in
-  let library_map = get_libraries ~maybe_reg ~opam_reg:env.opam_reg ~libraries in
+  let library_map = get_libraries ~outf ~maybe_reg ~opam_reg:env.opam_reg ~libraries in
   let library_map = match system_font_prefix with
-    | None -> Format.printf "Not gathering system fonts\n"; library_map
+    | None -> Format.fprintf outf "Not gathering system fonts\n"; library_map
     | Some(prefix) ->
-      Format.printf "Gathering system fonts with prefix %s\n" prefix;
-      let systemFontLibrary = SystemFontLibrary.get_library prefix () in
+      Format.fprintf outf "Gathering system fonts with prefix %s\n" prefix;
+      let systemFontLibrary = SystemFontLibrary.get_library prefix ~outf () in
       Map.add_exn ~key:"%fonts-system" ~data:systemFontLibrary library_map
   in
-  install_libraries d ~verbose  ~library_map ~copy ();
+  install_libraries d ~verbose ~outf ~library_map ~copy ();
   Format.close_box ()

--- a/src/registry.ml
+++ b/src/registry.ml
@@ -23,7 +23,7 @@ let remove_multiple reg names =
 let remove reg name =
   remove_multiple reg [name]
 
-let build_library reg name =
+let build_library ~outf reg name =
   match Metadata.mem reg.metadata name with
   | false -> failwith (Printf.sprintf "Library %s is not found" name)
   | true ->
@@ -32,12 +32,12 @@ let build_library reg name =
     let library = Library.read_dir dir in
     Library.to_string library |> print_endline;
     Store.remove reg.registry name;
-    Store.add_library reg.registry name library
+    Store.add_library ~outf reg.registry name library
 
 (* TODO build only obsoleted libraries *)
-let update_all reg =
+let update_all ~outf reg =
   let updated_libraries = list reg in
-  List.iter ~f:(build_library reg) updated_libraries;
+  List.iter ~f:(build_library ~outf reg) updated_libraries;
   Some updated_libraries
 
 (* Advanced operations *)

--- a/src/satysfiDirs.ml
+++ b/src/satysfiDirs.ml
@@ -18,7 +18,7 @@ let user_dir () =
 let is_runtime_dir dir =
   FileUtil.(test Is_dir) (Filename.concat dir "packages")
 
-let opam_share_dir () =
+let opam_share_dir ~outf =
   try
     Unix.open_process_in "opam var share"
     |> In_channel.input_all
@@ -29,16 +29,15 @@ let opam_share_dir () =
     end
   with
     Failure x ->
-      print_endline "Failed to get opam directory.";
-      print_endline x;
+      Format.fprintf outf "Failed to get opam directory.\n %s@." x;
       None
 
 let option_to_list = function
   | Some x -> [x]
   | None -> []
 
-let satysfi_dist_dir () =
-  let shares = option_to_list (opam_share_dir ()) @ ["/usr/local/share"; "/usr/share"] in
+let satysfi_dist_dir ~outf =
+  let shares = option_to_list (opam_share_dir ~outf) @ ["/usr/local/share"; "/usr/share"] in
   let dist_dirs = List.map shares ~f:(fun d -> Filename.concat d "satysfi" |> (fun d -> Filename.concat d "dist")) in
   let rec f = function
     | [] -> failwith "Can't find SATySFi lib. Please install it."


### PR DESCRIPTION
Use `Format.fprintf` everywhere instead of `Format.printf` or `Printf.printf`.