### PR TITLE
Refactoring: Explicitly handle dist runtime directory

### DIFF
--- a/bin/commandOpam.ml
+++ b/bin/commandOpam.ml
@@ -30,12 +30,15 @@ let opam_with_build_module_command ~prefix_optionality f =
         | None -> begin
           if StringMap.length builsscript = 1
           then let build_module = StringMap.nth_exn builsscript 0 |> snd in
-            f ~outf ~verbose ~prefix ~build_module ~buildscript_path ~opam_reg:Setup.reg_opam
+            let env = Setup.read_environment () in
+            f ~outf ~verbose ~prefix ~build_module ~buildscript_path ~env
           else failwith "Please specify module name with -name option"
         end
         | Some name ->
           match StringMap.find builsscript name with
-            | Some build_module -> f ~outf ~verbose ~prefix ~build_module ~buildscript_path ~opam_reg:Setup.reg_opam
+            | Some build_module ->
+              let env = Setup.read_environment () in
+              f ~outf ~verbose ~prefix ~build_module ~buildscript_path ~env
             | _ ->
               failwithf "Build file does not contains library %s" name ()
     ]

--- a/bin/commandStatus.ml
+++ b/bin/commandStatus.ml
@@ -16,7 +16,8 @@ let status () =
   [%derive.show: string list] (SatysfiDirs.runtime_dirs ()) |> print_endline;
   printf "SATySFi user directory: ";
   [%derive.show: string option] (SatysfiDirs.user_dir ()) |> print_endline;
-  printf "Selected SATySFi runtime distribution: %s\n" (SatysfiDirs.satysfi_dist_dir ~outf)
+  [%derive.show: string option] (SatysfiDirs.satysfi_dist_dir ~outf)
+  |> printf "Selected SATySFi runtime distribution: %s\n"
 
 let status_command =
   let open Command.Let_syntax in

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -65,5 +65,6 @@ let default_target_dir =
 
 let read_environment () =
   let repo = try_read_repo () in
-  Environment.{ repo; opam_reg = reg_opam }
+  let dist_library_dir = SatysfiDirs.satysfi_dist_dir ~outf:Format.std_formatter in
+  Environment.{ repo; opam_reg = reg_opam; dist_library_dir }
 

--- a/src/Environment.ml
+++ b/src/Environment.ml
@@ -6,5 +6,6 @@ type repo = {
 type t = {
   repo: repo option;
   opam_reg: OpamSatysfiRegistry.t option;
+  dist_library_dir: string option;
 }
 

--- a/src/commandInstall.ml
+++ b/src/commandInstall.ml
@@ -19,8 +19,9 @@ let transitive_closure map =
 
 
 (* TODO Install transitive dependencies *)
-let get_libraries ~outf ~maybe_reg ~opam_reg ~libraries =
-  let dist_library_dir = SatysfiDirs.satysfi_dist_dir ~outf in
+let get_libraries ~outf ~maybe_reg ~(env: Environment.t) ~libraries =
+  let dist_library_dir = Option.value_exn ~message:"SATySFi dist directory is not found. Please run opam install satysfi-dist" env.dist_library_dir in
+  let opam_reg = env.opam_reg in
   Format.fprintf outf "Reading runtime dist: %s\n" dist_library_dir;
   let dist_library = Library.read_dir dist_library_dir in
   let user_libraries = Option.map maybe_reg ~f:(fun reg -> Registry.list reg
@@ -137,7 +138,7 @@ let install d ~outf ~system_font_prefix ~libraries ~verbose ~copy ~(env: Environ
       Format.fprintf outf "No libraries built@,"
     end);
   let maybe_reg = Option.map maybe_repo ~f:(fun p -> p.reg) in
-  let library_map = get_libraries ~outf ~maybe_reg ~opam_reg:env.opam_reg ~libraries in
+  let library_map = get_libraries ~outf ~maybe_reg ~env ~libraries in
   let library_map = match system_font_prefix with
     | None -> Format.fprintf outf "Not gathering system fonts\n"; library_map
     | Some(prefix) ->

--- a/src/satysfiDirs.ml
+++ b/src/satysfiDirs.ml
@@ -40,10 +40,10 @@ let satysfi_dist_dir ~outf =
   let shares = option_to_list (opam_share_dir ~outf) @ ["/usr/local/share"; "/usr/share"] in
   let dist_dirs = List.map shares ~f:(fun d -> Filename.concat d "satysfi" |> (fun d -> Filename.concat d "dist")) in
   let rec f = function
-    | [] -> failwith "Can't find SATySFi lib. Please install it."
+    | [] -> None
     | (d :: ds) ->
       if is_runtime_dir d
-        then d
+        then Some d
         else f ds
   in
   f dist_dirs


### PR DESCRIPTION
Add dist_runtime_dir to Environment.t in order to reduce implicit environmental dependencies.

This is part of #19.