### PR TITLE
Snapshot tests for install subcommand

### DIFF
--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -28,6 +28,7 @@ depends: [
   "json-derivers"
   "ppx_deriving"
   "opam-format" {>= "2.0" & < "2.1"}
+  "stringext" {with-test}
   "uri" {>= "3.0.0"}
   "uri-sexp" {>= "3.0.0"}
   "yojson"

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -1,0 +1,10 @@
+(tests
+ (names
+   install__emptyDist
+   install__missingDist
+   install__onlyDist
+   install__unmanagedDirAlreadyExists
+ )
+ (preprocess (pps ppx_deriving.std ppx_jane))
+ (libraries core satyrographos shexp.process uri)
+ )

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -4,6 +4,7 @@
    install__missingDist
    install__onlyDist
    install__unmanagedDirAlreadyExists
+   install__thirdParties
  )
  (preprocess (pps ppx_deriving.std ppx_jane))
  (libraries core satyrographos shexp.process uri)

--- a/test/testcases/install__emptyDist.expected
+++ b/test/testcases/install__emptyDist.expected
@@ -1,0 +1,21 @@
+Installing packages
+------------------------------------------------------------
+Reading runtime dist: @@temp_dir@@/empty_dist
+Read user libraries: ()
+Reading opam libraries: ()
+Not gathering system fonts
+Installing libraries: (dist)
+Removing destination @@dest_dir@@/dest
+Loaded libraries
+(((name ()) (version ())))Installing ((name ()) (version ()))
+Installation completed!
+------------------------------------------------------------
+@@dest_dir@@
+@@dest_dir@@/dest
+@@dest_dir@@/dest/metadata
+@@dest_dir@@/dest/.satyrographos
+------------------------------------------------------------
+diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
+0a1,2
+> ((version 1) (libraryName "") (libraryVersion "") (compatibility ())
+>  (dependencies ()))

--- a/test/testcases/install__emptyDist.ml
+++ b/test/testcases/install__emptyDist.ml
@@ -1,0 +1,25 @@
+module StdList = List
+
+open TestLib
+
+open Shexp_process
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let empty_dist = FilePath.concat temp_dir "empty_dist" in
+  PrepareDist.empty empty_dist
+  >> return Satyrographos.Environment.{
+    repo = None;
+    opam_reg = None;
+    dist_library_dir = Some empty_dist;
+  }
+
+let () =
+  let system_font_prefix = None in
+  let libraries = None in
+  let verbose = true in
+  let copy = false in
+  let main env ~dest_dir ~temp_dir:_ =
+    let dest_dir = FilePath.concat dest_dir "dest" in
+    Satyrographos.CommandInstall.install dest_dir ~system_font_prefix ~libraries ~verbose ~copy ~env () in
+  eval (test_install env main)

--- a/test/testcases/install__missingDist.expected
+++ b/test/testcases/install__missingDist.expected
@@ -1,0 +1,7 @@
+Installing packages
+------------------------------------------------------------
+Exception:
+"SATySFi dist directory is not found. Please run opam install satysfi-dist"
+------------------------------------------------------------
+@@dest_dir@@
+------------------------------------------------------------

--- a/test/testcases/install__missingDist.ml
+++ b/test/testcases/install__missingDist.ml
@@ -1,0 +1,22 @@
+module StdList = List
+
+open TestLib
+
+open Shexp_process
+
+let env ~dest_dir:_ ~temp_dir:_ : Satyrographos.Environment.t t =
+  return Satyrographos.Environment.{
+    repo = None;
+    opam_reg = None;
+    dist_library_dir = None;
+  }
+
+let () =
+  let system_font_prefix = None in
+  let libraries = None in
+  let verbose = true in
+  let copy = false in
+  let main env ~dest_dir ~temp_dir:_ =
+    let dest_dir = FilePath.concat dest_dir "dest" in
+    Satyrographos.CommandInstall.install dest_dir ~system_font_prefix ~libraries ~verbose ~copy ~env () in
+  eval (test_install env main)

--- a/test/testcases/install__onlyDist.expected
+++ b/test/testcases/install__onlyDist.expected
@@ -1,0 +1,72 @@
+Installing packages
+------------------------------------------------------------
+Reading runtime dist: @@temp_dir@@/simple_dist
+Read user libraries: ()
+Reading opam libraries: ()
+Not gathering system fonts
+Installing libraries: (dist)
+Removing destination @@dest_dir@@/dest
+Loaded libraries
+(((name ()) (version ())
+  (hashes
+   ((hash/fonts.satysfi-hash
+     ((@@temp_dir@@/simple_dist/hash/fonts.satysfi-hash)
+      (Assoc
+       ((Junicode
+         (Variant
+          (Single ((Assoc ((src (String dist/fonts/Junicode.ttf))))))))))))))
+  (files
+   ((fonts/Junicode.ttf
+     @@temp_dir@@/simple_dist/fonts/Junicode.ttf)
+    (packages/List.satyg
+     @@temp_dir@@/simple_dist/packages/List.satyg)
+    (unidata/UnicodeData.txt
+     @@temp_dir@@/simple_dist/unidata/UnicodeData.txt)))))Installing ((name ()) (version ())
+ (hashes
+  ((hash/fonts.satysfi-hash
+    ((@@temp_dir@@/simple_dist/hash/fonts.satysfi-hash)
+     (Assoc
+      ((Junicode
+        (Variant (Single ((Assoc ((src (String dist/fonts/Junicode.ttf))))))))))))))
+ (files
+  ((fonts/Junicode.ttf
+    @@temp_dir@@/simple_dist/fonts/Junicode.ttf)
+   (packages/List.satyg
+    @@temp_dir@@/simple_dist/packages/List.satyg)
+   (unidata/UnicodeData.txt
+    @@temp_dir@@/simple_dist/unidata/UnicodeData.txt))))
+Installation completed!
+------------------------------------------------------------
+@@dest_dir@@
+@@dest_dir@@/dest
+@@dest_dir@@/dest/metadata
+@@dest_dir@@/dest/hash
+@@dest_dir@@/dest/hash/fonts.satysfi-hash
+@@dest_dir@@/dest/unidata
+@@dest_dir@@/dest/unidata/UnicodeData.txt
+@@dest_dir@@/dest/packages
+@@dest_dir@@/dest/packages/List.satyg
+@@dest_dir@@/dest/fonts
+@@dest_dir@@/dest/fonts/Junicode.ttf
+@@dest_dir@@/dest/.satyrographos
+------------------------------------------------------------
+diff -Nr @@empty_dir@@/dest/fonts/Junicode.ttf @@dest_dir@@/dest/fonts/Junicode.ttf
+0a1
+> @@Junicode.ttf@@
+diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
+0a1
+> {"Junicode":<"Single":{"src":"dist/fonts/Junicode.ttf"}>}
+\ No newline at end of file
+diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
+0a1,2
+> ((version 1) (libraryName "") (libraryVersion "") (compatibility ())
+>  (dependencies ()))
+diff -Nr @@empty_dir@@/dest/packages/List.satyg @@dest_dir@@/dest/packages/List.satyg
+0a1,2
+> @stage: persistent
+> module List = struct end
+diff -Nr @@empty_dir@@/dest/unidata/UnicodeData.txt @@dest_dir@@/dest/unidata/UnicodeData.txt
+0a1,3
+> 0000;<control>;Cc;0;BN;;;;;N;NULL;;;;
+> 0001;<control>;Cc;0;BN;;;;;N;START OF HEADING;;;;
+> 0002;<control>;Cc;0;BN;;;;;N;START OF TEXT;;;;

--- a/test/testcases/install__onlyDist.expected
+++ b/test/testcases/install__onlyDist.expected
@@ -39,16 +39,16 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
-@@dest_dir@@/dest/metadata
-@@dest_dir@@/dest/hash
-@@dest_dir@@/dest/hash/fonts.satysfi-hash
-@@dest_dir@@/dest/unidata
-@@dest_dir@@/dest/unidata/UnicodeData.txt
-@@dest_dir@@/dest/packages
-@@dest_dir@@/dest/packages/List.satyg
 @@dest_dir@@/dest/fonts
 @@dest_dir@@/dest/fonts/Junicode.ttf
+@@dest_dir@@/dest/hash
+@@dest_dir@@/dest/hash/fonts.satysfi-hash
+@@dest_dir@@/dest/metadata
+@@dest_dir@@/dest/packages
+@@dest_dir@@/dest/packages/List.satyg
 @@dest_dir@@/dest/.satyrographos
+@@dest_dir@@/dest/unidata
+@@dest_dir@@/dest/unidata/UnicodeData.txt
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/fonts/Junicode.ttf @@dest_dir@@/dest/fonts/Junicode.ttf
 0a1

--- a/test/testcases/install__onlyDist.ml
+++ b/test/testcases/install__onlyDist.ml
@@ -1,0 +1,25 @@
+module StdList = List
+
+open TestLib
+
+open Shexp_process
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let dist_dir = FilePath.concat temp_dir "simple_dist" in
+  PrepareDist.simple dist_dir
+  >> return Satyrographos.Environment.{
+    repo = None;
+    opam_reg = None;
+    dist_library_dir = Some dist_dir;
+  }
+
+let () =
+  let system_font_prefix = None in
+  let libraries = None in
+  let verbose = true in
+  let copy = false in
+  let main env ~dest_dir ~temp_dir:_ =
+    let dest_dir = FilePath.concat dest_dir "dest" in
+    Satyrographos.CommandInstall.install dest_dir ~system_font_prefix ~libraries ~verbose ~copy ~env () in
+  eval (test_install env main)

--- a/test/testcases/install__thirdParties.expected
+++ b/test/testcases/install__thirdParties.expected
@@ -1,0 +1,144 @@
+Installing packages
+------------------------------------------------------------
+Reading runtime dist: @@temp_dir@@/empty_dist
+Read user libraries: ()
+Reading opam libraries: (fonts-theano grcnum)
+Not gathering system fonts
+Installing libraries: (dist fonts-theano grcnum)
+Removing destination @@dest_dir@@/dest
+Loaded libraries
+(((name ()) (version ()))
+ ((name (fonts-theano)) (version (2.0))
+  (hashes
+   ((hash/fonts.satysfi-hash
+     ((@@temp_dir@@/opam_reg/fonts-theano/hash/fonts.satysfi-hash)
+      (Assoc
+       ((fonts-theano:TheanoDidot
+         (Variant
+          (Single
+           ((Assoc
+             ((src-dist (String fonts-theano/TheanoDidot-Regular.otf))))))))
+        (fonts-theano:TheanoModern
+         (Variant
+          (Single
+           ((Assoc
+             ((src-dist (String fonts-theano/TheanoModern-Regular.otf))))))))
+        (fonts-theano:TheanoOldStyle
+         (Variant
+          (Single
+           ((Assoc
+             ((src-dist (String fonts-theano/TheanoOldStyle-Regular.otf))))))))))))))
+  (files
+   ((fonts/fonts-theano/TheanoDidot-Regular.otf
+     @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoDidot-Regular.otf)
+    (fonts/fonts-theano/TheanoModern-Regular.otf
+     @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoModern-Regular.otf)
+    (fonts/fonts-theano/TheanoOldStyle-Regular.otf
+     @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoOldStyle-Regular.otf)))
+  (compatibility
+   ((rename_fonts
+     (((new_name fonts-theano:TheanoDidot) (old_name TheanoDidot))
+      ((new_name fonts-theano:TheanoModern) (old_name TheanoModern))
+      ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle)))))))
+ ((name (grcnum)) (version (0.2))
+  (files
+   ((packages/grcnum/grcnum.satyh
+     @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh)))
+  (compatibility
+   ((rename_packages
+     (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
+  (dependencies (fonts-theano))))Installing ((name (fonts-theano)) (version (2.0))
+ (hashes
+  ((hash/fonts.satysfi-hash
+    ((@@temp_dir@@/opam_reg/fonts-theano/hash/fonts.satysfi-hash)
+     (Assoc
+      ((fonts-theano:TheanoDidot
+        (Variant
+         (Single
+          ((Assoc ((src-dist (String fonts-theano/TheanoDidot-Regular.otf))))))))
+       (fonts-theano:TheanoModern
+        (Variant
+         (Single
+          ((Assoc
+            ((src-dist (String fonts-theano/TheanoModern-Regular.otf))))))))
+       (fonts-theano:TheanoOldStyle
+        (Variant
+         (Single
+          ((Assoc
+            ((src-dist (String fonts-theano/TheanoOldStyle-Regular.otf))))))))))))))
+ (files
+  ((fonts/fonts-theano/TheanoDidot-Regular.otf
+    @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoDidot-Regular.otf)
+   (fonts/fonts-theano/TheanoModern-Regular.otf
+    @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoModern-Regular.otf)
+   (fonts/fonts-theano/TheanoOldStyle-Regular.otf
+    @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoOldStyle-Regular.otf)
+   (packages/grcnum/grcnum.satyh
+    @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh)))
+ (compatibility
+  ((rename_packages
+    (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))
+   (rename_fonts
+    (((new_name fonts-theano:TheanoDidot) (old_name TheanoDidot))
+     ((new_name fonts-theano:TheanoModern) (old_name TheanoModern))
+     ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle))))))
+ (dependencies (fonts-theano)))
+Installation completed!
+
+[1;33mCompatibility notice[0m for library fonts-theano:
+
+  Fonts have been renamed.
+  
+    TheanoDidot -> fonts-theano:TheanoDidot
+    TheanoModern -> fonts-theano:TheanoModern
+    TheanoOldStyle -> fonts-theano:TheanoOldStyle
+
+
+[1;33mCompatibility notice[0m for library grcnum:
+                                                      Packages have been renamed.
+                                                      
+                                                        grcnum.satyh -> grcnum/grcnum.satyh
+
+------------------------------------------------------------
+@@dest_dir@@
+@@dest_dir@@/dest
+@@dest_dir@@/dest/fonts
+@@dest_dir@@/dest/fonts/fonts-theano
+@@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
+@@dest_dir@@/dest/fonts/fonts-theano/TheanoModern-Regular.otf
+@@dest_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+@@dest_dir@@/dest/hash
+@@dest_dir@@/dest/hash/fonts.satysfi-hash
+@@dest_dir@@/dest/metadata
+@@dest_dir@@/dest/packages
+@@dest_dir@@/dest/packages/grcnum
+@@dest_dir@@/dest/packages/grcnum/grcnum.satyh
+@@dest_dir@@/dest/.satyrographos
+------------------------------------------------------------
+diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
+0a1
+> @@TheanoDidot-Regular.otf@@
+diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoModern-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoModern-Regular.otf
+0a1
+> @@TheanoModern-Regular.otf@@
+diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+0a1
+> @@TheanoOldStyle-Regular.otf@@
+diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
+0a1
+> {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
+\ No newline at end of file
+diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
+0a1,9
+> ((version 1) (libraryName fonts-theano) (libraryVersion 2.0)
+>  (compatibility
+>   ((rename_packages
+>     (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))
+>    (rename_fonts
+>     (((new_name fonts-theano:TheanoDidot) (old_name TheanoDidot))
+>      ((new_name fonts-theano:TheanoModern) (old_name TheanoModern))
+>      ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle))))))
+>  (dependencies ((fonts-theano ()))))
+diff -Nr @@empty_dir@@/dest/packages/grcnum/grcnum.satyh @@dest_dir@@/dest/packages/grcnum/grcnum.satyh
+0a1
+> @@grcnum.satyh@@

--- a/test/testcases/install__thirdParties.ml
+++ b/test/testcases/install__thirdParties.ml
@@ -1,0 +1,28 @@
+module StdList = List
+
+open TestLib
+
+open Shexp_process
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let empty_dist = FilePath.concat temp_dir "empty_dist" in
+  let opam_reg = FilePath.concat temp_dir "opam_reg" in
+  PrepareDist.empty empty_dist
+  >> PrepareOpamReg.(prepare opam_reg theanoFiles)
+  >> PrepareOpamReg.(prepare opam_reg grcnumFiles)
+  >> return Satyrographos.Environment.{
+    repo = None;
+    opam_reg = Some (Satyrographos.OpamSatysfiRegistry.read opam_reg);
+    dist_library_dir = Some empty_dist;
+  }
+
+let () =
+  let system_font_prefix = None in
+  let libraries = None in
+  let verbose = true in
+  let copy = false in
+  let main env ~dest_dir ~temp_dir:_ =
+    let dest_dir = FilePath.concat dest_dir "dest" in
+    Satyrographos.CommandInstall.install dest_dir ~system_font_prefix ~libraries ~verbose ~copy ~env () in
+  eval (test_install env main)

--- a/test/testcases/install__unmanagedDirAlreadyExists.expected
+++ b/test/testcases/install__unmanagedDirAlreadyExists.expected
@@ -1,0 +1,13 @@
+Installing packages
+------------------------------------------------------------
+Reading runtime dist: @@temp_dir@@/empty_dist
+Read user libraries: ()
+Reading opam libraries: ()
+Not gathering system fonts
+Installing libraries: (dist)
+Directory @@dest_dir@@/dest is not managed by Satyrographos.
+Please remove @@dest_dir@@/dest first.
+------------------------------------------------------------
+@@dest_dir@@
+@@dest_dir@@/dest
+------------------------------------------------------------

--- a/test/testcases/install__unmanagedDirAlreadyExists.ml
+++ b/test/testcases/install__unmanagedDirAlreadyExists.ml
@@ -1,0 +1,26 @@
+module StdList = List
+
+open TestLib
+
+open Shexp_process
+
+let env ~dest_dir ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let empty_dist = FilePath.concat temp_dir "empty_dist" in
+  PrepareDist.empty empty_dist
+  >> mkdir (FilePath.concat dest_dir "dest")
+  >> return Satyrographos.Environment.{
+    repo = None;
+    opam_reg = None;
+    dist_library_dir = Some empty_dist;
+  }
+
+let () =
+  let system_font_prefix = None in
+  let libraries = None in
+  let verbose = true in
+  let copy = false in
+  let main env ~dest_dir ~temp_dir:_ =
+    let dest_dir = FilePath.concat dest_dir "dest" in
+    Satyrographos.CommandInstall.install dest_dir ~system_font_prefix ~libraries ~verbose ~copy ~env () in
+  eval (test_install env main)

--- a/test/testcases/prepareDist.ml
+++ b/test/testcases/prepareDist.ml
@@ -1,0 +1,29 @@
+open Shexp_process
+open Shexp_process.Infix
+
+let fontsJunicode = "fonts/Junicode.ttf", "@@Junicode.ttf@@"
+
+let hashFonts = "hash/fonts.satysfi-hash",
+{|{"Junicode"  : <Single: {"src": "dist/fonts/Junicode.ttf"}>}|}
+
+let packagesList = "packages/List.satyg",
+{|@stage: persistent
+module List = struct end|}
+
+let unidataUnicodeData = "unidata/UnicodeData.txt",
+{|0000;<control>;Cc;0;BN;;;;;N;NULL;;;;
+0001;<control>;Cc;0;BN;;;;;N;START OF HEADING;;;;
+0002;<control>;Cc;0;BN;;;;;N;START OF TEXT;;;;|}
+
+let files = [ fontsJunicode; hashFonts; unidataUnicodeData; packagesList; ]
+
+let empty dir =
+  mkdir dir
+
+let simple dir =
+  List.iter files ~f:(fun (file, content) ->
+    let path = FilePath.concat dir file in
+    mkdir ~p:() (FilePath.dirname path)
+    >> (stdout_to path (echo content))
+  )
+

--- a/test/testcases/prepareOpamReg.ml
+++ b/test/testcases/prepareOpamReg.ml
@@ -1,0 +1,42 @@
+open Shexp_process
+open Shexp_process.Infix
+
+let theanoMetadata = "fonts-theano/metadata",
+{|((version 1) (libraryName fonts-theano) (libraryVersion 2.0)
+ (compatibility
+  ((rename_fonts
+    (((new_name fonts-theano:TheanoDidot) (old_name TheanoDidot))
+     ((new_name fonts-theano:TheanoModern) (old_name TheanoModern))
+     ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle))))))
+ (dependencies ()))|}
+
+let theanoFiles =
+  [ theanoMetadata;
+    "fonts-theano/hash/fonts.satysfi-hash",
+      {|{"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}|};
+    "fonts-theano/fonts/fonts-theano/TheanoDidot-Regular.otf",
+      "@@TheanoDidot-Regular.otf@@";
+    "fonts-theano/fonts/fonts-theano/TheanoModern-Regular.otf",
+      "@@TheanoModern-Regular.otf@@";
+    "fonts-theano/fonts/fonts-theano/TheanoOldStyle-Regular.otf",
+      "@@TheanoOldStyle-Regular.otf@@";
+  ]
+
+let grcnumMetadata = "grcnum/metadata",
+{|((version 1) (libraryName grcnum) (libraryVersion 0.2)
+ (compatibility
+  ((rename_packages
+    (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
+ (dependencies ((fonts-theano ()))))|}
+
+let grcnumPackagesGrcnumGrcnum = "grcnum/packages/grcnum/grcnum.satyh", "@@grcnum.satyh@@"
+
+let grcnumFiles = [ grcnumMetadata; grcnumPackagesGrcnumGrcnum; ]
+
+let prepare dir files =
+  List.iter files ~f:(fun (file, content) ->
+    let path = FilePath.concat dir file in
+    mkdir ~p:() (FilePath.dirname path)
+    >> (stdout_to path (echo content))
+  )
+

--- a/test/testcases/testLib.ml
+++ b/test/testcases/testLib.ml
@@ -1,0 +1,54 @@
+module StdList = List
+
+open Shexp_process
+open Shexp_process.Infix
+
+let repeat_string n s : string =
+  StdList.init n (fun _ -> s) |> StdList.fold_left (^) ""
+
+let censor replacements =
+  iter_lines (fun s -> Stringext.replace_all_assoc s replacements |> echo)
+
+let with_formatter ?(where=Std_io.Stdout) f =
+  let buf = Buffer.create 100 in
+  let fmt = Format.make_formatter (Buffer.add_substring buf) ignore in
+  let v = f fmt in
+  echo ~where ~n:() (Buffer.contents buf)
+  >> return v
+
+let echo_line =
+  echo "------------------------------------------------------------"
+
+let dump_dir dir : unit t =
+  with_temp_dir ~prefix:"Satyrographos" ~suffix:"dump_dir" (fun empty_dir ->
+    run "find" [dir]
+    >> echo_line
+    >> run_exit_code "diff" ["-Nr"; empty_dir; dir] >>| (fun _ -> ())
+    |- censor [ empty_dir, "@@empty_dir@@"; ]
+  )
+
+let test_install setup f : unit t =
+  let test dest_dir temp_dir =
+    let opam_prefix = Unix.open_process_in "opam var prefix" |> input_line (* Assume a path does not contain line breaks*) in
+    let replacements =
+      [ opam_prefix, "@@opam_prefix@@";
+        dest_dir, "@@dest_dir@@";
+        temp_dir, "@@temp_dir@@";
+        Unix.getenv "HOME", "@@home_dir@@";
+      ] in
+    echo "Installing packages"
+    >> echo_line
+    >> setup ~dest_dir ~temp_dir
+    >>= (fun setup_result ->
+      try
+        with_formatter (fun outf -> f setup_result ~dest_dir ~temp_dir ~outf; Format.fprintf outf "@?")
+      with e ->
+        echo "Exception:"
+        >> echo (Printexc.to_string e)
+      )
+    >> echo_line
+    >> dump_dir dest_dir
+    |- censor replacements in
+  (with_temp_dir ~prefix:"Satyrographos" ~suffix:"test_dest"
+    (fun dest_dir ->
+      with_temp_dir ~prefix:"Satyrographos" ~suffix:"test_temp" (test dest_dir)))

--- a/test/testcases/testLib.ml
+++ b/test/testcases/testLib.ml
@@ -21,7 +21,7 @@ let echo_line =
 
 let dump_dir dir : unit t =
   with_temp_dir ~prefix:"Satyrographos" ~suffix:"dump_dir" (fun empty_dir ->
-    run "find" [dir]
+    (run "find" [dir] |- run "sort" [])
     >> echo_line
     >> run_exit_code "diff" ["-Nr"; empty_dir; dir] >>| (fun _ -> ())
     |- censor [ empty_dir, "@@empty_dir@@"; ]

--- a/test/testcases/testLib.mli
+++ b/test/testcases/testLib.mli
@@ -1,0 +1,23 @@
+open Shexp_process
+
+val repeat_string : int -> string -> string
+(** [repeat_string n s] returns a string, repeating string [s] [n]-times. *)
+
+val censor : (string * string) list -> unit t
+(** [censor wordlist] returns a Shexp process which behaves like a sed which replaces words in the given word lists.
+
+    [wordlist] is an associative list of pairs of a censored word and a replecement. *)
+
+val with_formatter : ?where:Std_io.t -> (Format.formatter -> 'a) -> 'a t
+(** [with_formatter ~where f] returns a Shexp process which executes [f] with a formatter which redirect to
+    the given Shexp IO [where], whose default value is [Stdout] *)
+
+val echo_line : unit t
+(** A Shexp process which output a horizontal line to Stdout. *)
+
+val dump_dir : string -> unit t
+(** [dump_dir dir] returns a Shexp process which dumps directory [dir]’s content to Stdout. *)
+
+val test_install : (dest_dir:string -> temp_dir:string -> 'a t) ->
+  ('a -> dest_dir:string -> temp_dir:string -> outf:Format.formatter -> unit) ->
+  unit t


### PR DESCRIPTION
This PR introduce a simple snapshot tests for install subcommand in simple situations, where there are no thirdparty libraries or system fonts.

This is part of #19 .