### PR TITLE
Stop using [@sexp.option] which is not supported by older ppx_sexp_conv

### DIFF
--- a/src/library.ml
+++ b/src/library.ml
@@ -51,9 +51,10 @@ end
 
 
 type t = {
-  (* TODO (gh-50) make name and version into non-optional *)
-  name: string option [@sexp.option];
-  version: string option [@sexp.option];
+  (* TODO (gh-50) make name and version into non-optional.
+     These fields need to be split out. *)
+  name: string option;
+  version: string option;
 
   hashes: (string list * Json.t) LibraryFiles.t [@sexp.omit_nil];
   files: string LibraryFiles.t [@sexp.omit_nil];


### PR DESCRIPTION
This PR can introduce incompatibility for users who are using OCaml 4.09 and having opted-in `pin` subcommand use. I believe number of affected people is negligibly small.

Closes https://github.com/na4zagin3/satyrographos/issues/88