### PR TITLE
Add redirection prefix for external command execution

### DIFF
--- a/src/commandOpam.ml
+++ b/src/commandOpam.ml
@@ -41,10 +41,14 @@ let run_build_commands ~outf ~verbose ~libraries ~workingDir ~env buildCommands 
   let open P in
   let open P.Infix in
   let commands satysfi_runtime = P.List.iter buildCommands ~f:(function
-    | "make" :: args -> P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args)
+    | "make" :: args ->
+      let command = P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args) in
+      ProcessUtil.redirect_to_stdout ~prefix:"make" command
     | "satysfi" :: args ->
-      assert_satysfi_option_C satysfi_runtime
-      >> P.run "satysfi" (["-C"; satysfi_runtime] @ args)
+      let command =
+        assert_satysfi_option_C satysfi_runtime
+        >> P.run "satysfi" (["-C"; satysfi_runtime] @ args) in
+      ProcessUtil.redirect_to_stdout ~prefix:"satysfi" command
     | cmd -> failwithf "command %s is not yet supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()
   ) in
   let with_env c =

--- a/src/processUtil.ml
+++ b/src/processUtil.ml
@@ -1,0 +1,52 @@
+open Core
+
+module P = Shexp_process
+
+let redirect_to_stdout ?(prefix="") ?(prefix_out="out>") ?(prefix_err="err>") com =
+  let open P in
+  let put_prefix x = if String.is_empty prefix then x else prefix ^ " " ^ x in
+  let prefix_out = put_prefix prefix_out in
+  let prefix_err = put_prefix prefix_err in
+  let iter_lines_prefix prefix =
+    iter_lines (fun l -> if String.is_empty l then echo prefix else echo (prefix ^ " " ^ l)) in
+  epipe (pipe com (iter_lines_prefix prefix_out)) (iter_lines_prefix prefix_err)
+
+let%expect_test "redirect_to_stdout: stdout" =
+  let open P in
+  let open P.Infix in
+  let com =
+    echo ~where:P.Std_io.Stdout "output to stdout 1"
+    >> echo ~where:P.Std_io.Stdout "output to stdout 2"
+    >> echo ~where:P.Std_io.Stdout "output to stdout 3" in
+  let wrapped = redirect_to_stdout com in
+  P.eval wrapped;
+  [%expect{|
+    out> output to stdout 1
+    out> output to stdout 2
+    out> output to stdout 3 |}]
+
+let%expect_test "redirect_to_stdout: stderr" =
+  let open P in
+  let open P.Infix in
+  let com =
+    echo ~where:P.Std_io.Stderr "output to stdout 1"
+    >> echo ~where:P.Std_io.Stderr "output to stdout 2"
+    >> echo ~where:P.Std_io.Stderr "output to stdout 3" in
+  let wrapped = redirect_to_stdout com in
+  P.eval wrapped;
+  [%expect{|
+    err> output to stdout 1
+    err> output to stdout 2
+    err> output to stdout 3 |}]
+
+let%expect_test "redirect_to_stdout: with prefix" =
+  let open P in
+  let open P.Infix in
+  let com =
+    echo ~where:P.Std_io.Stdout "output to stdout 1"
+    >> echo ~where:P.Std_io.Stdout "output to stdout 2" in
+  let wrapped = redirect_to_stdout ~prefix:"com" com in
+  P.eval wrapped;
+  [%expect{|
+    com out> output to stdout 1
+    com out> output to stdout 2 |}]

--- a/src/processUtil.mli
+++ b/src/processUtil.mli
@@ -1,0 +1,6 @@
+module P = Shexp_process
+
+(** [redirect_to_stdout ~prefix ~prefix_out ~prefix_err c] return a command where
+    stdout and stderr from the given [c] are redirected to stdout with given prefixes. *)
+val redirect_to_stdout : ?prefix:string ->
+?prefix_out:string -> ?prefix_err:string -> unit P.t -> unit P.t

--- a/test/testcases/opam_build__doc_satysfi.expected
+++ b/test/testcases/opam_build__doc_satysfi.expected
@@ -1,36 +1,43 @@
 Installing packages
 ------------------------------------------------------------
-INPUT=doc-grcnum.saty
-OUTPUT=doc-grcnum-ja.pdf
-Target: build-doc
-Files under $SATYSFI_RUNTIME
-==============================
-.:
-dist
-
-./dist:
-fonts
-hash
-metadata
-packages
-
-./dist/fonts:
-fonts-theano
-
-./dist/fonts/fonts-theano:
-TheanoDidot-Regular.otf
-TheanoModern-Regular.otf
-TheanoOldStyle-Regular.otf
-
-./dist/hash:
-fonts.satysfi-hash
-
-./dist/packages:
-grcnum
-
-./dist/packages/grcnum:
-grcnum.satyh
-==============================
+satysfi err> Command invoked:
+satysfi err> satysfi -C @@build_temp_dir@@ --version
+satysfi err>
+satysfi err> Command invoked:
+satysfi err> satysfi -C @@build_temp_dir@@ doc-grcnum.saty -o doc-grcnum-ja.pdf
+satysfi out> INPUT=doc-grcnum.saty
+satysfi out> OUTPUT=doc-grcnum-ja.pdf
+satysfi err> doc-grcnum.saty -> doc-grcnum-ja.pdf
+satysfi err>
+make out> Target: build-doc
+make out> Files under $SATYSFI_RUNTIME
+make out> ==============================
+make out> .:
+make out> dist
+make out>
+make out> ./dist:
+make out> fonts
+make out> hash
+make out> metadata
+make out> packages
+make out>
+make out> ./dist/fonts:
+make out> fonts-theano
+make out>
+make out> ./dist/fonts/fonts-theano:
+make out> TheanoDidot-Regular.otf
+make out> TheanoModern-Regular.otf
+make out> TheanoOldStyle-Regular.otf
+make out>
+make out> ./dist/hash:
+make out> fonts.satysfi-hash
+make out>
+make out> ./dist/packages:
+make out> grcnum
+make out>
+make out> ./dist/packages/grcnum:
+make out> grcnum.satyh
+make out> ==============================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
 Reading opam libraries: (base class-greek fonts-theano grcnum)


### PR DESCRIPTION
This PR adds prefix to each line of output from external commands (i.e., make and satysfi) like this:

```
satysfi err>
satysfi err> Command invoked:
satysfi err> satysfi -C @@build_temp_dir@@ doc-grcnum.saty -o doc-grcnum-ja.pdf
satysfi out> INPUT=doc-grcnum.saty
satysfi out> OUTPUT=doc-grcnum-ja.pdf
satysfi err> doc-grcnum.saty -> doc-grcnum-ja.pdf
satysfi err>
make out> Target: build-doc
make out> Files under $SATYSFI_RUNTIME
make out> ==============================
make out> .:
```