### PR TITLE
Output invoked command to stdout

### DIFF
--- a/src/processUtil.ml
+++ b/src/processUtil.ml
@@ -7,9 +7,9 @@ let redirect_to_stdout ?(prefix="") ?(prefix_out="out>") ?(prefix_err="err>") co
   let put_prefix x = if String.is_empty prefix then x else prefix ^ " " ^ x in
   let prefix_out = put_prefix prefix_out in
   let prefix_err = put_prefix prefix_err in
-  let iter_lines_prefix prefix =
-    iter_lines (fun l -> if String.is_empty l then echo prefix else echo (prefix ^ " " ^ l)) in
-  epipe (pipe com (iter_lines_prefix prefix_out)) (iter_lines_prefix prefix_err)
+  let iter_lines_prefix ?where prefix =
+    iter_lines (fun l -> if String.is_empty l then echo ?where prefix else echo ?where (prefix ^ " " ^ l)) in
+  epipe (pipe com (iter_lines_prefix prefix_out)) (iter_lines_prefix ~where:Std_io.Stderr prefix_err)
 
 let%expect_test "redirect_to_stdout: stdout" =
   let open P in

--- a/test/testcases/opam_build__doc_satysfi.expected
+++ b/test/testcases/opam_build__doc_satysfi.expected
@@ -1,14 +1,10 @@
 Installing packages
 ------------------------------------------------------------
-satysfi err> Command invoked:
-satysfi err> satysfi -C @@build_temp_dir@@ --version
-satysfi err>
-satysfi err> Command invoked:
-satysfi err> satysfi -C @@build_temp_dir@@ doc-grcnum.saty -o doc-grcnum-ja.pdf
 satysfi out> INPUT=doc-grcnum.saty
 satysfi out> OUTPUT=doc-grcnum-ja.pdf
-satysfi err> doc-grcnum.saty -> doc-grcnum-ja.pdf
-satysfi err>
+satysfi out> Command invoked:
+satysfi out> satysfi -C @@build_temp_dir@@ doc-grcnum.saty -o doc-grcnum-ja.pdf
+satysfi out> doc-grcnum.saty -> doc-grcnum-ja.pdf
 make out> Target: build-doc
 make out> Files under $SATYSFI_RUNTIME
 make out> ==============================

--- a/test/testcases/prepareBin.ml
+++ b/test/testcases/prepareBin.ml
@@ -1,14 +1,12 @@
 
 let satysfi =
-  let payload =
+  let parse_options =
     {|
-payload () {
-INPUT=
-OUTPUT=
+parse_options () {
 while [ "$#" -ne "0" ] ; do
   case "$1" in
     --version)
-      echo '  SATySFi version 0.0.3'
+      MODE=version
       return 0
       ;;
     -C)
@@ -20,6 +18,7 @@ while [ "$#" -ne "0" ] ; do
       echo OUTPUT=$1
       ;;
     *)
+      MODE=process
       INPUT=$1
       echo INPUT=$1
       ;;
@@ -31,13 +30,31 @@ cat $INPUT > $OUTPUT
 }
     |}
   in
+  let payload =
+    {|
+payload () {
+case "$MODE" in
+  version)
+    echo '  SATySFi version 0.0.3'
+    ;;
+  process)
+    echo 'Command invoked:'
+    echo satysfi "$@" | sed -e 's!/tmp/\w*!@@build_temp_dir@@!'
+    echo "$INPUT -> $OUTPUT"
+    cat $INPUT > $OUTPUT
+esac
+}
+    |}
+  in
   String.concat "\n"
     [ "#!/bin/bash";
+      "MODE=help";
+      "INPUT=";
+      "OUTPUT=";
+      parse_options;
       payload;
-      "echo 'Command invoked:' >&2";
-      "echo satysfi \"$@\" | sed -e 's!/tmp/\\w*!@@build_temp_dir@@!' >&2";
+      "parse_options \"$@\"";
       "payload \"$@\"";
-      "echo >&2";
     ]
 
 let prepare_bin bin =


### PR DESCRIPTION
For more stable snapshot testing, stop redirection from stderr to stdout.

This will be finally resolved by #42 .