### PR TITLE
Log command invocation to a file rather than stdout

### DIFF
--- a/test/testcases/opam_build__doc_satysfi.expected
+++ b/test/testcases/opam_build__doc_satysfi.expected
@@ -1,10 +1,5 @@
 Installing packages
 ------------------------------------------------------------
-satysfi out> INPUT=doc-grcnum.saty
-satysfi out> OUTPUT=doc-grcnum-ja.pdf
-satysfi out> Command invoked:
-satysfi out> satysfi -C @@build_temp_dir@@ doc-grcnum.saty -o doc-grcnum-ja.pdf
-satysfi out> doc-grcnum.saty -> doc-grcnum-ja.pdf
 make out> Target: build-doc
 make out> Files under $SATYSFI_RUNTIME
 make out> ==============================
@@ -59,3 +54,9 @@ Setting up SATySFi env at @@build_opam@@
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------
+------------------------------------------------------------
+Command invoked:
+satysfi -C @@build_opam@@ --version
+Command invoked:
+satysfi -C @@build_opam@@ doc-grcnum.saty -o doc-grcnum-ja.pdf
+doc-grcnum.saty -> doc-grcnum-ja.pdf

--- a/test/testcases/opam_build__doc_satysfi.ml
+++ b/test/testcases/opam_build__doc_satysfi.ml
@@ -64,6 +64,7 @@ let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
   let empty_dist = FilePath.concat temp_dir "empty_dist" in
   let prepare_dist = PrepareDist.empty empty_dist in
   let opam_reg = FilePath.concat temp_dir "opam_reg" in
+  let log_file = exec_log_file_path temp_dir in
   let prepare_opam_reg =
     PrepareOpamReg.(prepare opam_reg theanoFiles)
     >> PrepareOpamReg.(prepare opam_reg grcnumFiles)
@@ -74,7 +75,7 @@ let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
   prepare_pkg
   >> prepare_dist
   >> prepare_opam_reg
-  >> PrepareBin.prepare_bin bin
+  >> PrepareBin.prepare_bin bin log_file
   >>| read_env ~opam_reg ~dist_library_dir:empty_dist
 
 let () =

--- a/test/testcases/prepareBin.ml
+++ b/test/testcases/prepareBin.ml
@@ -1,5 +1,10 @@
 
-let satysfi =
+let satysfi log_file =
+  let log_invocation =
+{|
+    echo 'Command invoked:' >> $LOG_FILE
+    echo satysfi "$@" | sed -e 's!/tmp/ \w*!@@build_temp_dir@@!' >> $LOG_FILE
+|} in
   let parse_options =
     {|
 parse_options () {
@@ -15,18 +20,14 @@ while [ "$#" -ne "0" ] ; do
     -o)
       shift
       OUTPUT=$1
-      echo OUTPUT=$1
       ;;
     *)
       MODE=process
       INPUT=$1
-      echo INPUT=$1
       ;;
   esac
   shift
 done
-echo "$INPUT -> $OUTPUT" >&2
-cat $INPUT > $OUTPUT
 }
     |}
   in
@@ -38,9 +39,7 @@ case "$MODE" in
     echo '  SATySFi version 0.0.3'
     ;;
   process)
-    echo 'Command invoked:'
-    echo satysfi "$@" | sed -e 's!/tmp/\w*!@@build_temp_dir@@!'
-    echo "$INPUT -> $OUTPUT"
+    echo "$INPUT -> $OUTPUT" >> $LOG_FILE
     cat $INPUT > $OUTPUT
 esac
 }
@@ -48,21 +47,23 @@ esac
   in
   String.concat "\n"
     [ "#!/bin/bash";
+      "LOG_FILE='" ^ log_file ^"'";
       "MODE=help";
       "INPUT=";
       "OUTPUT=";
+      log_invocation;
       parse_options;
       payload;
       "parse_options \"$@\"";
       "payload \"$@\"";
     ]
 
-let prepare_bin bin =
+let prepare_bin bin log_file =
   let satysfi_path = FilePath.concat bin "satysfi" in
   let path = Unix.getenv "PATH" in
   let open Shexp_process in
   let open Infix in
   Unix.putenv "PATH" (bin ^ ":" ^ path);
   mkdir bin
-  >> stdout_to satysfi_path (echo satysfi)
+  >> stdout_to satysfi_path (satysfi log_file |> echo)
   >> chmod satysfi_path ~perm:0o755

--- a/test/testcases/testLib.ml
+++ b/test/testcases/testLib.ml
@@ -3,6 +3,8 @@ module StdList = List
 open Shexp_process
 open Shexp_process.Infix
 
+let exec_log_file_path temp_dir = FilePath.concat temp_dir "commands.log"
+
 let repeat_string n s : string =
   StdList.init n (fun _ -> s) |> StdList.fold_left (^) ""
 
@@ -69,6 +71,11 @@ let test_install  setup f : unit t =
       )
     >> echo_line
     >> dump_dir dest_dir
+    >>= (fun () ->
+      let log_file = exec_log_file_path temp_dir in
+      if FileUtil.(test Is_file log_file)
+      then echo_line >> stdin_from log_file (iter_lines echo)
+      else return ())
     |- censor replacements
     |- censor_tempdirs in
   (with_temp_dir ~prefix:"Satyrographos" ~suffix:"test_dest"

--- a/test/testcases/testLib.mli
+++ b/test/testcases/testLib.mli
@@ -1,5 +1,7 @@
 open Shexp_process
 
+val exec_log_file_path : string -> string
+
 val repeat_string : int -> string -> string
 (** [repeat_string n s] returns a string, repeating string [s] [n]-times. *)
 


### PR DESCRIPTION
To get stable snapshot, leave external command invocations in a file rather than stdout.