### PR TITLE
Show filename when JSON parser raises an exception

### DIFF
--- a/src/library.ml
+++ b/src/library.ml
@@ -12,7 +12,8 @@ end
 module Json = struct
   (*
   include Yojson.Safe
-  let ( sexp_of_t, t_of_sexp, compare, hash ) = Json_erivers.Yojson.( sexp_of_t, t_of_sexp, compare, hash )
+  type t = Json_derivers.Yojson.t
+  let ( sexp_of_t, t_of_sexp, compare, hash ) = Json_derivers.Yojson.( sexp_of_t, t_of_sexp, compare, hash )
   *)
   let ( to_string, from_file, to_file ) = Yojson.Safe.( to_string, from_file, to_file )
   include Json_derivers.Yojson
@@ -141,8 +142,12 @@ let add_file f absolute_path p =
   else { p with files = LibraryFiles.add_exn ~key:f ~data:absolute_path p.files }
 
 let add_hash f abs_f p =
-  let json = Json.from_file abs_f in
-  { p with hashes = LibraryFiles.add_exn ~key:f ~data:([abs_f], json) p.hashes }
+  try
+    let json = Json.from_file abs_f in
+    { p with hashes = LibraryFiles.add_exn ~key:f ~data:([abs_f], json) p.hashes }
+  with
+  | Yojson.Json_error msg ->
+    failwithf "JSON Error in file %s: %s" abs_f msg ()
 
 let union p1 p2 =
   let handle_file_conflict f f1 f2 = match FileUtil.cmp f1 f2 with

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -1,5 +1,6 @@
 (tests
  (names
+   install__distWithBrokenHash
    install__distWithNonHashUnderHashDir
    install__emptyDist
    install__missingDist

--- a/test/testcases/install__distWithBrokenHash.expected
+++ b/test/testcases/install__distWithBrokenHash.expected
@@ -2,7 +2,7 @@ Installing packages
 ------------------------------------------------------------
 Exception:
 (Failure
-   "JSON Error in file @@temp_dir@@/simple_dist/hash/broken.satysfi-hash: Line 1, bytes 1-4:\
+   "JSON Error in file @@temp_dir@@/simple_dist/hash/broken.satysfi-hash: Line 1, bytes <zero-or-one>-4:\
   \nInvalid token 'abc\
   \n'")
 ------------------------------------------------------------

--- a/test/testcases/install__distWithBrokenHash.expected
+++ b/test/testcases/install__distWithBrokenHash.expected
@@ -1,0 +1,10 @@
+Installing packages
+------------------------------------------------------------
+Exception:
+(Failure
+   "JSON Error in file @@temp_dir@@/simple_dist/hash/broken.satysfi-hash: Line 1, bytes 1-4:\
+  \nInvalid token 'abc\
+  \n'")
+------------------------------------------------------------
+@@dest_dir@@
+------------------------------------------------------------

--- a/test/testcases/install__distWithBrokenHash.ml
+++ b/test/testcases/install__distWithBrokenHash.ml
@@ -1,0 +1,22 @@
+module StdList = List
+
+open TestLib
+
+open Shexp_process
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let dist_dir = FilePath.concat temp_dir "simple_dist" in
+  PrepareDist.simple dist_dir
+  >> stdout_to (FilePath.concat dist_dir "hash/broken.satysfi-hash") (echo "abc")
+  >>| read_env ~dist_library_dir:dist_dir
+
+let () =
+  let system_font_prefix = None in
+  let libraries = None in
+  let verbose = true in
+  let copy = false in
+  let main env ~dest_dir ~temp_dir:_ =
+    let dest_dir = FilePath.concat dest_dir "dest" in
+    Satyrographos.CommandInstall.install dest_dir ~system_font_prefix ~libraries ~verbose ~copy ~env () in
+  eval (test_install env main)

--- a/test/testcases/install__distWithBrokenHash.ml
+++ b/test/testcases/install__distWithBrokenHash.ml
@@ -16,7 +16,13 @@ let () =
   let libraries = None in
   let verbose = true in
   let copy = false in
+  let replacements =
+    [ (* YoJson 1.7.0 *)
+      "bytes 0-4", "bytes <zero-or-one>-4";
+      (* YoJson 1.4.1+satysfi *)
+      "bytes 1-4", "bytes <zero-or-one>-4";
+    ] in
   let main env ~dest_dir ~temp_dir:_ =
     let dest_dir = FilePath.concat dest_dir "dest" in
     Satyrographos.CommandInstall.install dest_dir ~system_font_prefix ~libraries ~verbose ~copy ~env () in
-  eval (test_install env main)
+  eval (test_install ~replacements env main)

--- a/test/testcases/testLib.ml
+++ b/test/testcases/testLib.ml
@@ -46,7 +46,7 @@ let dump_dir dir : unit t =
 
 let stacktrace = false
 
-let test_install  setup f : unit t =
+let test_install ?(replacements=[]) setup f : unit t =
   let test dest_dir temp_dir =
     let opam_prefix = Unix.open_process_in "opam var prefix" |> input_line (* Assume a path does not contain line breaks*) in
     let replacements =
@@ -54,7 +54,7 @@ let test_install  setup f : unit t =
         dest_dir, "@@dest_dir@@";
         temp_dir, "@@temp_dir@@";
         Unix.getenv "HOME", "@@home_dir@@";
-      ] in
+      ] @ replacements in
     echo "Installing packages"
     >> echo_line
     >> setup ~dest_dir ~temp_dir

--- a/test/testcases/testLib.mli
+++ b/test/testcases/testLib.mli
@@ -20,7 +20,9 @@ val echo_line : unit t
 val dump_dir : string -> unit t
 (** [dump_dir dir] returns a Shexp process which dumps directory [dir]’s content to Stdout. *)
 
-val test_install : (dest_dir:string -> temp_dir:string -> 'a t) ->
+val test_install :
+  ?replacements:(string * string) list ->
+  (dest_dir:string -> temp_dir:string -> 'a t) ->
   ('a -> dest_dir:string -> temp_dir:string -> outf:Format.formatter -> unit) ->
   unit t
 


### PR DESCRIPTION
#110 also has a problem where JSON format error does not have filenames. This PR adds a filename to a JSON format error.