### PR TITLE
Add Satysfi_autogen library

### DIFF
--- a/bin/commandInstall.ml
+++ b/bin/commandInstall.ml
@@ -12,15 +12,27 @@ let install_command =
     ~readme
     [%map_open
       let system_font_prefix = flag "system-font-prefix" (optional string) ~doc:"FONT_NAME_PREFIX Installing system fonts with names with the given prefix"
+      and autogen_library_list = flag "autogen" (listed string) ~aliases:["a"] ~doc:"AUTOGEN Enable non-default autogen libraries (e.g., %libraries) (EXPERIMENTAL)"
       and library_list = flag "library" (listed string) ~aliases:["l"] ~doc:"LIBRARY Library"
       and target_dir = anon (maybe_with_default default_target_dir ("DIR" %: string))
       and verbose = flag "verbose" no_arg ~doc:"Make verbose"
       and copy = flag "copy" no_arg ~doc:"Copy files instead of making symlinks"
       in
       fun () ->
+        if not (List.is_empty autogen_library_list)
+        then Compatibility.optin ();
         let libraries = match library_list with
           | [] -> None
           | xs -> Some xs in
         let env = Setup.read_environment () in
-        Satyrographos_command.Install.install target_dir ~outf:Format.std_formatter ~system_font_prefix ~libraries ~verbose ~copy ~env ()
+        Satyrographos_command.Install.install
+          target_dir
+          ~outf:Format.std_formatter
+          ~system_font_prefix
+          ~autogen_libraries:autogen_library_list
+          ~libraries
+          ~verbose
+          ~copy
+          ~env
+          ()
     ]

--- a/src/autogen/dune
+++ b/src/autogen/dune
@@ -1,0 +1,5 @@
+(library
+ (name satyrographos_autogen)
+ (inline_tests)
+ (preprocess (staged_pps ppx_deriving.std ppx_jane))
+ (libraries core fileutils satyrographos shexp.process))

--- a/src/autogen/fonts.ml
+++ b/src/autogen/fonts.ml
@@ -1,0 +1,143 @@
+open Core
+open Satyrographos
+
+module StringMap = Map.Make(String)
+
+let name = "%fonts"
+
+type font_location =
+  | Single of string
+  | Collection of string * int
+
+type font_type =
+  | TextFont
+  | MathFont
+
+type font = {
+  name : string;
+  library_name : string;
+  location: font_location;
+  font_type : font_type;
+}
+
+let get_assoc ~outf names = function
+  | `Assoc a -> a
+  | j ->
+    Format.fprintf outf "Invalid value in hash %s: %s. Ignored.@."
+      ([%sexp_of: string list] names |> Sexp.to_string_hum)
+      (Library.Json.to_string j);
+    []
+
+let decode_font_location ~outf library_name font_name (j : Library.Json.t) = match j with
+  | `Variant ("Collection", Some (`Assoc opts)) ->
+    let src = List.find ~f:(fun (field, _) -> String.equal field "src") opts in
+    let src_dist = List.find ~f:(fun (field, _) -> String.equal field "src-dist") opts in
+    let index = List.find ~f:(fun (field, _) -> String.equal field "index") opts in
+    begin match Option.first_some src src_dist, index with
+    | Some (_, `String src), Some (_, `Int index) ->
+      Some (Collection (src, index))
+    | _, _ ->
+      Format.fprintf outf "WARNING: Font %s (%s) does not have a valid font location.@." font_name library_name;
+      None
+    end
+  | `Variant ("Single", Some (`Assoc opts)) ->
+    let src = List.find ~f:(fun (field, _) -> String.equal field "src") opts in
+    let src_dist = List.find ~f:(fun (field, _) -> String.equal field "src-dist") opts in
+    begin match Option.first_some src src_dist with
+    | Some (_, `String src) ->
+      Some (Single src)
+    | _ ->
+      Format.fprintf outf "WARNING: Font %s (%s) does not have a valid font location.@." font_name library_name;
+      None
+    end
+  | _ ->
+    Format.fprintf outf "WARNING: Font %s (%s) does not have a valid font location.@." font_name library_name;
+    None
+
+let font_list ~outf (lib: Library.t) =
+  let fonts =
+    Map.find lib.hashes "hash/fonts.satysfi-hash"
+    |> Option.value_map ~default:[] ~f:(fun (name, hash) -> get_assoc ~outf name hash) in
+  let math_fonts =
+    Map.find lib.hashes "hash/mathfonts.satysfi-hash"
+    |> Option.value_map ~default:[] ~f:(fun (name, hash) -> get_assoc ~outf name hash) in
+  let library_name = Option.value ~default:"(no name)" lib.name in
+  let font_list font_type pairs =
+    List.filter_map pairs ~f:(fun (font_name, location) ->
+      decode_font_location ~outf library_name font_name location
+      |> Option.map ~f:(fun location -> { name = font_name; library_name; location; font_type })
+    )
+  in
+  font_list TextFont fonts @ font_list MathFont math_fonts
+  (* TODO Implement math fonts *)
+
+let package_name = "satyrographos/experimental/fonts"
+let package_path = "packages/" ^ package_name ^ ".satyg"
+
+let font_type_name = "font"
+let font_location_type_name = "font-location"
+let font_name_field_name = "name"
+let library_name_field_name = "library-name"
+let font_location_field_name = "font-location"
+let font_type_field_name = "font-type"
+let font_list_field_name = "list"
+
+let font_type_decl =
+  [ `Type ((font_location_type_name, []),
+      `TSum [
+        "Single", Some (`TConst "string");
+        "Collection", Some (`TTuple [`TConst "string"; `TConst "int"])]);
+    `Type (("font-type", []), `TSum ["TextFont", None; "MathFont", None]);
+    `Type (
+      (font_type_name, []),
+      `TAlias (`TRecord [
+        font_name_field_name, `TConst "string";
+        library_name_field_name, `TConst "string";
+        font_location_field_name, `TConst font_location_type_name;
+        font_type_field_name, `TConst font_type_field_name;
+      ]));
+  ]
+
+let font_module_sig =
+  [ `Val (font_list_field_name,
+      `TApp ([`TConst font_type_name], `TConst "list"));
+  ]
+
+let font_location_to_value = function
+  | Single src ->
+    `Constructor ("Single", [`LiteralString src])
+  | Collection (src, index) ->
+    `Constructor ("Collection", [`LiteralString src; `Integer index])
+
+let font_type_to_value = function
+  | TextFont ->
+    `Constructor ("TextFont", [])
+  | MathFont ->
+    `Constructor ("MathFont", [])
+
+let font_to_value f =
+  `Record [
+    font_name_field_name, `LiteralString f.name;
+    library_name_field_name, `LiteralString f.library_name;
+    font_location_field_name, font_location_to_value f.location;
+    font_type_field_name, font_type_to_value f.font_type;
+  ]
+
+let generate ~outf library_map =
+  let records =
+    Map.to_alist library_map
+    |> List.map ~f:(fun (_, library) -> font_list ~outf library)
+    |> List.join
+    |> List.map ~f:font_to_value
+  in
+  let f = `Module ("Fonts", font_module_sig, [`Let (font_list_field_name, `Array records)]) in
+  let decls =
+    Satysfi.expr_experimental_message package_name
+    @ font_type_decl
+    @ [f] in
+  let cont = Satysfi.format_file_to_string [] decls in
+  Library.{ empty with
+    name = Some name;
+    version = Some "0.1";
+    files = LibraryFiles.singleton package_path (`Content cont);
+  }

--- a/src/autogen/libraries.ml
+++ b/src/autogen/libraries.ml
@@ -1,0 +1,50 @@
+open Core
+open Satyrographos
+
+module StringMap = Map.Make(String)
+
+let name = "%libraries"
+
+let library_type_name = "library"
+let library_name_field_name = "name"
+let library_version_field_name = "version"
+let library_list_field_name = "list"
+
+let font_type_decl =
+  [ `Type (
+      (library_type_name, []),
+      `TAlias (`TRecord [
+        library_name_field_name, `TConst "string";
+        library_version_field_name, `TConst "string";
+      ]));
+  ]
+
+let library_module_sig =
+  [ `Val (library_list_field_name,
+      `TApp ([`TConst library_type_name], `TConst "list"));
+  ]
+
+let library_list_entry (name, (lib: Library.t)) =
+  `Record
+    [ "name", `LiteralString name;
+      "version", `LiteralString (Option.value ~default:"" lib.version);
+    ]
+
+let package_name = "satyrographos/experimental/libraries"
+let package_path = "packages/" ^ package_name ^ ".satyg"
+
+let generate ~outf:_ library_map =
+  let records =
+    Map.to_alist library_map
+    |> List.map ~f:library_list_entry in
+  let f = `Module ("Libraries", library_module_sig, [`Let ("list", `Array records)]) in
+  let decls =
+    Satysfi.expr_experimental_message package_name
+    @ font_type_decl
+    @ [f] in
+  let cont = Satysfi.format_file_to_string [] decls in
+  Library.{ empty with
+    name = Some name;
+    version = Some "0.1";
+    files = LibraryFiles.singleton package_path (`Content cont);
+  }

--- a/src/command/dune
+++ b/src/command/dune
@@ -2,4 +2,4 @@
  (name satyrographos_command)
  (inline_tests)
  (preprocess (staged_pps ppx_deriving.std ppx_jane))
- (libraries core fileutils satyrographos shexp.process))
+ (libraries core fileutils satyrographos satyrographos_autogen shexp.process))

--- a/src/satysfi.ml
+++ b/src/satysfi.ml
@@ -1,0 +1,450 @@
+open Core
+
+let literal_string str =
+  (* TODO Refactor with an elegant algorithm *)
+  if String.contains str '\n'
+  then failwithf "literal_string still does not support strings with newlines, but got: %S" str ();
+  let consequent_backticks =
+    let result = ref 0 in
+    let current = ref 0 in
+    String.iter str ~f:(fun c ->
+      if Char.equal c '`'
+      then begin
+        current := !current + 1;
+        if !current > !result
+        then result := !current
+      end
+      else current := 0);
+    !result in
+  let leading_spaces =
+    String.equal " " (String.prefix str 1) in
+  let trailing_spaces =
+    String.equal " " (String.suffix str 1) in
+  let hash_if b = if b then "#" else "" in
+  let quotes = String.init (consequent_backticks + 1) ~f:(fun _ -> '`') in
+  if String.is_empty str
+  then "` `"
+  else hash_if leading_spaces ^ quotes ^ str ^ quotes ^ hash_if trailing_spaces
+
+let%expect_test {|literal_string: empty|} =
+   literal_string ""
+   |> print_string;
+   [%expect{| ` ` |} ]
+let%expect_test {|literal_string: non-special chars|} =
+   literal_string "abc"
+   |> print_string;
+   [%expect{| `abc` |} ]
+let%expect_test {|literal_string: a leading space|} =
+   literal_string " abc"
+   |> print_string;
+   [%expect{| #` abc` |} ]
+let%expect_test {|literal_string: a trailing space|} =
+   literal_string "abc "
+   |> print_string;
+   [%expect{| `abc `# |} ]
+let%expect_test {|literal_string: leading and trailing spaces|} =
+   literal_string "   abc  "
+   |> print_string;
+   [%expect{| #`   abc  `# |} ]
+let%expect_test {|literal_string: backticks|} =
+   literal_string "abc``de`"
+   |> print_string;
+   [%expect{| ```abc``de```` |} ]
+
+
+let literal_simple ppf = function
+  | `Integer i -> Format.fprintf ppf "%d" i
+  | `LiteralString ls ->
+    literal_string ls
+    |> Format.fprintf ppf "%s"
+
+let%expect_test "literal_simple: integer: positive" =
+  `Integer 1
+  |> literal_simple Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| 1 |} ]
+let%expect_test "literal_simple: integer: negative" =
+  `Integer (-1)
+  |> literal_simple Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| -1 |} ]
+
+let%expect_test "literal_simple: string: negative" =
+  `LiteralString "abc `def` ghi"
+  |> literal_simple Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| ``abc `def` ghi`` |} ]
+
+(* TODO reject problematic values *)
+let rec format_type ppf = function
+  | `TVar x ->
+    Format.fprintf ppf "'%s" x
+  | `TConst c ->
+    Format.fprintf ppf "%s" c
+  | `TApp (ts, f) ->
+    (* TODO Remove redundant parentheses *)
+    Format.fprintf ppf "@[<2>";
+    List.iter ts ~f:(fun t -> begin match t with
+      | `TVar _ | `TConst _ ->
+        format_type ppf t
+      | _ ->
+        Format.fprintf ppf "(@[";
+        format_type ppf t;
+        Format.fprintf ppf "@])"
+      end;
+      Format.fprintf ppf "@ "
+    );
+    begin match f with
+    | `TVar _ | `TConst _ ->
+      format_type ppf f
+    | _ ->
+      Format.fprintf ppf "(@[";
+      format_type ppf f;
+      Format.fprintf ppf "@])"
+    end;
+    Format.fprintf ppf "@]"
+  | `TTuple [] ->
+    Format.fprintf ppf "()"
+  | `TTuple (t :: ts) ->
+    Format.fprintf ppf "(@[";
+    format_type ppf t;
+    List.iter ts ~f:(fun t ->
+      Format.fprintf ppf "@ *@ ";
+      format_type ppf t
+    );
+    Format.fprintf ppf "@])"
+  | `TRecord fs ->
+    Format.fprintf ppf "(| @[";
+    List.iter fs ~f:(fun (f, t) ->
+      Format.fprintf ppf "%s :@ @[" f;
+      format_type ppf t;
+      Format.fprintf ppf ";@]@ "
+    );
+    Format.fprintf ppf "@]|)"
+
+
+let%expect_test "format_type: var" =
+  `TVar "x"
+  |> format_type Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| 'x |}]
+let%expect_test "format_type: const" =
+  `TConst "int"
+  |> format_type Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| int |}]
+let%expect_test "format_type: app" =
+  `TApp ([`TConst "int"], `TConst "list")
+  |> format_type Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| int list |}]
+let%expect_test "format_type: app" =
+  `TApp ([`TConst "int"; `TConst "int"], `TConst "m")
+  |> format_type Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| int int m |}]
+let%expect_test "format_type: unit" =
+  `TTuple []
+  |> format_type Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| () |}]
+let%expect_test "format_type: tuple" =
+  `TTuple [`TVar "x"; `TConst "int"]
+  |> format_type Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| ('x * int) |}]
+let%expect_test "format_type: record" =
+  `TRecord ["a", `TVar "x"; "b", `TConst "int"]
+  |> format_type Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| (| a : 'x; b : int; |) |}]
+
+let format_type_decl_head ppf = function
+  | n, vs ->
+    Format.fprintf ppf "type ";
+    List.iter vs ~f:(fun v ->
+      Format.fprintf ppf "'%s@ " v
+    );
+    Format.fprintf ppf "%s" n
+
+let%expect_test "format_type_decl_head: no variables" =
+  ("t", [])
+  |> format_type_decl_head Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| type t |}]
+let%expect_test "format_type_decl_head: no variables" =
+  ("t", ["a"])
+  |> format_type_decl_head Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{|
+    type 'a
+    t |}]
+
+let format_type_decl_body ppf = function
+  | `TAlias t ->
+    Format.fprintf ppf " =@ @[<2>";
+    format_type ppf t;
+    Format.fprintf ppf "@]"
+  | `TSum cts ->
+    Format.fprintf ppf " =@ @[<2>";
+    List.iter cts ~f:(function
+      | c, None ->
+        Format.fprintf ppf "| %s@." c
+      | c, Some t ->
+        Format.fprintf ppf "@[<2>| %s of@ " c;
+        format_type ppf t;
+        Format.fprintf ppf "@]@."
+    );
+    Format.fprintf ppf "@]"
+
+let%expect_test "format_type_decl_body: alias" =
+  `TAlias (`TTuple [`TConst "int"; `TVar "x"])
+  |> format_type_decl_body Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{|
+     =
+    (int * 'x) |}]
+let%expect_test "format_type_decl_body: sum" =
+  `TSum (["A", Some (`TConst "int"); "B", Some (`TVar "x"); "C", None])
+  |> format_type_decl_body Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{|
+     =
+    | A of int
+    | B of 'x
+    | C |}]
+
+let format_type_decl ppf (h, b) =
+  format_type_decl_head ppf h;
+  format_type_decl_body ppf b
+
+let%expect_test "format_type_decl_body: sum" =
+  (("t", ["x"]), `TSum (["A", Some (`TConst "int"); "B", None]))
+  |> format_type_decl Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{|
+    type 'x t =
+    | A of int
+    | B |}]
+
+let rec format_expr ppf = function
+  | (`Integer _ | `LiteralString _) as ls -> literal_simple ppf ls
+  | `Var x ->
+    Format.fprintf ppf "%s" x
+  | `Apply (f, x) ->
+    Format.fprintf ppf "(@[<2>";
+    format_expr ppf f;
+    Format.fprintf ppf ") (";
+    format_expr ppf x;
+    Format.fprintf ppf "@])"
+  | `Array xs ->
+    Format.fprintf ppf "[ @[";
+    List.iter xs ~f:(fun l ->
+      format_expr ppf l;
+      Format.fprintf ppf ";@ ";
+    );
+    Format.fprintf ppf "@]]"
+  | `Record fs ->
+    Format.fprintf ppf "(| @[";
+    List.iter fs ~f:(fun (name, v) ->
+      Format.fprintf ppf "%s = @[" name;
+      format_expr ppf v;
+      Format.fprintf ppf "@];@ ";
+    );
+    Format.fprintf ppf "@]|)"
+  | `Tuple [] ->
+    Format.fprintf ppf "()"
+  | `Tuple (v :: vs) ->
+    Format.fprintf ppf "(@[";
+    format_expr ppf v;
+    List.iter vs ~f:(fun (v) ->
+      Format.fprintf ppf ",@ ";
+      format_expr ppf v;
+    );
+    Format.fprintf ppf "@])"
+  | `Constructor (c, []) ->
+    Format.fprintf ppf "%s" c
+  | `Constructor (c, f :: fs) ->
+    Format.fprintf ppf "%s(@[" c;
+    format_expr ppf f;
+    List.iter fs ~f:(fun (v) ->
+      Format.fprintf ppf ",@ ";
+      format_expr ppf v;
+    );
+    Format.fprintf ppf "@])"
+and format_decl ppf = function
+  | `Let (v, e) ->
+    Format.fprintf ppf "let %s =@.@[<2>" v;
+    format_expr ppf e;
+    Format.fprintf ppf "@]"
+  | `Module (m, ss, ds) ->
+    Format.fprintf ppf "module %s : sig@[<2>@." m;
+    List.iter ss ~f:(fun s ->
+      format_sig_decl ppf s;
+      Format.fprintf ppf "@."
+    );
+    Format.fprintf ppf "@]end = struct@[<2>@.";
+    List.iter ds ~f:(fun d ->
+      format_decl ppf d;
+      Format.fprintf ppf "@."
+    );
+    Format.fprintf ppf "@.end@]"
+  | `Type td ->
+    format_type_decl ppf td
+and format_sig_decl ppf = function
+  | `Val (v, t) ->
+    Format.fprintf ppf "val %s :@ @[<2>" v;
+    format_type ppf t;
+    Format.fprintf ppf "@]"
+  | `Type th ->
+    format_type_decl_head ppf th
+
+let%expect_test "format_expr: integer" =
+  `Integer 1
+  |> literal_simple Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| 1 |} ]
+let%expect_test "format_expr: integer list" =
+  `Array [`Integer 1; `Integer 2; `Integer 3]
+  |> format_expr Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| [ 1; 2; 3; ] |} ]
+
+let%expect_test "format_expr: literal string list" =
+  `Array (List.init 10 ~f:(fun _ -> `LiteralString "abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg"))
+  |> format_expr Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{|
+    [ `abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg`;
+      `abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg`;
+      `abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg`;
+      `abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg`;
+      `abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg`;
+      `abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg`;
+      `abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg`;
+      `abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg`;
+      `abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg`;
+      `abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg abcdefg`; ] |} ]
+
+let%expect_test "format_expr: var" =
+  `Var "x"
+  |> format_expr Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| x |} ]
+
+let%expect_test "format_expr: app" =
+  (* TODO Remove redundant parentheses *)
+  `Apply (`Var "f", `Var "x")
+  |> format_expr Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| (f) (x) |} ]
+
+let%expect_test "format_expr: record" =
+  `Record ["int", `Integer 1; "str", `LiteralString "abcdef"; "arr", `Array [`Integer 1; `Integer 3]]
+  |> format_expr Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| (| int = 1; str = `abcdef`; arr = [ 1; 3; ]; |) |} ]
+
+let%expect_test "format_expr: tuple: 0" =
+  `Tuple []
+  |> format_expr Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| () |} ]
+
+let%expect_test "format_expr: tuple: 1" =
+  `Tuple [`Integer 1]
+  |> format_expr Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| (1) |} ]
+
+let%expect_test "format_expr: tuple: 2" =
+  `Tuple [`Integer 1; `LiteralString "abc"]
+  |> format_expr Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| (1, `abc`) |} ]
+
+let%expect_test "format_expr: tuple: 3" =
+  `Tuple [`Integer 1; `LiteralString "abc"; `Array [`Tuple [`Array []; `LiteralString "d"]]]
+  |> format_expr Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| (1, `abc`, [ ([ ], `d`); ]) |} ]
+
+let%expect_test "format_expr: constructor: 0" =
+  `Constructor ("A4Paper", [])
+  |> format_expr Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| A4Paper |} ]
+
+let%expect_test "format_expr: constructor: 1" =
+  `Constructor ("Some", [`Integer 1])
+  |> format_expr Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{| Some(1) |} ]
+
+let%expect_test "format_decl: let" =
+  `Let ("x", `Integer 1)
+  |> format_decl Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{|
+    let x =
+    1 |} ]
+
+let%expect_test "format_decl: module" =
+  `Module ("List", [`Val ("x", `TConst "int")], [`Let ("x", `Integer 1)])
+  |> format_decl Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{|
+    module List : sig
+    val x :
+    int
+    end = struct
+    let x =
+    1
+
+    end |}]
+
+let%expect_test "format_decl: type decl" =
+  `Type (("list", ["a"]), `TSum ["Nil", None; "Cons", Some (`TTuple [`TVar "a"])])
+  |> format_decl Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{|
+    type 'a list =
+    | Nil
+    | Cons of ('a) |}]
+
+let format_directive ppf = function
+  | `Import x ->
+    Format.fprintf ppf "@import: %s@." x
+
+let format_file ppf dirs decls =
+  List.iter dirs ~f:(fun dir ->
+    format_directive ppf dir;
+    Format.fprintf ppf "@."
+  );
+  List.iter decls ~f:(fun decl ->
+    format_decl ppf decl;
+    Format.fprintf ppf "@."
+  )
+
+let format_file_to_string dirs decls =
+  let buf = Buffer.create 100 in
+  let ppf = Format.formatter_of_buffer buf in
+  format_file ppf dirs decls;
+  Buffer.contents buf
+
+let expr_show_message str =
+  `Let ("_", `Apply (`Var "display-message", `LiteralString str))
+
+let expr_experimental_message p =
+  [ expr_show_message (" [Warning] Satyrographos: Package " ^ p ^ " is an experimental autogen package.");
+    expr_show_message (" [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.");
+    expr_show_message (" [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.");
+  ]
+
+let%expect_test "expr_show_message" =
+  expr_show_message "p"
+  |> format_decl Format.std_formatter;
+  Format.pp_print_newline Format.std_formatter ();
+  [%expect{|
+    let _ =
+    (display-message) (`p`) |}]

--- a/test/testcases/command_install_l__autogen.expected
+++ b/test/testcases/command_install_l__autogen.expected
@@ -1,0 +1,238 @@
+Installing packages
+------------------------------------------------------------
+Reading runtime dist: @@temp_dir@@/empty_dist
+Read user libraries: ()
+Reading opam libraries: (base class-greek fonts-theano grcnum)
+Not gathering system fonts
+Generating autogen libraries
+Generating autogen library %libraries
+Installing libraries: (%libraries base dist fonts-theano grcnum)
+Removing destination @@dest_dir@@/dest
+Loaded libraries
+(((name (%libraries)) (version (0.1))
+  (files
+   ((packages/satyrographos/experimental/libraries.satyg
+     (Content
+       "let _ =\
+      \n(display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)\
+      \nlet _ =\
+      \n(display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
+      \nlet _ =\
+      \n(display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
+      \ntype library =\
+      \n(| name : string; version : string; |)\
+      \nmodule Libraries : sig\
+      \nval list :\
+      \nlibrary list\
+      \nend = struct\
+      \nlet list =\
+      \n[ (| name = `base`; version = `1.1.1`; |);\
+      \n  (| name = `dist`; version = ` `; |);\
+      \n  (| name = `fonts-theano`; version = `2.0`; |);\
+      \n  (| name = `grcnum`; version = `0.2`; |); ]\
+      \n\
+      \nend\
+      \n")))))
+ ((name (base)) (version (1.1.1))
+  (files
+   ((packages/base/void.satyh
+     (Filename
+      @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
+ ((name ()) (version ()))
+ ((name (fonts-theano)) (version (2.0))
+  (hashes
+   ((hash/fonts.satysfi-hash
+     ((@@temp_dir@@/opam_reg/fonts-theano/hash/fonts.satysfi-hash)
+      (Assoc
+       ((fonts-theano:TheanoDidot
+         (Variant
+          (Single
+           ((Assoc
+             ((src-dist (String fonts-theano/TheanoDidot-Regular.otf))))))))
+        (fonts-theano:TheanoModern
+         (Variant
+          (Single
+           ((Assoc
+             ((src-dist (String fonts-theano/TheanoModern-Regular.otf))))))))
+        (fonts-theano:TheanoOldStyle
+         (Variant
+          (Single
+           ((Assoc
+             ((src-dist (String fonts-theano/TheanoOldStyle-Regular.otf))))))))))))))
+  (files
+   ((fonts/fonts-theano/TheanoDidot-Regular.otf
+     (Filename
+      @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoDidot-Regular.otf))
+    (fonts/fonts-theano/TheanoModern-Regular.otf
+     (Filename
+      @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoModern-Regular.otf))
+    (fonts/fonts-theano/TheanoOldStyle-Regular.otf
+     (Filename
+      @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoOldStyle-Regular.otf))))
+  (compatibility
+   ((rename_fonts
+     (((new_name fonts-theano:TheanoDidot) (old_name TheanoDidot))
+      ((new_name fonts-theano:TheanoModern) (old_name TheanoModern))
+      ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle)))))))
+ ((name (grcnum)) (version (0.2))
+  (files
+   ((packages/grcnum/grcnum.satyh
+     (Filename
+      @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))))
+  (compatibility
+   ((rename_packages
+     (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
+  (dependencies (fonts-theano))))
+Installing ((name (%libraries)) (version (0.1))
+ (hashes
+  ((hash/fonts.satysfi-hash
+    ((@@temp_dir@@/opam_reg/fonts-theano/hash/fonts.satysfi-hash)
+     (Assoc
+      ((fonts-theano:TheanoDidot
+        (Variant
+         (Single
+          ((Assoc ((src-dist (String fonts-theano/TheanoDidot-Regular.otf))))))))
+       (fonts-theano:TheanoModern
+        (Variant
+         (Single
+          ((Assoc
+            ((src-dist (String fonts-theano/TheanoModern-Regular.otf))))))))
+       (fonts-theano:TheanoOldStyle
+        (Variant
+         (Single
+          ((Assoc
+            ((src-dist (String fonts-theano/TheanoOldStyle-Regular.otf))))))))))))))
+ (files
+  ((fonts/fonts-theano/TheanoDidot-Regular.otf
+    (Filename
+     @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoDidot-Regular.otf))
+   (fonts/fonts-theano/TheanoModern-Regular.otf
+    (Filename
+     @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoModern-Regular.otf))
+   (fonts/fonts-theano/TheanoOldStyle-Regular.otf
+    (Filename
+     @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoOldStyle-Regular.otf))
+   (packages/base/void.satyh
+    (Filename
+     @@temp_dir@@/opam_reg/base/packages/base/void.satyh))
+   (packages/grcnum/grcnum.satyh
+    (Filename
+     @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))
+   (packages/satyrographos/experimental/libraries.satyg
+    (Content
+      "let _ =\
+     \n(display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)\
+     \nlet _ =\
+     \n(display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
+     \nlet _ =\
+     \n(display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
+     \ntype library =\
+     \n(| name : string; version : string; |)\
+     \nmodule Libraries : sig\
+     \nval list :\
+     \nlibrary list\
+     \nend = struct\
+     \nlet list =\
+     \n[ (| name = `base`; version = `1.1.1`; |);\
+     \n  (| name = `dist`; version = ` `; |);\
+     \n  (| name = `fonts-theano`; version = `2.0`; |);\
+     \n  (| name = `grcnum`; version = `0.2`; |); ]\
+     \n\
+     \nend\
+     \n"))))
+ (compatibility
+  ((rename_packages
+    (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))
+   (rename_fonts
+    (((new_name fonts-theano:TheanoDidot) (old_name TheanoDidot))
+     ((new_name fonts-theano:TheanoModern) (old_name TheanoModern))
+     ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle))))))
+ (dependencies (fonts-theano)))
+Installation completed!
+
+[1;33mCompatibility notice[0m for library fonts-theano:
+
+  Fonts have been renamed.
+  
+    TheanoDidot -> fonts-theano:TheanoDidot
+    TheanoModern -> fonts-theano:TheanoModern
+    TheanoOldStyle -> fonts-theano:TheanoOldStyle
+
+
+[1;33mCompatibility notice[0m for library grcnum:
+                                                      Packages have been renamed.
+                                                      
+                                                        grcnum.satyh -> grcnum/grcnum.satyh
+
+------------------------------------------------------------
+@@dest_dir@@
+@@dest_dir@@/dest
+@@dest_dir@@/dest/fonts
+@@dest_dir@@/dest/fonts/fonts-theano
+@@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
+@@dest_dir@@/dest/fonts/fonts-theano/TheanoModern-Regular.otf
+@@dest_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+@@dest_dir@@/dest/hash
+@@dest_dir@@/dest/hash/fonts.satysfi-hash
+@@dest_dir@@/dest/metadata
+@@dest_dir@@/dest/packages
+@@dest_dir@@/dest/packages/base
+@@dest_dir@@/dest/packages/base/void.satyh
+@@dest_dir@@/dest/packages/grcnum
+@@dest_dir@@/dest/packages/grcnum/grcnum.satyh
+@@dest_dir@@/dest/packages/satyrographos
+@@dest_dir@@/dest/packages/satyrographos/experimental
+@@dest_dir@@/dest/packages/satyrographos/experimental/libraries.satyg
+@@dest_dir@@/dest/.satyrographos
+------------------------------------------------------------
+diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
+0a1
+> @@TheanoDidot-Regular.otf@@
+diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoModern-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoModern-Regular.otf
+0a1
+> @@TheanoModern-Regular.otf@@
+diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+0a1
+> @@TheanoOldStyle-Regular.otf@@
+diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
+0a1
+> {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
+\ No newline at end of file
+diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
+0a1,9
+> ((version 1) (libraryName %libraries) (libraryVersion 0.1)
+>  (compatibility
+>   ((rename_packages
+>     (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))
+>    (rename_fonts
+>     (((new_name fonts-theano:TheanoDidot) (old_name TheanoDidot))
+>      ((new_name fonts-theano:TheanoModern) (old_name TheanoModern))
+>      ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle))))))
+>  (dependencies ((fonts-theano ()))))
+diff -Nr @@empty_dir@@/dest/packages/base/void.satyh @@dest_dir@@/dest/packages/base/void.satyh
+0a1
+> @@void.satyh@@
+diff -Nr @@empty_dir@@/dest/packages/grcnum/grcnum.satyh @@dest_dir@@/dest/packages/grcnum/grcnum.satyh
+0a1
+> @@grcnum.satyh@@
+diff -Nr @@empty_dir@@/dest/packages/satyrographos/experimental/libraries.satyg @@dest_dir@@/dest/packages/satyrographos/experimental/libraries.satyg
+0a1,19
+> let _ =
+> (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)
+> let _ =
+> (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
+> let _ =
+> (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
+> type library =
+> (| name : string; version : string; |)
+> module Libraries : sig
+> val list :
+> library list
+> end = struct
+> let list =
+> [ (| name = `base`; version = `1.1.1`; |);
+>   (| name = `dist`; version = ` `; |);
+>   (| name = `fonts-theano`; version = `2.0`; |);
+>   (| name = `grcnum`; version = `0.2`; |); ]
+> 
+> end

--- a/test/testcases/command_install_l__autogen.ml
+++ b/test/testcases/command_install_l__autogen.ml
@@ -1,0 +1,27 @@
+module StdList = List
+
+open TestLib
+
+open Shexp_process
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let empty_dist = FilePath.concat temp_dir "empty_dist" in
+  let opam_reg = FilePath.concat temp_dir "opam_reg" in
+  PrepareDist.empty empty_dist
+  >> PrepareOpamReg.(prepare opam_reg theanoFiles)
+  >> PrepareOpamReg.(prepare opam_reg grcnumFiles)
+  >> PrepareOpamReg.(prepare opam_reg classGreekFiles)
+  >> PrepareOpamReg.(prepare opam_reg baseFiles)
+  >>| read_env ~opam_reg ~dist_library_dir:empty_dist
+
+let () =
+  let system_font_prefix = None in
+  let autogen_libraries = ["%libraries"] in
+  let libraries = Some ["grcnum"; "base"] in
+  let verbose = true in
+  let copy = false in
+  let main env ~dest_dir ~temp_dir:_ =
+    let dest_dir = FilePath.concat dest_dir "dest" in
+    Satyrographos_command.Install.install dest_dir ~system_font_prefix ~autogen_libraries ~libraries ~verbose ~copy ~env () in
+  eval (test_install env main)

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -9,6 +9,7 @@
    command_install__unmanagedDirAlreadyExists
    command_install__thirdParties
    command_install__thirdParties_brokenDependency
+   command_install_l__autogen
    command_install_l__dependent
    command_install_l__simple
    command_install_l__independentTwo


### PR DESCRIPTION
Satysfi_autogen library has two autogen libraries:

- `satyrographos/experimental/fonts`: list of installed fonts
- `satyrographos/experimental/libraries`: list of installed libraries

Those libraries will be used with `-a` option of `install` subcommand like:

    satyrographos install -a '%libraries' -a '%fonts'

This PR makes it possible to write a font specimen document like https://gist.github.com/na4zagin3/4c9d32cb9659e128cdd35e3f650539bc

This is an initial step of https://github.com/na4zagin3/satyrographos/issues/112