### PR TITLE
Set proper values to autogen libraries’ information fields

### DIFF
--- a/src/command/install.ml
+++ b/src/command/install.ml
@@ -49,6 +49,9 @@ let get_libraries ~outf ~maybe_reg ~(env: Environment.t) ~libraries =
     | `Duplicate ->
       Format.fprintf outf "Overriding dist with user installed one\n";
       all_libraries in
+  (* A dirty hack to set library metadata of dist library *)
+  (* TODO (gh-123) Add library version too *)
+  let all_libraries = Map.change all_libraries "dist" ~f:(Option.map ~f:(fun l -> {l with Library.name = Some "dist"})) in
   let required_library_names =
     "dist" :: Option.value ~default:(Map.keys all_libraries) libraries in
   let library_dependency_map =

--- a/src/systemFontLibrary.ml
+++ b/src/systemFontLibrary.ml
@@ -2,6 +2,8 @@ open Core
 
 module StringSet = Set.Make(String)
 
+let name = "%fonts-system"
+
 let blacklist = StringSet.of_list [
   (* Each SanFranciso font has several weights with the same postscriptname *)
   "/System/Library/Fonts/SFNSDisplay.ttf";
@@ -115,6 +117,8 @@ let fonts_to_library ~outf prefix fonts =
     ) in
   let hash_path_fonts = "#Automatically generated from the system fonts#" in
   Library.{ empty with
+    name = Some name;
+    version = Some "0.1";
     hashes = LibraryFiles.singleton hash_filename_fonts ([hash_path_fonts], `Assoc hash);
     files = LibraryFiles.map map ~f:(fun fn -> `Filename fn)
   }

--- a/test/testcases/command_install__distWithNonHashUnderHashDir.expected
+++ b/test/testcases/command_install__distWithNonHashUnderHashDir.expected
@@ -8,7 +8,7 @@ Not gathering system fonts
 Installing libraries: (dist)
 Removing destination @@dest_dir@@/dest
 Loaded libraries
-(((name ()) (version ())
+(((name (dist)) (version ())
   (hashes
    ((hash/fonts.satysfi-hash
      ((@@temp_dir@@/simple_dist/hash/fonts.satysfi-hash)
@@ -26,7 +26,7 @@ Loaded libraries
     (unidata/UnicodeData.txt
      (Filename
       @@temp_dir@@/simple_dist/unidata/UnicodeData.txt))))))
-Installing ((name ()) (version ())
+Installing ((name (dist)) (version ())
  (hashes
   ((hash/fonts.satysfi-hash
     ((@@temp_dir@@/simple_dist/hash/fonts.satysfi-hash)
@@ -67,7 +67,7 @@ diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts
 \ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2
-> ((version 1) (libraryName "") (libraryVersion "") (compatibility ())
+> ((version 1) (libraryName dist) (libraryVersion "") (compatibility ())
 >  (dependencies ()))
 diff -Nr @@empty_dir@@/dest/packages/List.satyg @@dest_dir@@/dest/packages/List.satyg
 0a1,2

--- a/test/testcases/command_install__emptyDist.expected
+++ b/test/testcases/command_install__emptyDist.expected
@@ -7,7 +7,7 @@ Not gathering system fonts
 Installing libraries: (dist)
 Removing destination @@dest_dir@@/dest
 Loaded libraries
-(((name ()) (version ())))Installing ((name ()) (version ()))
+(((name (dist)) (version ())))Installing ((name (dist)) (version ()))
 Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
@@ -17,5 +17,5 @@ Installation completed!
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2
-> ((version 1) (libraryName "") (libraryVersion "") (compatibility ())
+> ((version 1) (libraryName dist) (libraryVersion "") (compatibility ())
 >  (dependencies ()))

--- a/test/testcases/command_install__onlyDist.expected
+++ b/test/testcases/command_install__onlyDist.expected
@@ -7,7 +7,7 @@ Not gathering system fonts
 Installing libraries: (dist)
 Removing destination @@dest_dir@@/dest
 Loaded libraries
-(((name ()) (version ())
+(((name (dist)) (version ())
   (hashes
    ((hash/fonts.satysfi-hash
      ((@@temp_dir@@/simple_dist/hash/fonts.satysfi-hash)
@@ -25,7 +25,7 @@ Loaded libraries
     (unidata/UnicodeData.txt
      (Filename
       @@temp_dir@@/simple_dist/unidata/UnicodeData.txt))))))
-Installing ((name ()) (version ())
+Installing ((name (dist)) (version ())
  (hashes
   ((hash/fonts.satysfi-hash
     ((@@temp_dir@@/simple_dist/hash/fonts.satysfi-hash)
@@ -66,7 +66,7 @@ diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts
 \ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2
-> ((version 1) (libraryName "") (libraryVersion "") (compatibility ())
+> ((version 1) (libraryName dist) (libraryVersion "") (compatibility ())
 >  (dependencies ()))
 diff -Nr @@empty_dir@@/dest/packages/List.satyg @@dest_dir@@/dest/packages/List.satyg
 0a1,2

--- a/test/testcases/command_install__thirdParties.expected
+++ b/test/testcases/command_install__thirdParties.expected
@@ -7,7 +7,7 @@ Not gathering system fonts
 Installing libraries: (dist fonts-theano grcnum)
 Removing destination @@dest_dir@@/dest
 Loaded libraries
-(((name ()) (version ()))
+(((name (dist)) (version ()))
  ((name (fonts-theano)) (version (2.0))
   (hashes
    ((hash/fonts.satysfi-hash
@@ -52,7 +52,7 @@ Loaded libraries
    ((rename_packages
      (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
   (dependencies (fonts-theano))))
-Installing ((name (fonts-theano)) (version (2.0))
+Installing ((name (dist)) (version (2.0))
  (hashes
   ((hash/fonts.satysfi-hash
     ((@@temp_dir@@/opam_reg/fonts-theano/hash/fonts.satysfi-hash)
@@ -139,7 +139,7 @@ diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts
 \ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
-> ((version 1) (libraryName fonts-theano) (libraryVersion 2.0)
+> ((version 1) (libraryName dist) (libraryVersion 2.0)
 >  (compatibility
 >   ((rename_packages
 >     (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))

--- a/test/testcases/command_install__twoDists.expected
+++ b/test/testcases/command_install__twoDists.expected
@@ -16,5 +16,5 @@ Installation completed!
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2
-> ((version 1) (libraryName "") (libraryVersion "") (compatibility ())
+> ((version 1) (libraryName dist) (libraryVersion "") (compatibility ())
 >  (dependencies ()))

--- a/test/testcases/command_install_l__autogen.expected
+++ b/test/testcases/command_install_l__autogen.expected
@@ -38,7 +38,7 @@ Loaded libraries
    ((packages/base/void.satyh
      (Filename
       @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
- ((name ()) (version ()))
+ ((name (dist)) (version ()))
  ((name (fonts-theano)) (version (2.0))
   (hashes
    ((hash/fonts.satysfi-hash

--- a/test/testcases/command_install_l__dependent.expected
+++ b/test/testcases/command_install_l__dependent.expected
@@ -7,7 +7,7 @@ Not gathering system fonts
 Installing libraries: (dist fonts-theano)
 Removing destination @@dest_dir@@/dest
 Loaded libraries
-(((name ()) (version ()))
+(((name (dist)) (version ()))
  ((name (fonts-theano)) (version (2.0))
   (hashes
    ((hash/fonts.satysfi-hash
@@ -43,7 +43,7 @@ Loaded libraries
      (((new_name fonts-theano:TheanoDidot) (old_name TheanoDidot))
       ((new_name fonts-theano:TheanoModern) (old_name TheanoModern))
       ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle))))))))
-Installing ((name (fonts-theano)) (version (2.0))
+Installing ((name (dist)) (version (2.0))
  (hashes
   ((hash/fonts.satysfi-hash
     ((@@temp_dir@@/opam_reg/fonts-theano/hash/fonts.satysfi-hash)
@@ -115,7 +115,7 @@ diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts
 \ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,7
-> ((version 1) (libraryName fonts-theano) (libraryVersion 2.0)
+> ((version 1) (libraryName dist) (libraryVersion 2.0)
 >  (compatibility
 >   ((rename_fonts
 >     (((new_name fonts-theano:TheanoDidot) (old_name TheanoDidot))

--- a/test/testcases/command_install_l__independentTwo.expected
+++ b/test/testcases/command_install_l__independentTwo.expected
@@ -12,7 +12,7 @@ Loaded libraries
    ((packages/base/void.satyh
      (Filename
       @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
- ((name ()) (version ()))
+ ((name (dist)) (version ()))
  ((name (fonts-theano)) (version (2.0))
   (hashes
    ((hash/fonts.satysfi-hash

--- a/test/testcases/command_install_l__simple.expected
+++ b/test/testcases/command_install_l__simple.expected
@@ -12,7 +12,7 @@ Loaded libraries
    ((packages/base/void.satyh
      (Filename
       @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
- ((name ()) (version ())))
+ ((name (dist)) (version ())))
 Installing ((name (base)) (version (1.1.1))
  (files
   ((packages/base/void.satyh

--- a/test/testcases/command_install_l__transitive.expected
+++ b/test/testcases/command_install_l__transitive.expected
@@ -12,7 +12,7 @@ Loaded libraries
    ((packages/base/void.satyh
      (Filename
       @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
- ((name ()) (version ()))
+ ((name (dist)) (version ()))
  ((name (fonts-theano)) (version (2.0))
   (hashes
    ((hash/fonts.satysfi-hash


### PR DESCRIPTION
As #122 expose names and versions of autogen libraries, it’d better to assign proper values to them.

Version field of `dist` library will be addressed with #123.

Related to #112