### PR TITLE
Fix Travis CI setting and add cache setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: c
-sudo: required
 install: test -e .travis.opam.sh || wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
@@ -7,3 +6,8 @@ env:
   - OCAML_VERSION=4.10
 os:
   - linux
+dist: xenial
+cache:
+  directories:
+    - $HOME/ocaml
+    - $HOME/.opam


### PR DESCRIPTION
- Remove `sudo: required` to suppress a warning
    - It's now deprecated: https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments
- Add Linux distribution: `xenial` (Ubuntu 16.04)
    - Would it be better `bionic` (Ubuntu 18.04) than `xenial`?
    - For now I deal with to remove the unspecified warning at first
- Add cache setting, which is the same as https://github.com/gfngfn/SATySFi/pull/227