### PR TITLE
Add GNU style long options and deprecate old ones

### DIFF
--- a/bin/commandInstall.ml
+++ b/bin/commandInstall.ml
@@ -3,6 +3,7 @@ open Core
 
 let install_command =
   let open Command.Let_syntax in
+  let open RenameOption in
   let default_target_dir = Setup.default_target_dir in
   let readme () =
     sprintf "Install SATySFi Libraries to a directory environmental variable SATYSFI_RUNTIME has or %s. Currently it accepts an argument DIR, but this is experimental." default_target_dir
@@ -11,14 +12,63 @@ let install_command =
     ~summary:"Install SATySFi runtime"
     ~readme
     [%map_open
-      let system_font_prefix = flag "system-font-prefix" (optional string) ~doc:"FONT_NAME_PREFIX Installing system fonts with names with the given prefix"
-      and autogen_library_list = flag "autogen" (listed string) ~aliases:["a"] ~doc:"AUTOGEN Enable non-default autogen libraries (e.g., %libraries) (EXPERIMENTAL)"
-      and library_list = flag "library" (listed string) ~aliases:["l"] ~doc:"LIBRARY Library"
-      and target_dir = anon (maybe_with_default default_target_dir ("DIR" %: string))
-      and verbose = flag "verbose" no_arg ~doc:"Make verbose"
-      and copy = flag "copy" no_arg ~doc:"Copy files instead of making symlinks"
+      let use_system_font = flag "--use-system-fonts" no_arg ~doc:"Installing system fonts with names with prefix “system:”"
+      and system_font_prefix = flag "system-font-prefix" (optional string) ~doc:"FONT_NAME_PREFIX Deprecated: Installing system fonts with names with the given prefix.  Use --use-system-fonts instead"
+      and autogen_library_list = long_flag_listed "autogen" string ~aliases:["a"] ~doc_arg:"AUTOGEN" ~doc:"Enable non-default autogen libraries (e.g., %libraries) (EXPERIMENTAL)"
+      and library_list = long_flag_listed "library" string ~aliases:["l"] ~doc_arg:"LIBRARY" ~doc:"Library"
+      and target_dir_old = anon (maybe ("DIR" %: string))
+      and target_dir = long_flag_optional "output" string ~doc_arg:"SATYSFI_ROOT" ~doc:("Install files to (default: " ^ default_target_dir ^ ")")
+      and verbose = long_flag_bool "verbose" no_arg ~doc:"Make verbose"
+      and copy = long_flag_bool "copy" no_arg ~doc:"Copy files instead of making symlinks"
+      and _ = standard_help
       in
       fun () ->
+        let system_font_prefix =
+          let default_system_font_prefix = Satyrographos.SystemFontLibrary.system_font_prefix in
+          let deprecation_warning () =
+            print_err_warn
+              "Option “-system-font-prefix” has been deprecated. Use “--use-system-fonts” instead."
+          in
+          match system_font_prefix, use_system_font with
+            | Some value, _ when String.equal value default_system_font_prefix ->
+              deprecation_warning ();
+              Some value
+            | Some value, false ->
+              deprecation_warning ();
+              Printf.sprintf
+                "System font prefix will be fixed to “%s” in the near future."
+                default_system_font_prefix
+              |> print_err_warn;
+              Some value
+            | Some _, true ->
+              deprecation_warning ();
+              Printf.sprintf
+                "System font prefix gets “%s”."
+                default_system_font_prefix
+              |> print_err_warn;
+              Some default_system_font_prefix
+            | None, value -> Option.some_if value default_system_font_prefix
+        in
+        let target_dir =
+          let deprecation_warning () =
+            print_err_warn
+              "Anonymous argument DIR has been deprecated. Use “--output” instead."
+          in
+          match target_dir_old, target_dir with
+            | Some value, None ->
+              deprecation_warning ();
+              value
+            | Some _, Some value ->
+              deprecation_warning ();
+              Printf.sprintf
+                "Both Anonymous argument and “--output” option are specified. Deprecated one is ignored."
+              |> print_err_warn;
+              value
+            | None, Some value ->
+              value
+            | None, None ->
+              default_target_dir
+        in
         if not (List.is_empty autogen_library_list)
         then Compatibility.optin ();
         let libraries = match library_list with
@@ -34,5 +84,6 @@ let install_command =
           ~verbose
           ~copy
           ~env
-          ()
+          ();
+        reprint_err_warn ()
     ]

--- a/bin/commandLibrary.ml
+++ b/bin/commandLibrary.ml
@@ -10,6 +10,7 @@ let library_show_command_g p_show =
     ~summary:"Show library information (experimental)"
     [%map_open
       let p = anon ("LIBRARY" %: string)
+      and _ = RenameOption.standard_help
       in
       fun () ->
         p_show p ()
@@ -20,6 +21,7 @@ let library_list_command_g p_list =
     ~summary:"Show list of libraries installed (experimental)"
     [%map_open
       let _ = args (* ToDo: Remove this *)
+      and _ = RenameOption.standard_help
       in
       fun () ->
         p_list ()

--- a/bin/commandPin.ml
+++ b/bin/commandPin.ml
@@ -6,10 +6,14 @@ let pin_list_command =
   let open Command.Let_syntax in
   Command.basic
     ~summary:"List installed libraries (experimental)"
-    (return (fun () ->
+    [%map_open
+      let _ = RenameOption.standard_help
+      in
+      fun () ->
       Compatibility.optin ();
       let repo = (Setup.read_repo ()).repo in
-      Satyrographos_command.Pin.pin_list ~outf repo))
+      Satyrographos_command.Pin.pin_list ~outf repo
+    ]
 
 let pin_dir_command =
   let open Command.Let_syntax in
@@ -17,6 +21,7 @@ let pin_dir_command =
     ~summary:"Get directory where library LIBRARY is stored (experimental)"
     [%map_open
       let p = anon ("LIBRARY" %: string)
+      and _ = RenameOption.standard_help
       in
       fun () ->
         Compatibility.optin ();
@@ -31,6 +36,7 @@ let pin_add_command =
     [%map_open
       let p = anon ("LIBRARY" %: string)
       and url = anon ("URL" %: string) (* TODO define Url.t Arg_type.t *)
+      and _ = RenameOption.standard_help
       in
       fun () ->
         Compatibility.optin ();
@@ -46,6 +52,7 @@ let pin_remove_command =
     ~summary:"Remove library (experimental)"
     [%map_open
       let p = anon ("LIBRARY" %: string) (* ToDo: Remove this *)
+      and _ = RenameOption.standard_help
       in
       fun () ->
         Compatibility.optin ();

--- a/bin/commandStatus.ml
+++ b/bin/commandStatus.ml
@@ -25,6 +25,7 @@ let status_command =
     ~summary:"Show status (experimental)"
     [%map_open
       let _ = args (* ToDo: Remove this *)
+      and _ = RenameOption.standard_help
       in
       fun () ->
         status ()

--- a/bin/dune
+++ b/bin/dune
@@ -3,5 +3,5 @@
  (public_name satyrographos)
  (preprocess (pps ppx_deriving.std ppx_jane))
  (libraries core satyrographos_command shexp.process uri)
- (modules setup compatibility commandInstall commandLibrary commandOpam commandPin commandStatus main)
+ (modules setup renameOption compatibility commandInstall commandLibrary commandOpam commandPin commandStatus main)
  )

--- a/bin/renameOption.ml
+++ b/bin/renameOption.ml
@@ -1,0 +1,84 @@
+open Core
+
+let printed_err_warns = ref []
+
+let print_err_warn ?(record=true) msg =
+  if record
+  then printed_err_warns := msg :: !printed_err_warns;
+  Format.fprintf Format.err_formatter
+    "\027[1;31m[OPTION DEPRECATION WARNING]\027[0m %s@."
+      msg
+
+let reprint_err_warn () =
+  print_err_warn ~record:false "";
+  List.iter ~f:(print_err_warn ~record:false) !printed_err_warns;
+  print_err_warn ~record:false ""
+
+let rename_option old_name old_value new_name new_value =
+  let deprecated_warn () =
+    Printf.sprintf
+      "Option “%s” has been deprecated. Use “%s” instead."
+        old_name new_name
+    |> print_err_warn
+  in
+  match old_value, new_value with
+    | Some value, None ->
+      deprecated_warn ();
+      Some value
+    | Some _, Some value ->
+      deprecated_warn ();
+      Printf.sprintf
+        "Both “%s” and “%s” are specified. Deprecated one is ignored."
+          old_name new_name
+      |> print_err_warn;
+      Some value
+    | None, value -> value
+
+let rename_bool old_name old_value new_name new_value =
+  rename_option old_name (Option.some_if old_value ()) new_name (Option.some_if new_value ())
+  |> Option.is_some
+
+let rename_list old_name old_value new_name new_value =
+  let to_option = function
+    | [] -> None
+    | xs -> Some xs
+  in
+  let from_option = function
+    | None -> []
+    | Some xs -> xs
+  in
+  rename_option old_name (to_option old_value) new_name (to_option new_value)
+  |> from_option
+
+let standard_help =
+  let open Command.Let_syntax in
+  [%map_open
+    let show_help = flag "--help" no_arg ~doc:"print this help text and exit"
+    and help_text = help
+    in
+      if show_help
+      then begin
+        Format.printf "%s@." (Lazy.force help_text);
+        ignore (exit 0 : _)
+      end
+  ]
+
+let long_flag_f rename_f arg_f ?doc_arg flag_name ?(aliases) arg ~doc =
+  let open Command.Let_syntax in
+  let doc_prefix = Option.map ~f:(fun x -> x ^ " ") doc_arg |> Option.value ~default:"" in
+  [%map_open
+    let new_opt = flag ("--" ^ flag_name) (arg_f arg) ?aliases ~doc:(doc_prefix ^ doc)
+    and old_opt = flag (flag_name) (arg_f arg) ~doc:(doc_prefix ^ "Deprecated. Use --" ^ flag_name ^ "instead")
+    in
+      rename_f ("-" ^ flag_name) old_opt
+        ("--" ^ flag_name) new_opt
+  ]
+
+let long_flag_optional ?doc_arg flag_name =
+  long_flag_f rename_option Command.Flag.optional ?doc_arg flag_name
+
+let long_flag_bool ?doc_arg flag_name =
+  long_flag_f rename_bool (fun x -> x) ?doc_arg flag_name
+
+let long_flag_listed ?doc_arg flag_name =
+  long_flag_f rename_list Command.Flag.listed ?doc_arg flag_name

--- a/src/command/runSatysfi.ml
+++ b/src/command/runSatysfi.ml
@@ -50,10 +50,13 @@ let with_env ~outf ~setup c =
   in
   with_temp_dir ~prefix:"Satyrographos" ~suffix:"with_env" c
 
-let run_satysfi ~satysfi_runtime args =
+let run_satysfi_command ~satysfi_runtime args =
   let open P.Infix in
+  assert_satysfi_option_C satysfi_runtime
+  >> P.run "satysfi" (["-C"; satysfi_runtime] @ args)
+
+let run_satysfi ~satysfi_runtime args =
   let command =
-    assert_satysfi_option_C satysfi_runtime
-    >> P.run "satysfi" (["-C"; satysfi_runtime] @ args) in
+    run_satysfi_command ~satysfi_runtime args in
   ProcessUtil.redirect_to_stdout ~prefix:"satysfi" command
 

--- a/src/systemFontLibrary.ml
+++ b/src/systemFontLibrary.ml
@@ -3,6 +3,7 @@ open Core
 module StringSet = Set.Make(String)
 
 let name = "%fonts-system"
+let system_font_prefix = "system:"
 
 let blacklist = StringSet.of_list [
   (* Each SanFranciso font has several weights with the same postscriptname *)


### PR DESCRIPTION
This PR adds GNU Style long options (e.g., `--library`) and deprecates those that does not follow the rule (e.g., `-library`).

Additionally, this PR adds `--use-system-fonts` option to `install` subcommand, fixing system font prefix to `system:`.