### PR TITLE
Add new subcommand for creating a document/library from a template

### DIFF
--- a/bin/commandNew.ml
+++ b/bin/commandNew.ml
@@ -1,0 +1,39 @@
+open Core
+
+let templates =
+  Satyrographos_template.Template.templates
+
+let template_map =
+  Satyrographos_command.New.template_map
+
+let help_templates () =
+  Satyrographos_command.New.template_descriptions
+  |> List.map ~f:(fun (k, d) -> Printf.sprintf "  %s : %s" k d)
+  |> String.concat ~sep:"\n"
+
+let new_command =
+  let open Command.Let_syntax in
+  let open RenameOption in
+  let readme () =
+    sprintf {|
+Create a new SATySFi document/library from a chosen template.
+
+Available templates:
+%s|} (help_templates ())
+  in
+  Command.basic
+    ~summary:"Create a new SATySFi document/library"
+    ~readme
+    [%map_open
+      let template = anon ("TEMPLATE" %: Arg_type.of_map template_map)
+      and name = anon ("NAME" %: string)
+      and license = flag "--license" (optional string) ~doc:"LICENSE License"
+      in
+      fun () ->
+        Compatibility.optin ();
+        Satyrographos_command.New.create_project
+          name
+          license
+          template;
+        reprint_err_warn ()
+    ]

--- a/bin/dune
+++ b/bin/dune
@@ -2,6 +2,6 @@
  (name main)
  (public_name satyrographos)
  (preprocess (pps ppx_deriving.std ppx_jane -allow-unannotated-ignores))
- (libraries core satyrographos_command shexp.process uri)
- (modules setup renameOption compatibility commandInstall commandLibrary commandOpam commandPin commandSatysfi commandStatus main)
+ (libraries core satyrographos_template satyrographos_command shexp.process uri)
+ (modules setup renameOption compatibility commandNew commandInstall commandLibrary commandOpam commandPin commandSatysfi commandStatus main)
  )

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4,6 +4,7 @@ open Core
 let total_command =
   Command.group ~summary:"Simple SATySFi Package Manager"
     [
+      "new", CommandNew.new_command;
       "opam", CommandOpam.opam_command;
       "library", CommandLibrary.library_command;
       "library-opam", CommandLibrary.library_opam_command;

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
-(lang dune 1.11)
+(lang dune 2.7)
+(cram enable)
 (name satyrographos)

--- a/src/command/dune
+++ b/src/command/dune
@@ -2,4 +2,4 @@
  (name satyrographos_command)
  (inline_tests)
  (preprocess (staged_pps ppx_deriving.std ppx_jane -allow-unannotated-ignores))
- (libraries core fileutils satyrographos satyrographos_autogen shexp.process))
+ (libraries core fileutils satyrographos satyrographos_autogen satyrographos_template shexp.process))

--- a/src/command/new.ml
+++ b/src/command/new.ml
@@ -1,0 +1,63 @@
+open Core
+
+let templates =
+  Satyrographos_template.Template.templates
+
+let template_map =
+  templates
+  |> List.map ~f:(fun (k, (_, fs)) -> k, fs)
+  |> String.Map.of_alist_exn
+
+let template_descriptions =
+  templates
+  |> List.map ~f:(fun (k, (d, _)) -> k, d)
+
+let licenses = [
+  "MIT";
+  "LGPL-3.0-or-later";
+]
+
+let input_if_missing f = function
+  | Some value -> value
+  | None ->
+    f ()
+
+let rec choose_license () =
+  let license_list =
+    List.mapi ~f:(sprintf "%d) %s") licenses
+    |> String.concat ~sep:"\n"
+  in
+  printf "Choose licenses:\n%s\n> " license_list;
+  let result =
+    let (let>>=) = Option.(>>=) in
+    let>>= i = read_int_opt () in
+    let>>= l = List.nth licenses i in
+    Some l
+  in
+  match result with
+  | Some l -> l
+  | None ->
+    printf "Not a valid answer.\n";
+    choose_license ()
+
+let create_project name license files =
+  if FileUtil.(test Exists name)
+  then begin
+    Printf.printf "%s already exists.\n" name;
+    exit 1
+  end;
+  Printf.printf "Name: %s\n" name;
+  let license = input_if_missing choose_license license in
+  Printf.printf "License: %s\n" license;
+  let vars = [
+    "library", name;
+    "license", license;
+    "satysfi_version", {|>= "0.0.5" & < "0.0.6"|};
+    "satyrographos_version", {|>= "0.0.2.6" & < "0.0.3"|};
+  ] in
+  Satyrographos_template.Template.create_files
+    ~basedir:name
+    vars
+    files;
+  Printf.printf "Created a new library/document.\n"
+

--- a/src/template/dune
+++ b/src/template/dune
@@ -1,0 +1,5 @@
+(library
+ (name satyrographos_template)
+ (inline_tests)
+ (preprocess (staged_pps ppx_deriving.std ppx_jane))
+ (libraries core fileutils satyrographos shexp.process))

--- a/src/template/template.ml
+++ b/src/template/template.ml
@@ -24,7 +24,7 @@ let replace_template vars =
       v ^ ":camel", camelize t;
     ]
   in
-  let vars = List.concat_map expand_var vars in
+  let vars = List.map expand_var vars |> List.concat in
   let f g = List.assoc (Re.Group.get g 1) vars in
   (fun s -> Re.replace template_re ~all:true ~f s)
 

--- a/src/template/template.ml
+++ b/src/template/template.ml
@@ -1,0 +1,47 @@
+let template_re =
+  let open Re in
+  seq [
+    str {|@@|};
+    rep (Re.alt [wordc; char ':']) |> group;
+    str {|@@|};
+  ] |> compile
+
+let hyphen_re =
+  let open Re in
+  seq [
+    char '-';
+    rg 'a' 'z' |> group;
+  ] |> compile
+
+let camelize str =
+  let f g = String.uppercase_ascii (Re.Group.get g 1) in
+  Re.replace hyphen_re ~all:true ~f str
+  |> String.capitalize_ascii
+
+let replace_template vars =
+  let expand_var (v, t) =
+    [ v, t;
+      v ^ ":camel", camelize t;
+    ]
+  in
+  let vars = List.concat_map expand_var vars in
+  let f g = List.assoc (Re.Group.get g 1) vars in
+  (fun s -> Re.replace template_re ~all:true ~f s)
+
+let create_file ~basedir vars (name, content) =
+  let name = replace_template vars name |> FilePath.concat basedir in
+  let content = replace_template vars content in
+  FileUtil.(mkdir ~parent:true (FilePath.dirname name));
+  let oc = open_out name in
+  try
+    output_string oc content
+  with e ->
+    close_out_noerr oc;
+    raise e
+
+let create_files ~basedir vars templ =
+  List.iter (create_file ~basedir vars) templ
+
+let templates = [
+  "lib", ("Package library", TemplateLib.files);
+]

--- a/src/template/templateLib.ml
+++ b/src/template/templateLib.ml
@@ -1,0 +1,198 @@
+let name = "lib"
+
+let lib_satyh_template =
+"src/@@library@@.satyh",
+{|% .satyh files are loaded by the PDF backend.
+% .satyh-markdown and .saty-html files are loaded by the text backend for markdoown and html outputs, respectively.
+% A .satyg file is loaded when the corresponding .satyh or .satyh-* files are not loaded.
+
+% load standard list package
+@require: list
+
+% load float package from base library
+@require: base/float
+
+module @@library:camel@@ : sig
+  % Type declaration of module @@library:camel@@
+
+  val pi : float
+
+  val geo-mean : float list -> float
+
+end = struct
+  % Actual definitions
+
+  let pi = 3.1415926535897932384626433832795
+
+  % function definition that is not exposed
+  let sum xs =
+    xs
+    |> List.fold-left (+.) 0.
+
+  let geo-mean xs =
+    xs
+    |> List.map Float.log
+    |> sum
+    |> Float.exp
+
+end
+|}
+
+let manual_template =
+"doc/manual.saty",
+{|@require: stdjareport
+@require: itemize
+@require: annot
+
+@require: base/typeset/base
+@require: base/float
+
+@require: @@library@@/@@library@@
+
+% Document-local function definition
+let-inline \show-float f =
+  f
+  |> Float.to-string
+  |> embed-string
+in
+
+document (|
+  title = {@@library@@ Manual};
+  author = {Your Name};
+|) '<
+  +p {
+    See `https://qiita.com/na4zagin3/items/b392f5d522f9bcc0493b` for the instruction in Japanese.
+  }
+  +chapter{Examples} <
+    +p {
+      ${\pi = \mathrm-token!(Float.to-string @@library:camel@@.pi)}.
+    }
+    +p {
+      Geometric mean of 1, 3, and 5 is
+      \show-float(@@library:camel@@.geo-mean [1.; 3.; 5.]);
+    }
+  >
+>
+|}
+
+let satyristes_template =
+"Satyristes",
+{|;; For Satyrographos 0.0.2 series
+(version 0.0.2)
+
+;; Library declaration
+(library
+  ;; Library name
+  (name "@@library@@")
+  ;; Library version
+  (version "1.0")
+  ;; Files
+  (sources
+    ((packageDir "src")))
+  ;; OPAM package file
+  (opam "satysfi-@@library@@.opam")
+  ;; Dependency
+  (dependencies
+    ((dist ()) ; Standard library
+     (base ()) ; Base library
+    )))
+
+;; Library doc declaration
+(libraryDoc
+  ;; Library doc name
+  (name "@@library@@-doc")
+  ;; Library version
+  (version "1.0")
+  ;; Working directory to build docs
+  (workingDirectory "doc")
+  ;; Build commands
+  (build
+    ;; Run SATySFi
+    ((satysfi "manual.saty" "-o" "manual.pdf")))
+  ;; Files
+  (sources
+    ((doc "manual.pdf" "doc/manual.pdf")))
+  ;; OPAM package file
+  (opam "satysfi-@@library@@-doc.opam")
+  ;; Dependency
+  (dependencies
+    ((@@library@@ ()) ; the main library
+     (dist ()) ; Standard library
+     (base ()) ; Base library
+    )))
+|}
+
+let library_opam_template =
+"satysfi-@@library@@.opam",
+{|opam-version: "2.0"
+name: "satysfi-@@library@@"
+version: "1.0"
+synopsis: "A Great SATySFi Package"
+description: """
+Brilliant description comes here.
+"""
+maintainer: "Your name <email@example.com>"
+authors: "Your name <email@example.com>"
+license: "@@license@@"
+homepage: "<product home page>"
+bug-reports: "<product issue tracker>"
+dev-repo: "<repo url>"
+depends: [
+  "satysfi" { @@satysfi_version@@ }
+  "satyrographos" { @@satyrographos_version@@ }
+
+  # If your library depends on other libraries, please write down here
+]
+build: [ ]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "@@library@@"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+|}
+
+let library_doc_opam_template =
+"satysfi-@@library@@-doc.opam",
+{|opam-version: "2.0"
+name: "satysfi-@@library@@-doc"
+version: "1.0"
+synopsis: "Document of A Great SATySFi Package"
+description: """
+Brilliant description comes here.
+"""
+maintainer: "Your name <email@example.com>"
+authors: "Your name <email@example.com>"
+license: "@@license@@" # Choose what you want
+homepage: "<product home page>"
+bug-reports: "<product issue tracker>"
+dev-repo: "<repo url>"
+depends: [
+  "satysfi" { @@satysfi_version@@ }
+  "satyrographos" { @@satyrographos_version@@ }
+  "satysfi-dist"
+
+  # You may want to include the corresponding library
+  "satysfi-@@library@@" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "--name" "@@library@@-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "@@library@@-doc"
+   "--prefix" "%{prefix}%"
+   "--script" "%{build}%/Satyristes"]
+]
+|}
+
+let files = [
+    lib_satyh_template;
+    manual_template;
+    satyristes_template;
+    library_opam_template;
+    library_doc_opam_template;
+  ]

--- a/test/testcases/command_new__existing_directory.t
+++ b/test/testcases/command_new__existing_directory.t
@@ -1,0 +1,8 @@
+Attempt to create a new library with the conflicting name
+  $ mkdir test-lib
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new --license MIT lib test-lib
+  Compatibility warning: You have opted in to use experimental features.
+  test-lib already exists.
+  [1]
+  $ ls -R test-lib
+  test-lib:

--- a/test/testcases/command_new__invalid_license_option.t
+++ b/test/testcases/command_new__invalid_license_option.t
@@ -1,0 +1,21 @@
+Interactively create a new library with giving wrong answers.
+  $ printf "\na\n999\n1\n" | SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new lib test-lib
+  Compatibility warning: You have opted in to use experimental features.
+  Name: test-lib
+  Choose licenses:
+  0) MIT
+  1) LGPL-3.0-or-later
+  > Not a valid answer.
+  Choose licenses:
+  0) MIT
+  1) LGPL-3.0-or-later
+  > Not a valid answer.
+  Choose licenses:
+  0) MIT
+  1) LGPL-3.0-or-later
+  > Not a valid answer.
+  Choose licenses:
+  0) MIT
+  1) LGPL-3.0-or-later
+  > License: LGPL-3.0-or-later
+  Created a new library/document.

--- a/test/testcases/command_new__lib.t
+++ b/test/testcases/command_new__lib.t
@@ -1,0 +1,205 @@
+Create a new library with --license option
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new --license MIT lib test-lib
+  Compatibility warning: You have opted in to use experimental features.
+  Name: test-lib
+  License: MIT
+  Created a new library/document.
+
+Dump generated files
+  $ mkdir empty-dir
+  $ diff -Nr empty-dir test-lib
+  diff -Nr empty-dir/Satyristes test-lib/Satyristes
+  0a1,43
+  > ;; For Satyrographos 0.0.2 series
+  > (version 0.0.2)
+  > 
+  > ;; Library declaration
+  > (library
+  >   ;; Library name
+  >   (name "test-lib")
+  >   ;; Library version
+  >   (version "1.0")
+  >   ;; Files
+  >   (sources
+  >     ((packageDir "src")))
+  >   ;; OPAM package file
+  >   (opam "satysfi-test-lib.opam")
+  >   ;; Dependency
+  >   (dependencies
+  >     ((dist ()) ; Standard library
+  >      (base ()) ; Base library
+  >     )))
+  > 
+  > ;; Library doc declaration
+  > (libraryDoc
+  >   ;; Library doc name
+  >   (name "test-lib-doc")
+  >   ;; Library version
+  >   (version "1.0")
+  >   ;; Working directory to build docs
+  >   (workingDirectory "doc")
+  >   ;; Build commands
+  >   (build
+  >     ;; Run SATySFi
+  >     ((satysfi "manual.saty" "-o" "manual.pdf")))
+  >   ;; Files
+  >   (sources
+  >     ((doc "manual.pdf" "doc/manual.pdf")))
+  >   ;; OPAM package file
+  >   (opam "satysfi-test-lib-doc.opam")
+  >   ;; Dependency
+  >   (dependencies
+  >     ((test-lib ()) ; the main library
+  >      (dist ()) ; Standard library
+  >      (base ()) ; Base library
+  >     )))
+  diff -Nr empty-dir/doc/manual.saty test-lib/doc/manual.saty
+  0a1,33
+  > @require: stdjareport
+  > @require: itemize
+  > @require: annot
+  > 
+  > @require: base/typeset/base
+  > @require: base/float
+  > 
+  > @require: test-lib/test-lib
+  > 
+  > % Document-local function definition
+  > let-inline \show-float f =
+  >   f
+  >   |> Float.to-string
+  >   |> embed-string
+  > in
+  > 
+  > document (|
+  >   title = {test-lib Manual};
+  >   author = {Your Name};
+  > |) '<
+  >   +p {
+  >     See `https://qiita.com/na4zagin3/items/b392f5d522f9bcc0493b` for the instruction in Japanese.
+  >   }
+  >   +chapter{Examples} <
+  >     +p {
+  >       ${\pi = \mathrm-token!(Float.to-string TestLib.pi)}.
+  >     }
+  >     +p {
+  >       Geometric mean of 1, 3, and 5 is
+  >       \show-float(TestLib.geo-mean [1.; 3.; 5.]);
+  >     }
+  >   >
+  > >
+  diff -Nr empty-dir/satysfi-test-lib-doc.opam test-lib/satysfi-test-lib-doc.opam
+  0a1,33
+  > opam-version: "2.0"
+  > name: "satysfi-test-lib-doc"
+  > version: "1.0"
+  > synopsis: "Document of A Great SATySFi Package"
+  > description: """
+  > Brilliant description comes here.
+  > """
+  > maintainer: "Your name <email@example.com>"
+  > authors: "Your name <email@example.com>"
+  > license: "MIT" # Choose what you want
+  > homepage: "<product home page>"
+  > bug-reports: "<product issue tracker>"
+  > dev-repo: "<repo url>"
+  > depends: [
+  >   "satysfi" { >= "0.0.5" & < "0.0.6" }
+  >   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  >   "satysfi-dist"
+  > 
+  >   # You may want to include the corresponding library
+  >   "satysfi-test-lib" {= "%{version}%"}
+  > ]
+  > build: [
+  >   ["satyrographos" "opam" "build"
+  >    "--name" "test-lib-doc"
+  >    "--prefix" "%{prefix}%"
+  >    "--script" "%{build}%/Satyristes"]
+  > ]
+  > install: [
+  >   ["satyrographos" "opam" "install"
+  >    "--name" "test-lib-doc"
+  >    "--prefix" "%{prefix}%"
+  >    "--script" "%{build}%/Satyristes"]
+  > ]
+  diff -Nr empty-dir/satysfi-test-lib.opam test-lib/satysfi-test-lib.opam
+  0a1,26
+  > opam-version: "2.0"
+  > name: "satysfi-test-lib"
+  > version: "1.0"
+  > synopsis: "A Great SATySFi Package"
+  > description: """
+  > Brilliant description comes here.
+  > """
+  > maintainer: "Your name <email@example.com>"
+  > authors: "Your name <email@example.com>"
+  > license: "MIT"
+  > homepage: "<product home page>"
+  > bug-reports: "<product issue tracker>"
+  > dev-repo: "<repo url>"
+  > depends: [
+  >   "satysfi" { >= "0.0.5" & < "0.0.6" }
+  >   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
+  > 
+  >   # If your library depends on other libraries, please write down here
+  > ]
+  > build: [ ]
+  > install: [
+  >   ["satyrographos" "opam" "install"
+  >    "--name" "test-lib"
+  >    "--prefix" "%{prefix}%"
+  >    "--script" "%{build}%/Satyristes"]
+  > ]
+  diff -Nr empty-dir/src/test-lib.satyh test-lib/src/test-lib.satyh
+  0a1,34
+  > % .satyh files are loaded by the PDF backend.
+  > % .satyh-markdown and .saty-html files are loaded by the text backend for markdoown and html outputs, respectively.
+  > % A .satyg file is loaded when the corresponding .satyh or .satyh-* files are not loaded.
+  > 
+  > % load standard list package
+  > @require: list
+  > 
+  > % load float package from base library
+  > @require: base/float
+  > 
+  > module TestLib : sig
+  >   % Type declaration of module TestLib
+  > 
+  >   val pi : float
+  > 
+  >   val geo-mean : float list -> float
+  > 
+  > end = struct
+  >   % Actual definitions
+  > 
+  >   let pi = 3.1415926535897932384626433832795
+  > 
+  >   % function definition that is not exposed
+  >   let sum xs =
+  >     xs
+  >     |> List.fold-left (+.) 0.
+  > 
+  >   let geo-mean xs =
+  >     xs
+  >     |> List.map Float.log
+  >     |> sum
+  >     |> Float.exp
+  > 
+  > end
+  [1]
+
+Interactively create a new library
+  $ mv test-lib test-lib-non-interactive
+  $ printf "0\n" | SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new lib test-lib
+  Compatibility warning: You have opted in to use experimental features.
+  Name: test-lib
+  Choose licenses:
+  0) MIT
+  1) LGPL-3.0-or-later
+  > License: MIT
+  Created a new library/document.
+  $ mv test-lib test-lib-interactive
+
+Compare them
+  $ diff -Nr test-lib-non-interactive test-lib-interactive


### PR DESCRIPTION
This PR adds a new subcommand `new` for creating document/library from the chosen template.  This is a part of #153.

As the first step, this PR also includes a template `lib` for a new library.

Usage:

```
$ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new lib test-lib
Compatibility warning: You have opted in to use experimental features.
Name: test-lib
Choose licenses:
0) MIT
1) LGPL-3.0-or-later
> 1
License: LGPL-3.0-or-later
Created a new library/document.
```