### PR TITLE
Reject invalid project names for new projects

### DIFF
--- a/src/command/new.ml
+++ b/src/command/new.ml
@@ -40,7 +40,49 @@ let rec choose_license () =
     printf "Not a valid answer.\n";
     choose_license ()
 
+let validate_name =
+  let re =
+    let open Re in
+    seq [
+      start;
+      rep (Re.alt [wordc; char '-']);
+      stop;
+    ] |> compile
+  in
+  let f name =
+    Re.matches re name
+    |> List.is_empty
+    |> not
+  in
+  f
+
+let%test "validate_name: accepts “abc”" =
+  validate_name "abc"
+
+let%test "validate_name: accepts “abc-def”" =
+  validate_name "abc-def"
+
+let%test "validate_name: rejects “abc.def”" =
+  validate_name "abc.def" |> not
+
+let%test "validate_name: rejects “abc*def”" =
+  validate_name "abc*def" |> not
+
+let%test "validate_name: rejects “abc+def”" =
+  validate_name "abc+def" |> not
+
+let%test "validate_name: rejects “../def”" =
+  validate_name "../def" |> not
+
+let%test "validate_name: rejects “abc def”" =
+  validate_name "abc def" |> not
+
 let create_project name license files =
+  if validate_name name |> not
+  then begin
+    Printf.printf "Project name should consist of ASCII alphabets, numbers, underscores, or hyphens.\n";
+    exit 1
+  end;
   if FileUtil.(test Exists name)
   then begin
     Printf.printf "%s already exists.\n" name;

--- a/test/testcases/command_new__invalid_names.t
+++ b/test/testcases/command_new__invalid_names.t
@@ -1,0 +1,13 @@
+Attempt to create libraries with invalid names
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new --license MIT lib test/lib
+  Compatibility warning: You have opted in to use experimental features.
+  Project name should consist of ASCII alphabets, numbers, underscores, or hyphens.
+  [1]
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new --license MIT lib test.lib
+  Compatibility warning: You have opted in to use experimental features.
+  Project name should consist of ASCII alphabets, numbers, underscores, or hyphens.
+  [1]
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new --license MIT lib test-lib.
+  Compatibility warning: You have opted in to use experimental features.
+  Project name should consist of ASCII alphabets, numbers, underscores, or hyphens.
+  [1]


### PR DESCRIPTION
Project names should consist only of ASCII alphabets, numbers, underscores, and hyphens.

Closes #155.