### PR TITLE
Fix indents in compatibility warning messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: c
 install: test -e .travis.opam.sh || wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
-env:
-  - OCAML_VERSION=4.09
-  - OCAML_VERSION=4.10
-  - OCAML_VERSION=4.11
-os:
-  - linux
-dist: bionic
+matrix:
+  include:
+    - os: linux
+      dist: bionic
+      env: OCAML_VERSION=4.10
+    - os: osx
+      osx_image: xcode11.3
+      env: OCAML_VERSION=4.11
+    - os: freebsd
+      dist: bionic
+      env: OCAML_VERSION=4.09
 cache:
   directories:
     - $HOME/ocaml

--- a/src/command/install.ml
+++ b/src/command/install.ml
@@ -81,10 +81,9 @@ let show_compatibility_warnings ~outf ~libraries =
           Format.fprintf outf "@]@]@,";
         end
       in
-      Format.fprintf outf "\n\027[1;33mCompatibility notice\027[0m for library %s:" library_name;
+      Format.fprintf outf "\n\027[1;33mCompatibility notice\027[0m for library %s:@," library_name;
       print_rename "Packages" compatibility.rename_packages;
       print_rename "Fonts" compatibility.rename_fonts;
-      Format.fprintf outf "@.";
     end
   )
 

--- a/test/testcases/command_install__distWithNonHashUnderHashDir.expected
+++ b/test/testcases/command_install__distWithNonHashUnderHashDir.expected
@@ -61,7 +61,7 @@ diff -Nr @@empty_dir@@/dest/fonts/Junicode.ttf @@dest_dir@@/dest/fonts/Junicode.
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"Junicode":<"Single":{"src":"dist/fonts/Junicode.ttf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2
 > ((version 1) (libraryName dist) (libraryVersion "") (compatibility ())

--- a/test/testcases/command_install__distWithNonHashUnderHashDir.expected
+++ b/test/testcases/command_install__distWithNonHashUnderHashDir.expected
@@ -18,14 +18,11 @@ Loaded libraries
           (Single ((Assoc ((src (String dist/fonts/Junicode.ttf))))))))))))))
   (files
    ((fonts/Junicode.ttf
-     (Filename
-      @@temp_dir@@/simple_dist/fonts/Junicode.ttf))
+     (Filename @@temp_dir@@/simple_dist/fonts/Junicode.ttf))
     (packages/List.satyg
-     (Filename
-      @@temp_dir@@/simple_dist/packages/List.satyg))
+     (Filename @@temp_dir@@/simple_dist/packages/List.satyg))
     (unidata/UnicodeData.txt
-     (Filename
-      @@temp_dir@@/simple_dist/unidata/UnicodeData.txt))))))
+     (Filename @@temp_dir@@/simple_dist/unidata/UnicodeData.txt))))))
 Installing ((name (dist)) (version ())
  (hashes
   ((hash/fonts.satysfi-hash
@@ -47,6 +44,7 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
+@@dest_dir@@/dest/.satyrographos
 @@dest_dir@@/dest/fonts
 @@dest_dir@@/dest/fonts/Junicode.ttf
 @@dest_dir@@/dest/hash
@@ -54,7 +52,6 @@ Installation completed!
 @@dest_dir@@/dest/metadata
 @@dest_dir@@/dest/packages
 @@dest_dir@@/dest/packages/List.satyg
-@@dest_dir@@/dest/.satyrographos
 @@dest_dir@@/dest/unidata
 @@dest_dir@@/dest/unidata/UnicodeData.txt
 ------------------------------------------------------------

--- a/test/testcases/command_install__distWithNonHashUnderHashDir.expected
+++ b/test/testcases/command_install__distWithNonHashUnderHashDir.expected
@@ -61,7 +61,7 @@ diff -Nr @@empty_dir@@/dest/fonts/Junicode.ttf @@dest_dir@@/dest/fonts/Junicode.
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"Junicode":<"Single":{"src":"dist/fonts/Junicode.ttf"}>}
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2
 > ((version 1) (libraryName dist) (libraryVersion "") (compatibility ())

--- a/test/testcases/command_install__emptyDist.expected
+++ b/test/testcases/command_install__emptyDist.expected
@@ -12,8 +12,8 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
-@@dest_dir@@/dest/metadata
 @@dest_dir@@/dest/.satyrographos
+@@dest_dir@@/dest/metadata
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2

--- a/test/testcases/command_install__onlyDist.expected
+++ b/test/testcases/command_install__onlyDist.expected
@@ -17,14 +17,11 @@ Loaded libraries
           (Single ((Assoc ((src (String dist/fonts/Junicode.ttf))))))))))))))
   (files
    ((fonts/Junicode.ttf
-     (Filename
-      @@temp_dir@@/simple_dist/fonts/Junicode.ttf))
+     (Filename @@temp_dir@@/simple_dist/fonts/Junicode.ttf))
     (packages/List.satyg
-     (Filename
-      @@temp_dir@@/simple_dist/packages/List.satyg))
+     (Filename @@temp_dir@@/simple_dist/packages/List.satyg))
     (unidata/UnicodeData.txt
-     (Filename
-      @@temp_dir@@/simple_dist/unidata/UnicodeData.txt))))))
+     (Filename @@temp_dir@@/simple_dist/unidata/UnicodeData.txt))))))
 Installing ((name (dist)) (version ())
  (hashes
   ((hash/fonts.satysfi-hash
@@ -46,6 +43,7 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
+@@dest_dir@@/dest/.satyrographos
 @@dest_dir@@/dest/fonts
 @@dest_dir@@/dest/fonts/Junicode.ttf
 @@dest_dir@@/dest/hash
@@ -53,7 +51,6 @@ Installation completed!
 @@dest_dir@@/dest/metadata
 @@dest_dir@@/dest/packages
 @@dest_dir@@/dest/packages/List.satyg
-@@dest_dir@@/dest/.satyrographos
 @@dest_dir@@/dest/unidata
 @@dest_dir@@/dest/unidata/UnicodeData.txt
 ------------------------------------------------------------

--- a/test/testcases/command_install__onlyDist.expected
+++ b/test/testcases/command_install__onlyDist.expected
@@ -60,7 +60,7 @@ diff -Nr @@empty_dir@@/dest/fonts/Junicode.ttf @@dest_dir@@/dest/fonts/Junicode.
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"Junicode":<"Single":{"src":"dist/fonts/Junicode.ttf"}>}
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2
 > ((version 1) (libraryName dist) (libraryVersion "") (compatibility ())

--- a/test/testcases/command_install__onlyDist.expected
+++ b/test/testcases/command_install__onlyDist.expected
@@ -60,7 +60,7 @@ diff -Nr @@empty_dir@@/dest/fonts/Junicode.ttf @@dest_dir@@/dest/fonts/Junicode.
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"Junicode":<"Single":{"src":"dist/fonts/Junicode.ttf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2
 > ((version 1) (libraryName dist) (libraryVersion "") (compatibility ())

--- a/test/testcases/command_install__thirdParties.expected
+++ b/test/testcases/command_install__thirdParties.expected
@@ -46,8 +46,7 @@ Loaded libraries
  ((name (grcnum)) (version (0.2))
   (files
    ((packages/grcnum/grcnum.satyh
-     (Filename
-      @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))))
+     (Filename @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))))
   (compatibility
    ((rename_packages
      (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
@@ -111,6 +110,7 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
+@@dest_dir@@/dest/.satyrographos
 @@dest_dir@@/dest/fonts
 @@dest_dir@@/dest/fonts/fonts-theano
 @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
@@ -122,7 +122,6 @@ Installation completed!
 @@dest_dir@@/dest/packages
 @@dest_dir@@/dest/packages/grcnum
 @@dest_dir@@/dest/packages/grcnum/grcnum.satyh
-@@dest_dir@@/dest/.satyrographos
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
 0a1

--- a/test/testcases/command_install__thirdParties.expected
+++ b/test/testcases/command_install__thirdParties.expected
@@ -101,12 +101,11 @@ Installation completed!
     TheanoModern -> fonts-theano:TheanoModern
     TheanoOldStyle -> fonts-theano:TheanoOldStyle
 
-
 [1;33mCompatibility notice[0m for library grcnum:
-                                                      Packages have been renamed.
-                                                      
-                                                        grcnum.satyh -> grcnum/grcnum.satyh
 
+  Packages have been renamed.
+  
+    grcnum.satyh -> grcnum/grcnum.satyh
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
@@ -135,7 +134,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName dist) (libraryVersion 2.0)

--- a/test/testcases/command_install__thirdParties.expected
+++ b/test/testcases/command_install__thirdParties.expected
@@ -134,7 +134,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName dist) (libraryVersion 2.0)

--- a/test/testcases/command_install__thirdParties.expected
+++ b/test/testcases/command_install__thirdParties.expected
@@ -134,7 +134,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName dist) (libraryVersion 2.0)

--- a/test/testcases/command_install__twoDists.expected
+++ b/test/testcases/command_install__twoDists.expected
@@ -11,8 +11,8 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
-@@dest_dir@@/dest/metadata
 @@dest_dir@@/dest/.satyrographos
+@@dest_dir@@/dest/metadata
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2

--- a/test/testcases/command_install_l__autogen.expected
+++ b/test/testcases/command_install_l__autogen.expected
@@ -36,8 +36,7 @@ Loaded libraries
  ((name (base)) (version (1.1.1))
   (files
    ((packages/base/void.satyh
-     (Filename
-      @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
+     (Filename @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
  ((name (dist)) (version ()))
  ((name (fonts-theano)) (version (2.0))
   (hashes
@@ -77,8 +76,7 @@ Loaded libraries
  ((name (grcnum)) (version (0.2))
   (files
    ((packages/grcnum/grcnum.satyh
-     (Filename
-      @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))))
+     (Filename @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))))
   (compatibility
    ((rename_packages
      (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
@@ -167,6 +165,7 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
+@@dest_dir@@/dest/.satyrographos
 @@dest_dir@@/dest/fonts
 @@dest_dir@@/dest/fonts/fonts-theano
 @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
@@ -183,7 +182,6 @@ Installation completed!
 @@dest_dir@@/dest/packages/satyrographos
 @@dest_dir@@/dest/packages/satyrographos/experimental
 @@dest_dir@@/dest/packages/satyrographos/experimental/libraries.satyg
-@@dest_dir@@/dest/.satyrographos
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
 0a1

--- a/test/testcases/command_install_l__autogen.expected
+++ b/test/testcases/command_install_l__autogen.expected
@@ -194,7 +194,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName %libraries) (libraryVersion 0.1)

--- a/test/testcases/command_install_l__autogen.expected
+++ b/test/testcases/command_install_l__autogen.expected
@@ -194,7 +194,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName %libraries) (libraryVersion 0.1)

--- a/test/testcases/command_install_l__autogen.expected
+++ b/test/testcases/command_install_l__autogen.expected
@@ -156,12 +156,11 @@ Installation completed!
     TheanoModern -> fonts-theano:TheanoModern
     TheanoOldStyle -> fonts-theano:TheanoOldStyle
 
-
 [1;33mCompatibility notice[0m for library grcnum:
-                                                      Packages have been renamed.
-                                                      
-                                                        grcnum.satyh -> grcnum/grcnum.satyh
 
+  Packages have been renamed.
+  
+    grcnum.satyh -> grcnum/grcnum.satyh
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
@@ -195,7 +194,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName %libraries) (libraryVersion 0.1)

--- a/test/testcases/command_install_l__dependent.expected
+++ b/test/testcases/command_install_l__dependent.expected
@@ -86,7 +86,6 @@ Installation completed!
     TheanoDidot -> fonts-theano:TheanoDidot
     TheanoModern -> fonts-theano:TheanoModern
     TheanoOldStyle -> fonts-theano:TheanoOldStyle
-
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
@@ -112,7 +111,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,7
 > ((version 1) (libraryName dist) (libraryVersion 2.0)

--- a/test/testcases/command_install_l__dependent.expected
+++ b/test/testcases/command_install_l__dependent.expected
@@ -111,7 +111,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,7
 > ((version 1) (libraryName dist) (libraryVersion 2.0)

--- a/test/testcases/command_install_l__dependent.expected
+++ b/test/testcases/command_install_l__dependent.expected
@@ -90,6 +90,7 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
+@@dest_dir@@/dest/.satyrographos
 @@dest_dir@@/dest/fonts
 @@dest_dir@@/dest/fonts/fonts-theano
 @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
@@ -98,7 +99,6 @@ Installation completed!
 @@dest_dir@@/dest/hash
 @@dest_dir@@/dest/hash/fonts.satysfi-hash
 @@dest_dir@@/dest/metadata
-@@dest_dir@@/dest/.satyrographos
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
 0a1

--- a/test/testcases/command_install_l__dependent.expected
+++ b/test/testcases/command_install_l__dependent.expected
@@ -111,7 +111,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,7
 > ((version 1) (libraryName dist) (libraryVersion 2.0)

--- a/test/testcases/command_install_l__independentTwo.expected
+++ b/test/testcases/command_install_l__independentTwo.expected
@@ -143,7 +143,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName base) (libraryVersion 1.1.1)

--- a/test/testcases/command_install_l__independentTwo.expected
+++ b/test/testcases/command_install_l__independentTwo.expected
@@ -143,7 +143,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName base) (libraryVersion 1.1.1)

--- a/test/testcases/command_install_l__independentTwo.expected
+++ b/test/testcases/command_install_l__independentTwo.expected
@@ -108,12 +108,11 @@ Installation completed!
     TheanoModern -> fonts-theano:TheanoModern
     TheanoOldStyle -> fonts-theano:TheanoOldStyle
 
-
 [1;33mCompatibility notice[0m for library grcnum:
-                                                      Packages have been renamed.
-                                                      
-                                                        grcnum.satyh -> grcnum/grcnum.satyh
 
+  Packages have been renamed.
+  
+    grcnum.satyh -> grcnum/grcnum.satyh
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
@@ -144,7 +143,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName base) (libraryVersion 1.1.1)

--- a/test/testcases/command_install_l__independentTwo.expected
+++ b/test/testcases/command_install_l__independentTwo.expected
@@ -10,8 +10,7 @@ Loaded libraries
 (((name (base)) (version (1.1.1))
   (files
    ((packages/base/void.satyh
-     (Filename
-      @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
+     (Filename @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
  ((name (dist)) (version ()))
  ((name (fonts-theano)) (version (2.0))
   (hashes
@@ -51,8 +50,7 @@ Loaded libraries
  ((name (grcnum)) (version (0.2))
   (files
    ((packages/grcnum/grcnum.satyh
-     (Filename
-      @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))))
+     (Filename @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))))
   (compatibility
    ((rename_packages
      (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
@@ -119,6 +117,7 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
+@@dest_dir@@/dest/.satyrographos
 @@dest_dir@@/dest/fonts
 @@dest_dir@@/dest/fonts/fonts-theano
 @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
@@ -132,7 +131,6 @@ Installation completed!
 @@dest_dir@@/dest/packages/base/void.satyh
 @@dest_dir@@/dest/packages/grcnum
 @@dest_dir@@/dest/packages/grcnum/grcnum.satyh
-@@dest_dir@@/dest/.satyrographos
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
 0a1

--- a/test/testcases/command_install_l__simple.expected
+++ b/test/testcases/command_install_l__simple.expected
@@ -10,8 +10,7 @@ Loaded libraries
 (((name (base)) (version (1.1.1))
   (files
    ((packages/base/void.satyh
-     (Filename
-      @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
+     (Filename @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
  ((name (dist)) (version ())))
 Installing ((name (base)) (version (1.1.1))
  (files
@@ -22,11 +21,11 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
+@@dest_dir@@/dest/.satyrographos
 @@dest_dir@@/dest/metadata
 @@dest_dir@@/dest/packages
 @@dest_dir@@/dest/packages/base
 @@dest_dir@@/dest/packages/base/void.satyh
-@@dest_dir@@/dest/.satyrographos
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2

--- a/test/testcases/command_install_l__transitive.expected
+++ b/test/testcases/command_install_l__transitive.expected
@@ -143,7 +143,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName base) (libraryVersion 1.1.1)

--- a/test/testcases/command_install_l__transitive.expected
+++ b/test/testcases/command_install_l__transitive.expected
@@ -143,7 +143,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName base) (libraryVersion 1.1.1)

--- a/test/testcases/command_install_l__transitive.expected
+++ b/test/testcases/command_install_l__transitive.expected
@@ -108,12 +108,11 @@ Installation completed!
     TheanoModern -> fonts-theano:TheanoModern
     TheanoOldStyle -> fonts-theano:TheanoOldStyle
 
-
 [1;33mCompatibility notice[0m for library grcnum:
-                                                      Packages have been renamed.
-                                                      
-                                                        grcnum.satyh -> grcnum/grcnum.satyh
 
+  Packages have been renamed.
+  
+    grcnum.satyh -> grcnum/grcnum.satyh
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
@@ -144,7 +143,7 @@ diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@dest
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,9
 > ((version 1) (libraryName base) (libraryVersion 1.1.1)

--- a/test/testcases/command_install_l__transitive.expected
+++ b/test/testcases/command_install_l__transitive.expected
@@ -10,8 +10,7 @@ Loaded libraries
 (((name (base)) (version (1.1.1))
   (files
    ((packages/base/void.satyh
-     (Filename
-      @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
+     (Filename @@temp_dir@@/opam_reg/base/packages/base/void.satyh)))))
  ((name (dist)) (version ()))
  ((name (fonts-theano)) (version (2.0))
   (hashes
@@ -51,8 +50,7 @@ Loaded libraries
  ((name (grcnum)) (version (0.2))
   (files
    ((packages/grcnum/grcnum.satyh
-     (Filename
-      @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))))
+     (Filename @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))))
   (compatibility
    ((rename_packages
      (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
@@ -119,6 +117,7 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 @@dest_dir@@/dest
+@@dest_dir@@/dest/.satyrographos
 @@dest_dir@@/dest/fonts
 @@dest_dir@@/dest/fonts/fonts-theano
 @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
@@ -132,7 +131,6 @@ Installation completed!
 @@dest_dir@@/dest/packages/base/void.satyh
 @@dest_dir@@/dest/packages/grcnum
 @@dest_dir@@/dest/packages/grcnum/grcnum.satyh
-@@dest_dir@@/dest/.satyrographos
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
 0a1

--- a/test/testcases/command_new__existing_directory.t
+++ b/test/testcases/command_new__existing_directory.t
@@ -4,5 +4,5 @@ Attempt to create a new library with the conflicting name
   Compatibility warning: You have opted in to use experimental features.
   test-lib already exists.
   [1]
-  $ ls -R test-lib
-  test-lib:
+  $ find test-lib | LC_ALL=C sort
+  test-lib

--- a/test/testcases/command_opam_build__doc_satysfi.expected
+++ b/test/testcases/command_opam_build__doc_satysfi.expected
@@ -3,31 +3,20 @@ Installing packages
 make out> Target: build-doc
 make out> Files under $SATYSFI_RUNTIME
 make out> ==============================
-make out> .:
-make out> dist
-make out>
-make out> ./dist:
-make out> fonts
-make out> hash
-make out> metadata
-make out> packages
-make out>
-make out> ./dist/fonts:
-make out> fonts-theano
-make out>
-make out> ./dist/fonts/fonts-theano:
-make out> TheanoDidot-Regular.otf
-make out> TheanoModern-Regular.otf
-make out> TheanoOldStyle-Regular.otf
-make out>
-make out> ./dist/hash:
-make out> fonts.satysfi-hash
-make out>
-make out> ./dist/packages:
-make out> grcnum
-make out>
-make out> ./dist/packages/grcnum:
-make out> grcnum.satyh
+make out> .
+make out> ./dist
+make out> ./dist/.satyrographos
+make out> ./dist/fonts
+make out> ./dist/fonts/fonts-theano
+make out> ./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
+make out> ./dist/fonts/fonts-theano/TheanoModern-Regular.otf
+make out> ./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+make out> ./dist/hash
+make out> ./dist/hash/fonts.satysfi-hash
+make out> ./dist/metadata
+make out> ./dist/packages
+make out> ./dist/packages/grcnum
+make out> ./dist/packages/grcnum/grcnum.satyh
 make out> ==============================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()

--- a/test/testcases/command_opam_build__doc_satysfi.expected
+++ b/test/testcases/command_opam_build__doc_satysfi.expected
@@ -34,12 +34,11 @@ Installation completed!
     TheanoModern -> fonts-theano:TheanoModern
     TheanoOldStyle -> fonts-theano:TheanoOldStyle
 
-
 [1;33mCompatibility notice[0m for library grcnum:
-                                                      Packages have been renamed.
-                                                      
-                                                        grcnum.satyh -> grcnum/grcnum.satyh
 
+  Packages have been renamed.
+  
+    grcnum.satyh -> grcnum/grcnum.satyh
 Setting up SATySFi env at @@with_env@@ 
 ------------------------------------------------------------
 @@dest_dir@@

--- a/test/testcases/command_opam_build__doc_satysfi.ml
+++ b/test/testcases/command_opam_build__doc_satysfi.ml
@@ -44,7 +44,7 @@ build-doc:
 	@echo "Target: build-doc"
 	@echo 'Files under $$SATYSFI_RUNTIME'
 	@echo "=============================="
-	@cd "$(SATYSFI_RUNTIME)" ; ls -R
+	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
 	@echo "=============================="
 |}
 

--- a/test/testcases/command_opam_install__library.expected
+++ b/test/testcases/command_opam_install__library.expected
@@ -48,7 +48,7 @@ diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/fonts/grcnum/grcnum-font.ttf @@
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash @@dest_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash
 0a1
 > {"grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/metadata @@dest_dir@@/dest/share/satysfi/grcnum/metadata
 0a1,5
 > ((version 1) (libraryName grcnum) (libraryVersion 0.2)

--- a/test/testcases/command_opam_install__library.expected
+++ b/test/testcases/command_opam_install__library.expected
@@ -48,7 +48,7 @@ diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/fonts/grcnum/grcnum-font.ttf @@
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash @@dest_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash
 0a1
 > {"grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>}
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/metadata @@dest_dir@@/dest/share/satysfi/grcnum/metadata
 0a1,5
 > ((version 1) (libraryName grcnum) (libraryVersion 0.2)

--- a/test/testcases/command_opam_install__library.expected
+++ b/test/testcases/command_opam_install__library.expected
@@ -11,10 +11,8 @@ Read library:
          (Single ((Assoc ((src-dist (String grcnum/grcnum-font.ttf))))))))))))))
  (files
   ((doc/grcnum.md (Filename @@temp_dir@@/pkg/README.md))
-   (fonts/grcnum/grcnum-font.ttf
-    (Filename @@temp_dir@@/pkg/font.ttf))
-   (packages/grcnum/grcnum.satyh
-    (Filename @@temp_dir@@/pkg/grcnum.satyh))))
+   (fonts/grcnum/grcnum-font.ttf (Filename @@temp_dir@@/pkg/font.ttf))
+   (packages/grcnum/grcnum.satyh (Filename @@temp_dir@@/pkg/grcnum.satyh))))
  (compatibility
   ((rename_packages
     (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))

--- a/test/testcases/command_opam_install__library_recursive.expected
+++ b/test/testcases/command_opam_install__library_recursive.expected
@@ -118,7 +118,7 @@ diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/fonts/grcnum/grcnum-font.ttf @@
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash @@dest_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash
 0a1
 > {"grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/metadata @@dest_dir@@/dest/share/satysfi/grcnum/metadata
 0a1,13
 > ((version 1) (libraryName grcnum) (libraryVersion 0.2)

--- a/test/testcases/command_opam_install__library_recursive.expected
+++ b/test/testcases/command_opam_install__library_recursive.expected
@@ -118,7 +118,7 @@ diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/fonts/grcnum/grcnum-font.ttf @@
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash @@dest_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash
 0a1
 > {"grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>}
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/metadata @@dest_dir@@/dest/share/satysfi/grcnum/metadata
 0a1,13
 > ((version 1) (libraryName grcnum) (libraryVersion 0.2)

--- a/test/testcases/command_opam_install__library_recursive.expected
+++ b/test/testcases/command_opam_install__library_recursive.expected
@@ -19,25 +19,19 @@ Read library:
     (Filename @@temp_dir@@/pkg/font/a/b-1/c-2/file1.ttf))
    (fonts/grcnum/a/b-1/file.ttf
     (Filename @@temp_dir@@/pkg/font/a/b-1/file.ttf))
-   (fonts/grcnum/a/file.ttf
-    (Filename @@temp_dir@@/pkg/font/a/file.ttf))
-   (fonts/grcnum/grcnum-font.ttf
-    (Filename @@temp_dir@@/pkg/font.ttf))
+   (fonts/grcnum/a/file.ttf (Filename @@temp_dir@@/pkg/font/a/file.ttf))
+   (fonts/grcnum/grcnum-font.ttf (Filename @@temp_dir@@/pkg/font.ttf))
    (packages/grcnum/a/b-1/c-1/file1.satyh
-    (Filename
-     @@temp_dir@@/pkg/src/a/b-1/c-1/file1.satyh))
+    (Filename @@temp_dir@@/pkg/src/a/b-1/c-1/file1.satyh))
    (packages/grcnum/a/b-1/c-1/file2.satyh
-    (Filename
-     @@temp_dir@@/pkg/src/a/b-1/c-1/file2.satyh))
+    (Filename @@temp_dir@@/pkg/src/a/b-1/c-1/file2.satyh))
    (packages/grcnum/a/b-1/c-2/file1.satyh
-    (Filename
-     @@temp_dir@@/pkg/src/a/b-1/c-2/file1.satyh))
+    (Filename @@temp_dir@@/pkg/src/a/b-1/c-2/file1.satyh))
    (packages/grcnum/a/b-1/file.satyh
     (Filename @@temp_dir@@/pkg/src/a/b-1/file.satyh))
    (packages/grcnum/a/file.satyh
     (Filename @@temp_dir@@/pkg/src/a/file.satyh))
-   (packages/grcnum/grcnum.satyh
-    (Filename @@temp_dir@@/pkg/grcnum.satyh))))
+   (packages/grcnum/grcnum.satyh (Filename @@temp_dir@@/pkg/grcnum.satyh))))
  (compatibility
   ((rename_packages
     (((new_name grcnum/a/b-1/c-1/file1.satyh)

--- a/test/testcases/library_write_dir__content.expected
+++ b/test/testcases/library_write_dir__content.expected
@@ -20,7 +20,7 @@ diff -Nr @@empty_dir@@/dest/fonts/Junicode.ttf @@dest_dir@@/dest/fonts/Junicode.
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"Junicode":<"Single":{"src":"dist/fonts/Junicode.ttf"}>}
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2
 > ((version 1) (libraryName "") (libraryVersion "") (compatibility ())
@@ -32,7 +32,7 @@ diff -Nr @@empty_dir@@/dest/packages/List.satyg @@dest_dir@@/dest/packages/List.
 diff -Nr @@empty_dir@@/dest/packages/test.satyg @@dest_dir@@/dest/packages/test.satyg
 0a1
 > let x = 1
-\ ファイル末尾に改行がありません
+\ No newline at end of file
 diff -Nr @@empty_dir@@/dest/unidata/UnicodeData.txt @@dest_dir@@/dest/unidata/UnicodeData.txt
 0a1,3
 > 0000;<control>;Cc;0;BN;;;;;N;NULL;;;;

--- a/test/testcases/library_write_dir__content.expected
+++ b/test/testcases/library_write_dir__content.expected
@@ -20,7 +20,7 @@ diff -Nr @@empty_dir@@/dest/fonts/Junicode.ttf @@dest_dir@@/dest/fonts/Junicode.
 diff -Nr @@empty_dir@@/dest/hash/fonts.satysfi-hash @@dest_dir@@/dest/hash/fonts.satysfi-hash
 0a1
 > {"Junicode":<"Single":{"src":"dist/fonts/Junicode.ttf"}>}
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 0a1,2
 > ((version 1) (libraryName "") (libraryVersion "") (compatibility ())
@@ -32,7 +32,7 @@ diff -Nr @@empty_dir@@/dest/packages/List.satyg @@dest_dir@@/dest/packages/List.
 diff -Nr @@empty_dir@@/dest/packages/test.satyg @@dest_dir@@/dest/packages/test.satyg
 0a1
 > let x = 1
-\ No newline at end of file
+\ ファイル末尾に改行がありません
 diff -Nr @@empty_dir@@/dest/unidata/UnicodeData.txt @@dest_dir@@/dest/unidata/UnicodeData.txt
 0a1,3
 > 0000;<control>;Cc;0;BN;;;;;N;NULL;;;;

--- a/test/testcases/prepareBin.ml
+++ b/test/testcases/prepareBin.ml
@@ -46,7 +46,7 @@ esac
     |}
   in
   String.concat "\n"
-    [ "#!/bin/bash";
+    [ "#!/bin/sh";
       "LOG_FILE='" ^ log_file ^"'";
       "MODE=help";
       "INPUT=";

--- a/test/testcases/testLib.ml
+++ b/test/testcases/testLib.ml
@@ -12,8 +12,10 @@ let repeat_string n s : string =
 let replace_tempdirs =
   let re =
     let open Re in
+    let temp_dir_name = Filename.get_temp_dir_name () in
     seq [
-      str {|/tmp/Satyrographos|};
+      FilePath.concat temp_dir_name "Satyrographos"
+      |> str ;
       repn xdigit 6 (Some 6);
       rep wordc |> group;
     ] |> compile in
@@ -26,6 +28,28 @@ let censor_tempdirs =
 let censor replacements =
   iter_lines (fun s -> Stringext.replace_all_assoc s replacements |> echo)
 
+let reformat_sexp =
+  let re =
+    let open Re in
+    seq [
+      bol;
+      char '(';
+      rep notnl;
+      eol;
+      seq [str "\n "; rep notnl; eol;]
+      |> rep;
+    ] |> group |> compile in
+  let f g =
+    let str = Re.Group.get g 1 in
+    try
+      Sexplib.Sexp.of_string str
+      |> Sexplib.Sexp.to_string_hum
+    with
+    | _ -> str
+  in
+  Shexp_process.read_all
+  >>= (fun s -> Re.replace re ~all:true ~f s |> echo ~n:())
+
 let with_formatter ?(where=Std_io.Stdout) f =
   let buf = Buffer.create 100 in
   let fmt = Format.make_formatter (Buffer.add_substring buf) ignore in
@@ -37,12 +61,13 @@ let echo_line =
   echo "------------------------------------------------------------"
 
 let dump_dir dir : unit t =
-  with_temp_dir ~prefix:"Satyrographos" ~suffix:"dump_dir" (fun empty_dir ->
+  with_temp_dir ~prefix:"Satyrographos" ~suffix:"empty_dir" (fun empty_dir ->
     (run "find" [dir] |- run "sort" [])
     >> echo_line
     >> run_exit_code "diff" ["-Nr"; empty_dir; dir] >>| (fun _ -> ())
     |- censor [ empty_dir, "@@empty_dir@@"; ]
   )
+  |> set_env "LC_ALL" "C"
 
 let stacktrace = false
 
@@ -55,32 +80,54 @@ let test_install ?(replacements=[]) setup f : unit t =
         temp_dir, "@@temp_dir@@";
         Unix.getenv "HOME", "@@home_dir@@";
       ] @ replacements in
+    let filter_output f c =
+      capture [Std_io.Stdout] c
+      >>= fun (v, out) ->
+      echo ~n:() out
+      |- f
+      >> return v
+    in
+    let censor_no_sexp c =
+      filter_output
+        (censor replacements
+         |- censor_tempdirs)
+        c
+    in
+    let censor c =
+      filter_output
+        (censor replacements
+         |- censor_tempdirs
+         |- reformat_sexp)
+        c
+    in
     echo "Installing packages"
     >> echo_line
-    >> setup ~dest_dir ~temp_dir
+    >> censor (setup ~dest_dir ~temp_dir)
     >>= (fun setup_result ->
-      try
-        with_formatter (fun outf -> f setup_result ~dest_dir ~temp_dir ~outf; Format.fprintf outf "@?")
-      with e ->
-        echo "Exception:"
-        >> echo (Printexc.to_string e)
-        >> if stacktrace
-           then echo "Stack trace:"
-             >> echo (Printexc.get_backtrace())
-           else return ()
+        try
+          with_formatter (fun outf -> f setup_result ~dest_dir ~temp_dir ~outf; Format.fprintf outf "@?")
+          |> censor
+        with e ->
+          let c =
+            echo "Exception:"
+            >> echo (Printexc.to_string e)
+            >> if stacktrace
+            then echo "Stack trace:"
+              >> echo (Printexc.get_backtrace())
+            else return ()
+          in censor_no_sexp c
       )
     >> echo_line
-    >> dump_dir dest_dir
+    >> censor (dump_dir dest_dir)
     >>= (fun () ->
-      let log_file = exec_log_file_path temp_dir in
-      if FileUtil.(test Is_file log_file)
-      then echo_line >> stdin_from log_file (iter_lines echo)
-      else return ())
-    |- censor replacements
-    |- censor_tempdirs in
-  (with_temp_dir ~prefix:"Satyrographos" ~suffix:"test_dest"
-    (fun dest_dir ->
-      with_temp_dir ~prefix:"Satyrographos" ~suffix:"test_temp" (test dest_dir)))
+        let log_file = exec_log_file_path temp_dir in
+        if FileUtil.(test Is_file log_file)
+        then echo_line >> stdin_from log_file (censor_no_sexp (iter_lines echo))
+        else return ())
+  in
+  (with_temp_dir ~prefix:"Satyrographos" ~suffix:"dest_dir"
+     (fun dest_dir ->
+        with_temp_dir ~prefix:"Satyrographos" ~suffix:"temp_dir" (test dest_dir)))
 
 let read_env ?repo:_ ?opam_reg ?dist_library_dir () =
   Satyrographos.Environment.{


### PR DESCRIPTION
This PR fixes #86 like below message:

```
Installation completed!

Compatibility notice for library assert-eq:

  Packages have been renamed.
  
    assert-eq.satyg -> assert-eq/assert-eq.satyg

Compatibility notice for library class-exdesign:

  Packages have been renamed.
  
    article-ja.satyh -> class-exdesign/article-ja.satyh
    exdesign.satyh -> class-exdesign/exdesign.satyh

Compatibility notice for library class-slydifi:

  Packages have been renamed.
  
    functions/color.satyh -> class-slydifi/functions/color.satyh
    functions/figbox.satyh -> class-slydifi/functions/figbox.satyh
    functions/footnote.satyh -> class-slydifi/functions/footnote.satyh
    functions/overlay.satyh -> class-slydifi/functions/overlay.satyh
    functions/param.satyh -> class-slydifi/functions/param.satyh
    slydifi.satyh -> class-slydifi/slydifi.satyh
    theme/akasaka.satyh -> class-slydifi/theme/akasaka.satyh
    theme/hakodate.satyh -> class-slydifi/theme/hakodate.satyh
    theme/plain.satyh -> class-slydifi/theme/plain.satyh
...
```