### PR TITLE
Add lint subcommand

### DIFF
--- a/bin/commandLint.ml
+++ b/bin/commandLint.ml
@@ -1,0 +1,23 @@
+open Core
+
+let lint_command =
+  let open Command.Let_syntax in
+  let open RenameOption in
+  let readme () =
+    sprintf {|Check validity of the library.|}
+  in
+  Command.basic
+    ~summary:"Check validity of the library"
+    ~readme
+    [%map_open
+      let verbose = flag "--verbose" no_arg ~aliases:["v"] ~doc:"Verbose"
+      and buildscript_path = flag "--script" (optional string) ~doc:"SCRIPT Install script"
+      in
+      fun () ->
+        Compatibility.optin ();
+        Satyrographos_command.Lint.lint
+          ~outf:Format.std_formatter
+          ~buildscript_path
+          ~verbose;
+        reprint_err_warn ()
+    ]

--- a/bin/dune
+++ b/bin/dune
@@ -3,5 +3,17 @@
  (public_name satyrographos)
  (preprocess (pps ppx_deriving.std ppx_jane -allow-unannotated-ignores))
  (libraries core satyrographos_template satyrographos_command shexp.process uri)
- (modules setup renameOption compatibility commandNew commandInstall commandLibrary commandOpam commandPin commandSatysfi commandStatus main)
+ (modules
+   setup
+   renameOption
+   compatibility
+   commandLint
+   commandNew
+   commandInstall
+   commandLibrary
+   commandOpam
+   commandPin
+   commandSatysfi
+   commandStatus
+   main)
  )

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -8,6 +8,7 @@ let total_command =
       "opam", CommandOpam.opam_command;
       "library", CommandLibrary.library_command;
       "library-opam", CommandLibrary.library_opam_command;
+      "lint", CommandLint.lint_command;
       "satysfi", CommandSatysfi.satysfi_command;
       "status", CommandStatus.status_command;
       "pin", CommandPin.pin_command;

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -24,6 +24,7 @@ depends: [
   "json-derivers"
   "ppx_deriving"
   "opam-format" {>= "2.0" & < "2.1"}
+  "opam-state" {>= "2.0" & < "2.1"}
   "re" {with-test}
   "stringext" {with-test}
   "uri" {>= "3.0.0"}

--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -167,7 +167,7 @@ let get_name = function
   | Library l -> l.name
   | LibraryDoc l -> l.name
 
-let get_opam = function
+let get_opam_opt = function
   | Library l -> Some l.opam
   | LibraryDoc l -> Some l.opam
 

--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -163,6 +163,10 @@ let export_opam_package = function
 let export_opam bs =
   StringMap.iter bs ~f:export_opam_package
 
+let get_dependencies_opt = function
+  | Library l -> Some l.dependencies
+  | LibraryDoc l -> Some l.dependencies
+
 let get_name = function
   | Library l -> l.name
   | LibraryDoc l -> l.name

--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -167,6 +167,10 @@ let get_name = function
   | Library l -> l.name
   | LibraryDoc l -> l.name
 
+let get_opam = function
+  | Library l -> Some l.opam
+  | LibraryDoc l -> Some l.opam
+
 (* Compatibility treatment *)
 let compatibility_treatment (p: library) (l: Library.t) =
   let f = function

--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -171,6 +171,10 @@ let get_opam_opt = function
   | Library l -> Some l.opam
   | LibraryDoc l -> Some l.opam
 
+let get_version_opt = function
+  | Library l -> Some l.version
+  | LibraryDoc l -> Some l.version
+
 (* Compatibility treatment *)
 let compatibility_treatment (p: library) (l: Library.t) =
   let f = function

--- a/src/command/dune
+++ b/src/command/dune
@@ -7,6 +7,7 @@
    fileutils
    opam-core
    opam-format
+   opam-state
    satyrographos
    satyrographos_autogen
    satyrographos_template

--- a/src/command/dune
+++ b/src/command/dune
@@ -2,4 +2,12 @@
  (name satyrographos_command)
  (inline_tests)
  (preprocess (staged_pps ppx_deriving.std ppx_jane -allow-unannotated-ignores))
- (libraries core fileutils satyrographos satyrographos_autogen satyrographos_template shexp.process))
+ (libraries
+   core
+   fileutils
+   opam-core
+   opam-format
+   satyrographos
+   satyrographos_autogen
+   satyrographos_template
+   shexp.process))

--- a/src/command/lint.ml
+++ b/src/command/lint.ml
@@ -1,0 +1,60 @@
+open Core
+open Satyrographos
+
+let show_problem ~outf ~buildscript_path =
+  function
+  | module_name, `E msg ->
+    Format.fprintf outf "@[<2>%s (module %s) Error:@,%s@]@." buildscript_path module_name msg
+  | module_name, `W msg ->
+    Format.fprintf outf "@[<2>%s (module %s) Warning:@,%s@]@." buildscript_path module_name msg
+
+let show_problems ~outf ~buildscript_path =
+  List.iter ~f:(show_problem ~outf ~buildscript_path)
+
+let lint_module_opam ~basedir ~buildscript_basename:_ (m : BuildScript.m) opam_path =
+  let opam_file =
+    OpamFilename.create (OpamFilename.Dir.of_string basedir) (OpamFilename.Base.of_string opam_path)
+      |> OpamFile.make
+  in
+  let open OpamFile in
+  let opam = OPAM.read opam_file in
+  let opam_name =
+    OPAM.name_opt opam
+    |> Option.map ~f:OpamPackage.Name.to_string
+    |> Option.value ~default:(FilePath.basename opam_path |> FilePath.chop_extension)
+  in
+  let test_name module_name opam_name =
+    if String.equal ("satysfi-" ^ module_name) opam_name |> not
+    then (module_name, `E (sprintf "OPAM package name “%s” should be “satysfi-%s”." opam_name module_name))
+         |> Option.some
+    else None
+  in
+  List.filter_opt
+    [ test_name (BuildScript.get_name m) opam_name
+    ]
+
+let lint_module ~basedir ~buildscript_basename (m : BuildScript.m) =
+  let opam_problems =
+    BuildScript.get_opam m
+    |> Option.map ~f:(lint_module_opam ~basedir ~buildscript_basename m)
+    |> Option.value ~default:[]
+  in
+  opam_problems
+
+let lint ~outf ~verbose:_ ~buildscript_path =
+  let buildscript_path = Option.value ~default:"Satyristes" buildscript_path in
+  let buildscript_path =
+    let cwd = FileUtil.pwd () in
+    FilePath.make_absolute cwd buildscript_path
+  in
+  let basedir = FilePath.dirname buildscript_path in
+  let buildscript_basename = FilePath.basename buildscript_path in
+  let buildscript = BuildScript.from_file buildscript_path in
+  let problems =
+    Map.to_alist buildscript
+    |> List.concat_map ~f:(fun (_, m) ->
+        lint_module ~basedir ~buildscript_basename m)
+  in
+  show_problems ~outf ~buildscript_path problems;
+  List.length problems
+  |> Format.fprintf outf "%d problem(s) found.@."

--- a/src/command/lint.ml
+++ b/src/command/lint.ml
@@ -28,6 +28,11 @@ let show_problem ~outf ~basedir (locs, level, msg) =
 let show_problems ~outf ~basedir =
   List.iter ~f:(show_problem ~outf ~basedir)
 
+let lint_opam_file ~opam ~opam_path:_ ~loc =
+  OpamFileTools.lint opam
+  |> List.map ~f:(fun (error_no, level, msg) ->
+      loc, level, sprintf "(%d) %s" error_no msg)
+
 let get_opam_name ~opam ~opam_path =
   OpamFile.OPAM.name_opt opam
   |> Option.map ~f:OpamPackage.Name.to_string
@@ -85,6 +90,7 @@ let lint_module_opam ~loc ~basedir ~buildscript_basename:_ (m : BuildScript.m) o
   List.concat
     [ test_name;
       test_version;
+      lint_opam_file ~opam ~opam_path ~loc;
     ]
 
 let lint_module ~basedir ~buildscript_basename (m : BuildScript.m) =

--- a/test/testcases/command_lint__invalid_opam_file.expected
+++ b/test/testcases/command_lint__invalid_opam_file.expected
@@ -1,0 +1,6 @@
+@@test_library@@/Satyristes (module package):
+@@test_library@@/satysfi-package.opam:
+Warning:
+  (47) Synopsis (or description first line) should start with a capital and not end with a dot
+
+1 problem(s) found.

--- a/test/testcases/command_lint__invalid_opam_file.ml
+++ b/test/testcases/command_lint__invalid_opam_file.ml
@@ -1,0 +1,28 @@
+open Core
+
+let satysfi_package_opam =
+  "satysfi-package.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package"
+    ~synopsis:""
+    ~version:"0.1"
+    ()
+
+let satyristes =
+  "Satyristes", sprintf
+    {|(version "0.0.2")
+
+(library
+  (name "package")
+  (version "0.1")
+  (sources ())
+  (opam "satysfi-package.opam")
+  (dependencies ()))
+|}
+
+let files =
+  [ satysfi_package_opam;
+    satyristes;
+  ]
+
+let () =
+  TestCommand.test_lint_command files

--- a/test/testcases/command_lint__missing_dependencies.expected
+++ b/test/testcases/command_lint__missing_dependencies.expected
@@ -1,0 +1,11 @@
+@@test_library@@/Satyristes (module package):
+@@test_library@@/satysfi-package.opam:
+Warning:
+  The OPAM file lacks dependencies on specified SATySFi libraries: (unspecified-package).
+
+@@test_library@@/Satyristes (module package-doc):
+@@test_library@@/satysfi-package-doc.opam:
+Warning:
+  The OPAM file lacks dependencies on specified SATySFi libraries: (package).
+
+2 problem(s) found.

--- a/test/testcases/command_lint__missing_dependencies.ml
+++ b/test/testcases/command_lint__missing_dependencies.ml
@@ -10,12 +10,6 @@ let satysfi_package_doc_opam =
   "satysfi-package-doc.opam", TestLib.opam_file_for_test
     ~name:"satysfi-package-doc"
     ~version:"0.1"
-    ~depends:{|
-  "satysfi" {>= "0.0.5" & < "0.0.6"}
-  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
-
-  "satysfi-package" {= "0.1"}
-|}
     ()
 
 let satyristes =
@@ -27,7 +21,7 @@ let satyristes =
   (version "0.1")
   (sources ())
   (opam "satysfi-package.opam")
-  (dependencies ()))
+  (dependencies ((unspecified-package ()))))
 
 (libraryDoc
   (name "package-doc")

--- a/test/testcases/command_lint__missing_opam.expected
+++ b/test/testcases/command_lint__missing_opam.expected
@@ -1,0 +1,2 @@
+Exception:
+OpamSystem.Internal_error("File @@test_library@@/satysfi-package.opam does not exist or can't be read")

--- a/test/testcases/command_lint__missing_opam.ml
+++ b/test/testcases/command_lint__missing_opam.ml
@@ -1,9 +1,10 @@
 open Core
 
-let opam_file_without_name_field =
-  "satysfi-package-doc.opam", sprintf
-    {|opam-version: "2.0"
-|}
+let satysfi_package_doc_opam =
+  "satysfi-package-doc.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package-doc"
+    ~version:"0.1"
+    ()
 
 let satyristes =
   "Satyristes", sprintf
@@ -26,7 +27,7 @@ let satyristes =
 |}
 
 let files =
-  [ opam_file_without_name_field;
+  [ satysfi_package_doc_opam;
     satyristes;
   ]
 

--- a/test/testcases/command_lint__missing_opam.ml
+++ b/test/testcases/command_lint__missing_opam.ml
@@ -1,0 +1,34 @@
+open Core
+
+let opam_file_without_name_field =
+  "satysfi-package-doc.opam", sprintf
+    {|opam-version: "2.0"
+|}
+
+let satyristes =
+  "Satyristes", sprintf
+    {|(version "0.0.2")
+
+(library
+  (name "package")
+  (version "0.1")
+  (sources ())
+  (opam "satysfi-package.opam")
+  (dependencies ()))
+
+(libraryDoc
+  (name "package-doc")
+  (version "0.1")
+  (build ())
+  (sources ())
+  (opam "satysfi-package-doc.opam")
+  (dependencies ((package ()))))
+|}
+
+let files =
+  [ opam_file_without_name_field;
+    satyristes;
+  ]
+
+let () =
+  TestCommand.test_lint_command files

--- a/test/testcases/command_lint__missing_satyristes.expected
+++ b/test/testcases/command_lint__missing_satyristes.expected
@@ -1,0 +1,3 @@
+Exception:
+(Sys_error
+  "@@test_library@@/Satyristes: No such file or directory")

--- a/test/testcases/command_lint__missing_satyristes.ml
+++ b/test/testcases/command_lint__missing_satyristes.ml
@@ -1,18 +1,18 @@
-open Core
+let satysfi_package_opam =
+  "satysfi-package.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package"
+    ~version:"0.1"
+    ()
 
-let opam_file_with_name_field =
-  "satysfi-package.opam", sprintf
-    {|opam-version: "2.0"
-|}
-
-let opam_file_without_name_field =
-  "satysfi-package-doc.opam", sprintf
-    {|opam-version: "2.0"
-|}
+let satysfi_package_doc_opam =
+  "satysfi-package-doc.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package-doc"
+    ~version:"0.1"
+    ()
 
 let files =
-  [ opam_file_with_name_field;
-    opam_file_without_name_field;
+  [ satysfi_package_opam;
+    satysfi_package_doc_opam;
   ]
 
 let () =

--- a/test/testcases/command_lint__missing_satyristes.ml
+++ b/test/testcases/command_lint__missing_satyristes.ml
@@ -1,0 +1,19 @@
+open Core
+
+let opam_file_with_name_field =
+  "satysfi-package.opam", sprintf
+    {|opam-version: "2.0"
+|}
+
+let opam_file_without_name_field =
+  "satysfi-package-doc.opam", sprintf
+    {|opam-version: "2.0"
+|}
+
+let files =
+  [ opam_file_with_name_field;
+    opam_file_without_name_field;
+  ]
+
+let () =
+  TestCommand.test_lint_command files

--- a/test/testcases/command_lint__unmatched_names.expected
+++ b/test/testcases/command_lint__unmatched_names.expected
@@ -1,5 +1,11 @@
-@@test_library@@/Satyristes (module package) Error:
+@@test_library@@/Satyristes (module package):
+@@test_library@@/satysfi-package.opam:
+Error:
   OPAM package name “satysfi-package-mark-ii” should be “satysfi-package”.
-@@test_library@@/Satyristes (module package-doc) Error:
+
+@@test_library@@/Satyristes (module package-doc):
+@@test_library@@/satysfi-package-document.opam:
+Error:
   OPAM package name “satysfi-package-document” should be “satysfi-package-doc”.
+
 2 problem(s) found.

--- a/test/testcases/command_lint__unmatched_names.expected
+++ b/test/testcases/command_lint__unmatched_names.expected
@@ -1,0 +1,5 @@
+@@test_library@@/Satyristes (module package) Error:
+  OPAM package name “satysfi-package-mark-ii” should be “satysfi-package”.
+@@test_library@@/Satyristes (module package-doc) Error:
+  OPAM package name “satysfi-package-document” should be “satysfi-package-doc”.
+2 problem(s) found.

--- a/test/testcases/command_lint__unmatched_names.ml
+++ b/test/testcases/command_lint__unmatched_names.ml
@@ -1,0 +1,40 @@
+open Core
+
+let opam_file_with_name_field =
+  "satysfi-package.opam", sprintf
+    {|opam-version: "2.0"
+name: "satysfi-package-mark-ii"
+|}
+
+let opam_file_without_name_field =
+  "satysfi-package-document.opam", sprintf
+    {|opam-version: "2.0"|}
+
+let satyristes =
+  "Satyristes", sprintf
+    {|(version "0.0.2")
+
+(library
+  (name "package")
+  (version "0.1")
+  (sources ())
+  (opam "satysfi-package.opam")
+  (dependencies ()))
+
+(libraryDoc
+  (name "package-doc")
+  (version "0.1")
+  (build ())
+  (sources ())
+  (opam "satysfi-package-document.opam")
+  (dependencies ((package ()))))
+|}
+
+let files =
+  [ opam_file_with_name_field;
+    opam_file_without_name_field;
+    satyristes;
+  ]
+
+let () =
+  TestCommand.test_lint_command files

--- a/test/testcases/command_lint__unmatched_names.ml
+++ b/test/testcases/command_lint__unmatched_names.ml
@@ -11,6 +11,12 @@ let opam_file_without_name_field =
   "satysfi-package-document.opam", TestLib.opam_file_for_test
     ?name:None
     ~version:"0.1"
+    ~depends:{|
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+
+  "satysfi-package" {= "0.1"}
+|}
     ()
 
 let satyristes =

--- a/test/testcases/command_lint__unmatched_names.ml
+++ b/test/testcases/command_lint__unmatched_names.ml
@@ -1,14 +1,17 @@
 open Core
 
 let opam_file_with_name_field =
-  "satysfi-package.opam", sprintf
-    {|opam-version: "2.0"
-name: "satysfi-package-mark-ii"
-|}
+  "satysfi-package.opam",
+  TestLib.opam_file_for_test
+    ~name:"satysfi-package-mark-ii"
+    ~version:"0.1"
+    ()
 
 let opam_file_without_name_field =
-  "satysfi-package-document.opam", sprintf
-    {|opam-version: "2.0"|}
+  "satysfi-package-document.opam", TestLib.opam_file_for_test
+    ?name:None
+    ~version:"0.1"
+    ()
 
 let satyristes =
   "Satyristes", sprintf

--- a/test/testcases/command_lint__unmatched_versions.expected
+++ b/test/testcases/command_lint__unmatched_versions.expected
@@ -1,0 +1,17 @@
+@@test_library@@/Satyristes (module package):
+@@test_library@@/satysfi-package.opam:
+Error: OPAM package version “0.0.1” should be prefixed with “0.1”.
+
+@@test_library@@/Satyristes (module package-doc):
+@@test_library@@/satysfi-package-doc.opam:
+Error: OPAM file lacks the version field
+
+@@test_library@@/Satyristes (module package-end-with-alpha):
+@@test_library@@/satysfi-package-end-with-alpha.opam:
+Error: OPAM package version “0ab” should be prefixed with “0a”.
+
+@@test_library@@/Satyristes (module package-end-with-digit):
+@@test_library@@/satysfi-package-end-with-digit.opam:
+Error: OPAM package version “0.11” should be prefixed with “0.1”.
+
+4 problem(s) found.

--- a/test/testcases/command_lint__unmatched_versions.ml
+++ b/test/testcases/command_lint__unmatched_versions.ml
@@ -25,6 +25,12 @@ let opam_file_without_version_field =
   "satysfi-package-doc.opam", TestLib.opam_file_for_test
     ~name:"satysfi-package-doc"
     ?version:None
+    ~depends:{|
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+
+  "satysfi-package" {= "0.1"}
+|}
     ()
 
 let satyristes =

--- a/test/testcases/command_lint__unmatched_versions.ml
+++ b/test/testcases/command_lint__unmatched_versions.ml
@@ -1,0 +1,73 @@
+open Core
+
+let opam_file_with_version_field =
+  "satysfi-package.opam",
+  TestLib.opam_file_for_test
+    ~name:"satysfi-package"
+    ~version:"0.0.1"
+    ()
+
+let opam_file_with_version_field_digit =
+  "satysfi-package-end-with-digit.opam",
+  TestLib.opam_file_for_test
+    ~name:"satysfi-package-end-with-digit"
+    ~version:"0.11"
+    ()
+
+let opam_file_with_version_field_alpha =
+  "satysfi-package-end-with-alpha.opam",
+  TestLib.opam_file_for_test
+    ~name:"satysfi-package-end-with-alpha"
+    ~version:"0ab"
+    ()
+
+let opam_file_without_version_field =
+  "satysfi-package-doc.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package-doc"
+    ?version:None
+    ()
+
+let satyristes =
+  "Satyristes", sprintf
+    {|(version "0.0.2")
+
+(library
+  (name "package")
+  (version "0.1")
+  (sources ())
+  (opam "satysfi-package.opam")
+  (dependencies ()))
+
+(library
+  (name "package-end-with-digit")
+  (version "0.1")
+  (sources ())
+  (opam "satysfi-package-end-with-digit.opam")
+  (dependencies ()))
+
+(library
+  (name "package-end-with-alpha")
+  (version "0a")
+  (sources ())
+  (opam "satysfi-package-end-with-alpha.opam")
+  (dependencies ()))
+
+(libraryDoc
+  (name "package-doc")
+  (version "0.1")
+  (build ())
+  (sources ())
+  (opam "satysfi-package-doc.opam")
+  (dependencies ((package ()))))
+|}
+
+let files =
+  [ opam_file_with_version_field;
+    opam_file_with_version_field_digit;
+    opam_file_with_version_field_alpha;
+    opam_file_without_version_field;
+    satyristes;
+  ]
+
+let () =
+  TestCommand.test_lint_command files

--- a/test/testcases/command_lint__valid.expected
+++ b/test/testcases/command_lint__valid.expected
@@ -1,0 +1,1 @@
+0 problem(s) found.

--- a/test/testcases/command_lint__valid.ml
+++ b/test/testcases/command_lint__valid.ml
@@ -1,14 +1,16 @@
 open Core
 
-let opam_file_with_name_field =
-  "satysfi-package.opam", sprintf
-    {|opam-version: "2.0"
-|}
+let satysfi_package_opam =
+  "satysfi-package.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package"
+    ~version:"0.1"
+    ()
 
-let opam_file_without_name_field =
-  "satysfi-package-doc.opam", sprintf
-    {|opam-version: "2.0"
-|}
+let satysfi_package_doc_opam =
+  "satysfi-package-doc.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package-doc"
+    ~version:"0.1"
+    ()
 
 let satyristes =
   "Satyristes", sprintf
@@ -31,8 +33,8 @@ let satyristes =
 |}
 
 let files =
-  [ opam_file_with_name_field;
-    opam_file_without_name_field;
+  [ satysfi_package_opam;
+    satysfi_package_doc_opam;
     satyristes;
   ]
 

--- a/test/testcases/command_lint__valid.ml
+++ b/test/testcases/command_lint__valid.ml
@@ -1,0 +1,40 @@
+open Core
+
+let opam_file_with_name_field =
+  "satysfi-package.opam", sprintf
+    {|opam-version: "2.0"
+|}
+
+let opam_file_without_name_field =
+  "satysfi-package-doc.opam", sprintf
+    {|opam-version: "2.0"
+|}
+
+let satyristes =
+  "Satyristes", sprintf
+    {|(version "0.0.2")
+
+(library
+  (name "package")
+  (version "0.1")
+  (sources ())
+  (opam "satysfi-package.opam")
+  (dependencies ()))
+
+(libraryDoc
+  (name "package-doc")
+  (version "0.1")
+  (build ())
+  (sources ())
+  (opam "satysfi-package-doc.opam")
+  (dependencies ((package ()))))
+|}
+
+let files =
+  [ opam_file_with_name_field;
+    opam_file_without_name_field;
+    satyristes;
+  ]
+
+let () =
+  TestCommand.test_lint_command files

--- a/test/testcases/command_lint__valid_in_specified_location.expected
+++ b/test/testcases/command_lint__valid_in_specified_location.expected
@@ -1,0 +1,1 @@
+0 problem(s) found.

--- a/test/testcases/command_lint__valid_in_specified_location.ml
+++ b/test/testcases/command_lint__valid_in_specified_location.ml
@@ -1,14 +1,16 @@
 open Core
 
-let opam_file_with_name_field =
-  "satysfi-package.opam", sprintf
-    {|opam-version: "2.0"
-|}
+let satysfi_package_opam =
+  "satysfi-package.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package"
+    ~version:"0.1"
+    ()
 
-let opam_file_without_name_field =
-  "satysfi-package-doc.opam", sprintf
-    {|opam-version: "2.0"
-|}
+let satysfi_package_doc_opam =
+  "satysfi-package-doc.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package-doc"
+    ~version:"0.1"
+    ()
 
 let satyristes =
   "Satyristes", sprintf
@@ -31,8 +33,8 @@ let satyristes =
 |}
 
 let files =
-  [ opam_file_with_name_field;
-    opam_file_without_name_field;
+  [ satysfi_package_opam;
+    satysfi_package_doc_opam;
     satyristes;
   ]
 

--- a/test/testcases/command_lint__valid_in_specified_location.ml
+++ b/test/testcases/command_lint__valid_in_specified_location.ml
@@ -1,0 +1,43 @@
+open Core
+
+let opam_file_with_name_field =
+  "satysfi-package.opam", sprintf
+    {|opam-version: "2.0"
+|}
+
+let opam_file_without_name_field =
+  "satysfi-package-doc.opam", sprintf
+    {|opam-version: "2.0"
+|}
+
+let satyristes =
+  "Satyristes", sprintf
+    {|(version "0.0.2")
+
+(library
+  (name "package")
+  (version "0.1")
+  (sources ())
+  (opam "satysfi-package.opam")
+  (dependencies ()))
+
+(libraryDoc
+  (name "package-doc")
+  (version "0.1")
+  (build ())
+  (sources ())
+  (opam "satysfi-package-doc.opam")
+  (dependencies ((package ()))))
+|}
+
+let files =
+  [ opam_file_with_name_field;
+    opam_file_without_name_field;
+    satyristes;
+  ]
+
+let () =
+  let f cwd =
+    ".", Some (FilePath.concat cwd "Satyristes")
+  in
+  TestCommand.test_lint_command ~f files

--- a/test/testcases/command_lint__valid_in_specified_location.ml
+++ b/test/testcases/command_lint__valid_in_specified_location.ml
@@ -10,6 +10,12 @@ let satysfi_package_doc_opam =
   "satysfi-package-doc.opam", TestLib.opam_file_for_test
     ~name:"satysfi-package-doc"
     ~version:"0.1"
+    ~depends:{|
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+
+  "satysfi-package" {= "0.1"}
+|}
     ()
 
 let satyristes =

--- a/test/testcases/command_lint__valid_versions.expected
+++ b/test/testcases/command_lint__valid_versions.expected
@@ -1,0 +1,1 @@
+0 problem(s) found.

--- a/test/testcases/command_lint__valid_versions.ml
+++ b/test/testcases/command_lint__valid_versions.ml
@@ -1,0 +1,80 @@
+open Core
+
+let opam_file_alpha_digit =
+  "satysfi-package-alpha-digit.opam",
+  TestLib.opam_file_for_test
+    ~name:"satysfi-package-alpha-digit"
+    ~version:"0a1"
+    ()
+
+let opam_file_alpha_symb =
+  "satysfi-package-alpha-symb.opam",
+  TestLib.opam_file_for_test
+    ~name:"satysfi-package-alpha-symb"
+    ~version:"0a+1"
+    ()
+
+let opam_file_digit_alpha =
+  "satysfi-package-digit-alpha.opam",
+  TestLib.opam_file_for_test
+    ~name:"satysfi-package-digit-alpha"
+    ~version:"0.1a"
+    ()
+
+let opam_file_digit_symb =
+  "satysfi-package-digit-symb.opam",
+  TestLib.opam_file_for_test
+    ~name:"satysfi-package-digit-symb"
+    ~version:"0.1+1"
+    ()
+
+let opam_file_with_version_field_alpha =
+  "satysfi-package-end-with-alpha.opam",
+  TestLib.opam_file_for_test
+    ~name:"satysfi-package-end-with-alpha"
+    ~version:"0a0"
+    ()
+
+let satyristes =
+  "Satyristes", sprintf
+    {|(version "0.0.2")
+
+(library
+  (name "package-alpha-digit")
+  (version "0a")
+  (sources ())
+  (opam "satysfi-package-alpha-digit.opam")
+  (dependencies ()))
+
+(library
+  (name "package-alpha-symb")
+  (version "0a")
+  (sources ())
+  (opam "satysfi-package-alpha-symb.opam")
+  (dependencies ()))
+
+(library
+  (name "package-digit-alpha")
+  (version "0.1")
+  (sources ())
+  (opam "satysfi-package-digit-alpha.opam")
+  (dependencies ()))
+
+(library
+  (name "package-digit-symb")
+  (version "0.1")
+  (sources ())
+  (opam "satysfi-package-digit-symb.opam")
+  (dependencies ()))
+|}
+
+let files =
+  [ opam_file_alpha_digit;
+    opam_file_alpha_symb;
+    opam_file_digit_alpha;
+    opam_file_digit_symb;
+    satyristes;
+  ]
+
+let () =
+  TestCommand.test_lint_command files

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -18,8 +18,10 @@
    command_lint__missing_opam
    command_lint__missing_satyristes
    command_lint__unmatched_names
+   command_lint__unmatched_versions
    command_lint__valid
    command_lint__valid_in_specified_location
+   command_lint__valid_versions
    command_opam_build__doc_satysfi
    command_opam_install__doc
    command_opam_install__library

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -15,6 +15,7 @@
    command_install_l__independentTwo
    command_install_l__thirdParties_brokenDependency
    command_install_l__transitive
+   command_lint__invalid_opam_file
    command_lint__missing_opam
    command_lint__missing_satyristes
    command_lint__unmatched_names

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -15,6 +15,11 @@
    command_install_l__independentTwo
    command_install_l__thirdParties_brokenDependency
    command_install_l__transitive
+   command_lint__missing_opam
+   command_lint__missing_satyristes
+   command_lint__unmatched_names
+   command_lint__valid
+   command_lint__valid_in_specified_location
    command_opam_build__doc_satysfi
    command_opam_install__doc
    command_opam_install__library

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -16,6 +16,7 @@
    command_install_l__thirdParties_brokenDependency
    command_install_l__transitive
    command_lint__invalid_opam_file
+   command_lint__missing_dependencies
    command_lint__missing_opam
    command_lint__missing_satyristes
    command_lint__unmatched_names

--- a/test/testcases/prepareOpamReg.ml
+++ b/test/testcases/prepareOpamReg.ml
@@ -1,6 +1,3 @@
-open Shexp_process
-open Shexp_process.Infix
-
 let theanoMetadata = "fonts-theano/metadata",
 {|((version 1) (libraryName fonts-theano) (libraryVersion 2.0)
  (compatibility
@@ -51,10 +48,7 @@ let baseFiles = [
 (dependencies ()))|};
   "base/packages/base/void.satyh", "@@void.satyh@@"; ]
 
-let prepare dir files =
-  List.iter files ~f:(fun (file, content) ->
-    let path = FilePath.concat dir file in
-    mkdir ~p:() (FilePath.dirname path)
-    >> (stdout_to path (echo content))
-  )
+(* TODO Remove this function *)
+let prepare =
+  TestLib.prepare_files
 

--- a/test/testcases/testCommand.ml
+++ b/test/testcases/testCommand.ml
@@ -1,0 +1,17 @@
+let test_lint_command ?(f=fun cwd -> cwd, None) files =
+  let open Shexp_process in
+  let open Shexp_process.Infix in
+  let test_cmd =
+    Shexp_process.cwd_logical
+    >>= fun cwd ->
+    TestLib.run_function (fun ~outf ->
+        let cwd, path = f cwd in
+        Unix.chdir cwd;
+        Satyrographos_command.Lint.lint ~outf ~verbose:false ~buildscript_path:path)
+  in
+  let test_cmd test_dir =
+    TestLib.prepare_files test_dir files
+    >> Shexp_process.chdir test_dir test_cmd
+  in
+  with_temp_dir ~prefix:"Satyrographos" ~suffix:"test_library" test_cmd
+  |> Shexp_process.eval

--- a/test/testcases/testLib.ml
+++ b/test/testcases/testLib.ml
@@ -14,8 +14,11 @@ let replace_tempdirs =
     let open Re in
     let temp_dir_name = Filename.get_temp_dir_name () in
     seq [
+      (* Mac OS X links /var to /private/var, which sometime appears *)
+      str "/private"
+      |> opt;
       FilePath.concat temp_dir_name "Satyrographos"
-      |> str ;
+      |> str;
       repn xdigit 6 (Some 6);
       rep wordc |> group;
     ] |> compile in

--- a/test/testcases/testLib.ml
+++ b/test/testcases/testLib.ml
@@ -137,3 +137,10 @@ let read_env ?repo:_ ?opam_reg ?dist_library_dir () =
       | None -> None end;
     dist_library_dir;
   }
+
+let prepare_files dir files =
+  List.iter files ~f:(fun (file, content) ->
+      let path = FilePath.concat dir file in
+      mkdir ~p:() (FilePath.dirname path)
+      >> (stdout_to path (echo content))
+    )

--- a/test/testcases/testLib.ml
+++ b/test/testcases/testLib.ml
@@ -169,3 +169,52 @@ let prepare_files dir files =
       mkdir ~p:() (FilePath.dirname path)
       >> (stdout_to path (echo content))
     )
+
+let opam_file_for_test
+  ?(synopsis="Test Package")
+  ?name
+  ?version
+  ?(description="Test package for SATySFi")
+  ?(depends={|
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+
+  "satysfi-base" {>= "1.3.0" & < "2"}
+  "satysfi-fonts-junicode" {>= "1" & < "2"}
+|})
+  ?(satysfi_name="test-package")
+  ()
+  =
+  let name =
+    Option.map (Printf.sprintf {|name: "%s"|}) name
+    |> Option.value ~default:""
+  in
+  let version =
+    Option.map (Printf.sprintf {|version: "%s"|}) version
+    |> Option.value ~default:""
+  in
+  Printf.sprintf
+    {|opam-version: "2.0"
+synopsis: "%s"
+%s
+%s
+description: """
+%s
+"""
+maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/na4zagin3/satysfi-fss"
+dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
+bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
+depends: [
+%s
+]
+build: [ ]
+install: [
+  ["satyrographos" "opam" "install"
+   "--name" "%s"
+   "--prefix" "%%{prefix}%%"
+   "--script" "%%{build}%%/Satyristes"]
+]
+|} synopsis name version description depends satysfi_name

--- a/test/testcases/testLib.mli
+++ b/test/testcases/testLib.mli
@@ -27,3 +27,7 @@ val test_install :
   unit t
 
 val read_env : ?repo:unit -> ?opam_reg:string -> ?dist_library_dir:string -> unit -> Satyrographos.Environment.t
+
+val prepare_files :
+  string -> (string * string) list -> unit t
+(** [prepare_files dir files] creates [files] under [directory] *)

--- a/test/testcases/testLib.mli
+++ b/test/testcases/testLib.mli
@@ -39,3 +39,9 @@ val read_env : ?repo:unit -> ?opam_reg:string -> ?dist_library_dir:string -> uni
 val prepare_files :
   string -> (string * string) list -> unit t
 (** [prepare_files dir files] creates [files] under [directory] *)
+
+val opam_file_for_test :
+  ?synopsis:string ->
+  ?name:string ->
+  ?version:string ->
+  ?description:string -> ?depends:string -> ?satysfi_name:string -> unit -> string

--- a/test/testcases/testLib.mli
+++ b/test/testcases/testLib.mli
@@ -10,6 +10,10 @@ val censor : (string * string) list -> unit t
 
     [wordlist] is an associative list of pairs of a censored word and a replecement. *)
 
+val censor_tempdirs : unit t
+(** [censor_tempdirs] returns a Shexp process which behaves like a sed which masks
+    paths to temporary directories *)
+
 val with_formatter : ?where:Std_io.t -> (Format.formatter -> 'a) -> 'a t
 (** [with_formatter ~where f] returns a Shexp process which executes [f] with a formatter which redirect to
     the given Shexp IO [where], whose default value is [Stdout] *)
@@ -19,6 +23,10 @@ val echo_line : unit t
 
 val dump_dir : string -> unit t
 (** [dump_dir dir] returns a Shexp process which dumps directory [dir]’s content to Stdout. *)
+
+val run_function : (outf:Format.formatter -> unit) -> unit t
+(** [run_fuction f] return a Shexp running [f ~outf] where [~outf] is a Formatter.
+    Exceptions raised by [f] will be caught and its stacktraces will be output. *)
 
 val test_install :
   ?replacements:(string * string) list ->


### PR DESCRIPTION
This PR adds `lint` subcommand to check validity of Satyristes and OPAM files.

The command checks...

- if OPAM package names follow Satyristes naming convention;
- if each OPAM package version prefixed with Satyristes module version (e.g., if Satyristes module version is `0.1`, OPAM package versions should be for example `0.1+1`, `0.1a`, `0.1.1` but not `0.11`, `1` etc.);
- if each OPAM package has OPAM package dependencies corresponding to dependencies described in Satyristes; and
- if each OPAM file has no errors

Closes https://github.com/na4zagin3/satyrographos/issues/150