### PR TITLE
Fix typo SATYSFI_ROOT

### DIFF
--- a/bin/commandInstall.ml
+++ b/bin/commandInstall.ml
@@ -16,7 +16,7 @@ let install_command =
       and autogen_library_list = long_flag_listed "autogen" string ~aliases:["a"] ~doc_arg:"AUTOGEN" ~doc:"Enable non-default autogen libraries (e.g., %libraries) (EXPERIMENTAL)"
       and library_list = long_flag_listed "library" string ~aliases:["l"] ~doc_arg:"LIBRARY" ~doc:"Library"
       and target_dir_old = anon (maybe ("DIR" %: string))
-      and target_dir = long_flag_optional "output" string ~doc_arg:"SATYSFI_ROOT" ~doc:("Install files to (default: " ^ default_target_dir ^ ")")
+      and target_dir = long_flag_optional "output" string ~doc_arg:"DIR" ~doc:("Install files to (default: " ^ default_target_dir ^ ")")
       and verbose = long_flag_bool "verbose" no_arg ~doc:"Make verbose"
       and copy = long_flag_bool "copy" no_arg ~doc:"Copy files instead of making symlinks"
       in

--- a/bin/renameOption.ml
+++ b/bin/renameOption.ml
@@ -58,7 +58,7 @@ let long_flag_f rename_f arg_f ?doc_arg flag_name ?(aliases) arg ~doc =
   let doc_prefix = Option.map ~f:(fun x -> x ^ " ") doc_arg |> Option.value ~default:"" in
   [%map_open
     let new_opt = flag ("--" ^ flag_name) (arg_f arg) ?aliases ~doc:(doc_prefix ^ doc)
-    and old_opt = flag (flag_name) (arg_f arg) ~doc:(doc_prefix ^ "Deprecated. Use --" ^ flag_name ^ "instead")
+    and old_opt = flag (flag_name) (arg_f arg) ~doc:(doc_prefix ^ "Deprecated. Use --" ^ flag_name ^ " instead")
     in
       rename_f ("-" ^ flag_name) old_opt
         ("--" ^ flag_name) new_opt


### PR DESCRIPTION
Especially SATYSFI_ROOT is too confusing because SATYSFI_ROOT environment
variable is used to specify something like ~/.satysfi rather than ~/.satysfi/dist.