### PR TITLE
Add DependencyGraph module

### DIFF
--- a/bin/commandDebug.ml
+++ b/bin/commandDebug.ml
@@ -1,0 +1,40 @@
+open Core
+
+open Satyrographos_satysfi
+
+
+let depgraph_command =
+  let open Command.Let_syntax in
+  let readme () =
+    sprintf "Output dependency graph (EXPERIMENTAL)"
+  in
+  Command.basic
+    ~summary:"Output dependency graph"
+    ~readme
+    [%map_open
+      let runtime_dirs = flag "--satysfi-root-dirs" (optional string) ~aliases:["C"] ~doc:"DIRs Colon-separated list of SATySFi root directories"
+      and _verbose = flag "--verbose" no_arg ~doc:"Make verbose"
+      and follow_required = flag "--follow-required" no_arg ~aliases:["r"] ~doc:"Follow required package files"
+      and satysfi_files = anon (non_empty_sequence_as_list ("FILE" %: string))
+      in
+      fun () ->
+        Compatibility.optin ();
+        let runtime_dirs = match runtime_dirs with
+          | Some runtime_dirs ->
+            String.split ~on:':' runtime_dirs
+          | None ->
+            let open SatysfiDirs in
+            Option.to_list (user_dir ()) @ runtime_dirs ()
+        in
+        let outf = Format.err_formatter in
+        (* TODO detect Satysfi version *)
+        let satysfi_version = Version.Satysfi_0_0_5 in
+        let package_root_dirs = SatysfiDirs.expand_package_root_dirs ~satysfi_version runtime_dirs in
+        let g = DependencyGraph.dependency_graph ~outf ~package_root_dirs ~follow_required satysfi_files in
+        DependencyGraph.Dot.fprint_graph Format.std_formatter g
+    ]
+
+let debug_command =
+  Command.group ~summary:"SATySFi related utilities for debugging Satyrographos (experimental)"
+    [ "depgraph", depgraph_command;
+    ]

--- a/bin/dune
+++ b/bin/dune
@@ -2,11 +2,19 @@
  (name main)
  (public_name satyrographos)
  (preprocess (pps ppx_deriving.std ppx_jane -allow-unannotated-ignores))
- (libraries core satyrographos_template satyrographos_command shexp.process uri)
+ (libraries
+   core
+   satyrographos_template
+   satyrographos_command
+   satyrographos_satysfi
+   shexp.process
+   uri
+ )
  (modules
    setup
    renameOption
    compatibility
+   commandDebug
    commandLint
    commandNew
    commandInstall

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4,6 +4,7 @@ open Core
 let total_command =
   Command.group ~summary:"Simple SATySFi Package Manager"
     [
+      "debug", CommandDebug.debug_command;
       "new", CommandNew.new_command;
       "opam", CommandOpam.opam_command;
       "library", CommandLibrary.library_command;

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -23,6 +23,7 @@ depends: [
   "fileutils"
   "json-derivers"
   "ppx_deriving"
+  "ocamlgraph"
   "opam-format" {>= "2.0" & < "2.1"}
   "opam-state" {>= "2.0" & < "2.1"}
   "re" {with-test}

--- a/src/satysfi/dependency.ml
+++ b/src/satysfi/dependency.ml
@@ -1,0 +1,181 @@
+open Core
+
+type directive =
+  | Import of string
+  | Require of string
+[@@deriving sexp, compare, hash, equal]
+
+type t = {
+  path: string;
+  imports: string list;
+  requires: string list;
+}
+[@@deriving sexp]
+
+let render_directive = function
+  | Import f -> sprintf "@import: %s" f
+  | Require p -> sprintf "@require: %s" p
+
+let parse_directives =
+  (* TODO Rewrite when multi-line comment is added to SATySFi *)
+  let open Re in
+  let line_re =
+    seq [
+      rep space;
+      alt [
+        char '%';
+        seq [
+          str "@";
+          alt [str "require"; str "import"];
+          str ":";
+        ];
+      ]
+      |> group;
+      rep (char ' ');
+      rep (notnl)
+      |> group;
+      alt [eol; eos;];
+    ]
+  in
+  let file_re =
+    seq [
+      bos;
+      rep line_re;
+    ]
+  in
+  let line_c = compile line_re in
+  let file_c = compile file_re in
+  fun str ->
+    match Re.Seq.matches file_c str () with
+    | Nil -> []
+    | Cons (ls, _) ->
+      let f g =
+        match Group.all g with
+        | [| _; "%"; _ |] -> []
+        | [| _; "@import:"; c |] ->
+          [ Import c ]
+        | [| _; "@require:"; c |] ->
+          [ Require c ]
+        | a ->
+          failwithf !"BUG: parse_line: Unmatched Re %{sexp:string array} Please report this." a ()
+      in
+      Re.all line_c ls
+      |> List.concat_map ~f
+
+let of_directives ~path ds =
+  let accum acc = function
+    | Import c ->
+      { acc with imports = c :: acc.imports; }
+    | Require c ->
+      { acc with requires = c :: acc.requires; }
+  in
+  let empty = {
+    path = path;
+    imports = [];
+    requires = [];
+  } in
+  List.fold_left ~f:accum ~init:empty ds
+
+let parse_string ~path str =
+  parse_directives str
+  |> of_directives ~path
+
+let parse_file path =
+  In_channel.read_all path
+  |> parse_directives
+  |> of_directives ~path
+
+let%expect_test "parse_string: empty" =
+  let path = "test.saty" in
+  parse_string ~path ""
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (imports ()) (requires ())) |}]
+
+let%expect_test "parse_string: single import with eol" =
+  let path = "test.saty" in
+  parse_string ~path "@import: imported/file1\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (imports (imported/file1)) (requires ())) |}]
+
+let%expect_test "parse_string: single import with eos" =
+  let path = "test.saty" in
+  parse_string ~path "@import: imported/file1"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (imports (imported/file1)) (requires ())) |}]
+
+let%expect_test "parse_string: single require" =
+  let path = "test.saty" in
+  parse_string ~path "@require: required/file1"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (imports ()) (requires (required/file1))) |}]
+
+let%expect_test "parse_string: imports and requires" =
+  let path = "test.saty" in
+  parse_string ~path "@require: required/file1\n@import: imported/file1\n@require: required/file2\n@import: imported/file2\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (imports (imported/file2 imported/file1))
+     (requires (required/file2 required/file1))) |}]
+
+let%expect_test "parse_string: conflicting names" =
+  let path = "test.saty" in
+  parse_string ~path "@require: file1\n@import: file1\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (imports (file1)) (requires (file1))) |}]
+
+let%expect_test "parse_string: % in package name" =
+  let path = "test.saty" in
+  parse_string ~path "@require: file1 % not a comment\n@import: file1 % not a comment\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (imports ("file1 % not a comment"))
+     (requires ("file1 % not a comment"))) |}]
+
+let%expect_test "parse_string: comment lines" =
+  let path = "test.saty" in
+  parse_string ~path "% comment\n%\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (imports ()) (requires ())) |}]
+
+let%expect_test "parse_string: comment lines followed by directives" =
+  let path = "test.saty" in
+  parse_string ~path "% comment\n%\n@import: file\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (imports (file)) (requires ())) |}]
+
+let%expect_test "parse_string: comment lines interleaved between directives" =
+  let path = "test.saty" in
+  parse_string ~path "% comment\n@require: lib\n%\n@import: file\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (imports (file)) (requires (lib))) |}]
+
+let%expect_test "parse_string: directives followed by declarations" =
+  let path = "test.saty" in
+  parse_string ~path "@import: file\nlet x = 1\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (imports (file)) (requires ())) |}]
+
+let referred_file_basenames ~package_root_dirs { path; imports; requires; }=
+  let basedir = FilePath.dirname path in
+  List.map imports ~f:(fun p -> Import p, [FilePath.concat basedir p])
+  @ List.map requires ~f:(fun p -> Require p, List.map package_root_dirs ~f:(fun rd -> FilePath.concat rd p))

--- a/src/satysfi/dependencyGraph.ml
+++ b/src/satysfi/dependencyGraph.ml
@@ -79,10 +79,14 @@ module Dot =
       let edge_display = function
         | Edge.Directive d ->
           let label = Dependency.render_directive d in
-          [`Label label; `Fontcolor 0x004422; `Color 0x004422]
+          let color = match d with
+            | Require _ -> 0x117722
+            | Import _ -> 0x002288
+          in
+          [`Label label; `Fontcolor color; `Color color]
         | Mode m ->
           let label = Mode.to_extension m in
-          [`Label label; `Fontcolor 0x002288; `Color 0x002288]
+          [`Label label; `Fontcolor 0x000000; `Color 0x000000; `Style `Dashed;]
       in
       Option.value_map ~default:[] ~f:(edge_display) e
     let default_edge_attributes _ = []

--- a/src/satysfi/dependencyGraph.ml
+++ b/src/satysfi/dependencyGraph.ml
@@ -1,0 +1,145 @@
+open Core
+
+let expand_file_basename =
+  let mode_name =
+    let open Re in
+    (* TODO Is this correct?  Shouldn't we put more restriction? *)
+    rep (diff any (char ','))
+  in
+  let re =
+    let open Re in
+    seq [
+      bos;
+      rep any
+      |> group;
+      alt [
+        str ".satyh";
+        (* TODO Exclude these for Satysfi 0.0.3 and earlier *)
+        seq [
+          str ".satyh-";
+          mode_name;
+        ];
+        str ".satyg";
+      ]
+      |> group;
+      eos;
+    ]
+    |> compile
+  in
+  fun package_path ->
+    let dir = FilePath.dirname package_path in
+    let basename = FilePath.basename package_path in
+    let f file_path =
+      FilePath.basename file_path
+      |> Re.exec_opt re
+      |> Option.bind ~f:(fun g ->
+          if Re.Group.get g 1 |> String.equal basename
+          then Some (Re.Group.get g 2, file_path)
+          else None)
+    in
+    if FileUtil.(test Is_dir dir)
+    then FileUtil.(ls dir |> List.filter_map ~f)
+    else []
+
+let get_files ~outf r bs =
+  match List.concat_map ~f:expand_file_basename bs with
+  | [] ->
+    Format.fprintf outf "Cannot read files for “%s”@." (Dependency.render_directive r);
+    Format.fprintf outf "@[<v 2>Candidate basenames:";
+    List.iter bs ~f:(Format.fprintf outf "@;- %s");
+    Format.fprintf outf "@]@.@.";
+    []
+  | files -> files
+
+module Vertex = struct
+  type t =
+    | File of string
+    | Package of string
+  [@@deriving sexp, compare, hash, equal]
+end
+
+let vertex_of_directive =
+  let open Dependency in
+  let open Vertex in
+  function
+  | Import f -> File f
+  | Require f -> Package f
+
+module Edge = struct
+  type edge = {
+    directive: Dependency.directive;
+    mode: string option;
+  }
+  [@@deriving sexp, compare, hash, equal]
+  type t = edge option
+  [@@deriving sexp, compare, hash, equal]
+  let default = None
+end
+
+module G =
+  Graph.Imperative.Digraph.ConcreteBidirectionalLabeled(Vertex)(Edge)
+
+module Dot =
+  Graph.Graphviz.Dot(struct
+    include G
+    let edge_attributes ((_f : vertex), (e : Edge.t), (_t : vertex)) =
+      let open Dependency in
+      let edge_display e =
+        let Edge.{ directive; mode; } = e in
+        let directive_display = render_directive directive in
+        directive_display ^ Option.value_map ~default:"" ~f:(sprintf " (%s)") mode
+      in
+      let label = Option.value_map ~default:"" ~f:(edge_display) e in
+      [`Label label; `Color 4711]
+    let default_edge_attributes _ = []
+    let get_subgraph _ = None
+    let vertex_attributes _ = [`Shape `Box]
+    let vertex_name (v : vertex) =
+      match v with
+      | File path -> sprintf "%S" path
+      | Package p -> sprintf "%S" p
+    let default_vertex_attributes _ = []
+    let graph_attributes _ = []
+  end)
+
+let dependency_graph ~outf ?(follow_required=false) ~package_root_dirs files =
+  let g = G.create () in
+  let rec f file =
+    let vf : G.vertex = File file in
+    if G.mem_vertex g vf
+    then ()
+    else begin
+      G.add_vertex g vf;
+      Dependency.parse_file file
+      |> Dependency.referred_file_basenames ~package_root_dirs
+      |> List.iter ~f:(
+        let add_edge_from_directive directive =
+          let vt : G.vertex = vertex_of_directive directive in
+          let e : Edge.t = Some {
+              directive;
+              mode = None;
+            } in
+          G.add_edge_e g (vf, e, vt)
+        in
+        function
+        | Dependency.Require _ as directive, _ when not follow_required ->
+          add_edge_from_directive directive
+        | directive, bs ->
+          match get_files ~outf directive bs with
+          | [] ->
+            add_edge_from_directive directive
+          | files ->
+            List.iter files ~f:(fun (mode, path) ->
+                let vt : G.vertex = File path in
+                let e : Edge.t = Some {
+                    directive;
+                    mode = Some mode;
+                  } in
+                f path;
+                G.add_edge_e g (vf, e, vt)
+              );
+      )
+    end
+  in
+  List.iter ~f files;
+  g

--- a/src/satysfi/dune
+++ b/src/satysfi/dune
@@ -5,6 +5,7 @@
  (libraries
    core
    fileutils
+   ocamlgraph
    re
    shexp.process
 ))

--- a/src/satysfi/mode.ml
+++ b/src/satysfi/mode.ml
@@ -1,0 +1,49 @@
+open Core
+
+type t =
+  | Pdf
+  | Text of string
+  | Generic
+[@@deriving sexp, compare, hash, equal]
+
+let of_extension_opt = function
+  | ".satyh" -> Some Pdf
+  | ".satyg" -> Some Generic
+  | s ->
+    String.chop_prefix ~prefix:".satyh-" s
+    |> Option.map ~f:(fun m -> Text m)
+
+let to_extension = function
+  | Pdf ->
+    ".satyh"
+  | Text mode ->
+    sprintf ".satyh-%s" mode
+  | Generic ->
+    ".satyg"
+
+let ( <=: ) a b = match a, b with
+  | Pdf, Pdf -> true
+  | Text a, Text b when String.equal a b -> true
+  | Generic, _ -> true
+  | _, _ -> false
+
+let%test "pdf <=: pdf" =
+  Pdf <=: Pdf
+let%test "pdf <=/: text" =
+  not (Pdf <=: Text "md")
+let%test "pdf <=/: generic" =
+  not (Pdf <=: Text "md")
+let%test "text <=/: pdf" =
+  not (Text "md" <=: Pdf)
+let%test "text md <=/: text text" =
+  not (Text "md" <=: Text "text")
+let%test "text md <=: text md" =
+  Text "md" <=: Text "md"
+let%test "text <=/: generic" =
+  not (Text "md" <=: Generic)
+let%test "generic <=: pdf" =
+  Generic <=: Pdf
+let%test "generic <=: text md" =
+  Generic <=: Text "md"
+let%test "generic <=: generic" =
+  Generic <=: Generic

--- a/src/satysfi/satysfiDirs.ml
+++ b/src/satysfi/satysfiDirs.ml
@@ -15,6 +15,16 @@ let home_dir () = if String.equal Sys.os_type "Win32"
 let user_dir () =
     Option.map ~f:(fun s -> Filename.concat s ".satysfi") (home_dir ())
 
+let expand_package_root_dirs ~satysfi_version package_root_dirs =
+  let suffixes =
+    ["dist/packages"]
+    @ if Version.read_local_packages satysfi_version
+    then ["local/packages"]
+    else []
+  in
+  List.concat_map suffixes ~f:(fun suffix ->
+      List.map package_root_dirs ~f:(fun path -> FilePath.concat path suffix))
+
 let is_runtime_dir dir =
   FileUtil.(test Is_dir) (Filename.concat dir "packages")
 

--- a/src/satysfi/version.ml
+++ b/src/satysfi/version.ml
@@ -1,0 +1,27 @@
+open Core
+
+type t =
+  | Satysfi_0_0_3
+  | Satysfi_0_0_4
+  | Satysfi_0_0_5
+[@@deriving sexp]
+
+let of_string_opt = function
+  | "0.0.3" -> Some Satysfi_0_0_3
+  | "0.0.4" -> Some Satysfi_0_0_4
+  | "0.0.5" -> Some Satysfi_0_0_5
+  | _ -> None
+
+let of_string_exn s : t =
+  of_string_opt s
+  |> Option.value_exn
+    ~error:(Error.createf "Invalid SATySFi version: %S" s)
+
+let to_string = function
+  | Satysfi_0_0_3 -> "0.0.3"
+  | Satysfi_0_0_4 -> "0.0.4"
+  | Satysfi_0_0_5 -> "0.0.5"
+
+let read_local_packages = function
+  | Satysfi_0_0_3 -> false
+  | _ -> true

--- a/test/testcases/command_debug_depgraph__empty.t
+++ b/test/testcases/command_debug_depgraph__empty.t
@@ -1,0 +1,21 @@
+Prepare SATySFi source
+  $ cat >empty.saty <<EOF
+  > EOF
+
+Generate dependency graphs
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph empty.saty
+  Compatibility warning: You have opted in to use experimental features.
+  digraph G {
+    "empty.saty" [shape=box, ];
+    
+    
+    
+    }
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph --follow-required empty.saty
+  Compatibility warning: You have opted in to use experimental features.
+  digraph G {
+    "empty.saty" [shape=box, ];
+    
+    
+    
+    }

--- a/test/testcases/command_debug_depgraph__import_duplex.t
+++ b/test/testcases/command_debug_depgraph__import_duplex.t
@@ -19,13 +19,13 @@ Generate dependency graphs
     "first.saty" [shape=box, ];
     
     
-    "second" -> "second.satyh" [color="#002288", fontcolor="#002288",
-                                label=".satyh", ];
-    "third" -> "third.satyh" [color="#002288", fontcolor="#002288",
-                              label=".satyh", ];
-    "second.satyh" -> "third" [color="#004422", fontcolor="#004422",
+    "second" -> "second.satyh" [color="#000000", fontcolor="#000000",
+                                label=".satyh", style="dashed", ];
+    "third" -> "third.satyh" [color="#000000", fontcolor="#000000",
+                              label=".satyh", style="dashed", ];
+    "second.satyh" -> "third" [color="#002288", fontcolor="#002288",
                                label="@import: third", ];
-    "first.saty" -> "second" [color="#004422", fontcolor="#004422",
+    "first.saty" -> "second" [color="#002288", fontcolor="#002288",
                               label="@import: second", ];
     
     }
@@ -39,13 +39,13 @@ Generate dependency graphs
     "first.saty" [shape=box, ];
     
     
-    "second" -> "second.satyh" [color="#002288", fontcolor="#002288",
-                                label=".satyh", ];
-    "third" -> "third.satyh" [color="#002288", fontcolor="#002288",
-                              label=".satyh", ];
-    "second.satyh" -> "third" [color="#004422", fontcolor="#004422",
+    "second" -> "second.satyh" [color="#000000", fontcolor="#000000",
+                                label=".satyh", style="dashed", ];
+    "third" -> "third.satyh" [color="#000000", fontcolor="#000000",
+                              label=".satyh", style="dashed", ];
+    "second.satyh" -> "third" [color="#002288", fontcolor="#002288",
                                label="@import: third", ];
-    "first.saty" -> "second" [color="#004422", fontcolor="#004422",
+    "first.saty" -> "second" [color="#002288", fontcolor="#002288",
                               label="@import: second", ];
     
     }

--- a/test/testcases/command_debug_depgraph__import_duplex.t
+++ b/test/testcases/command_debug_depgraph__import_duplex.t
@@ -1,0 +1,39 @@
+Prepare SATySFi source
+  $ cat >first.saty <<EOF
+  > @import: second
+  > EOF
+  $ cat >second.satyh <<EOF
+  > @import: third
+  > EOF
+  $ cat >third.satyh <<EOF
+  > EOF
+
+Generate dependency graphs
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  digraph G {
+    "third.satyh" [shape=box, ];
+    "first.saty" [shape=box, ];
+    "second.satyh" [shape=box, ];
+    
+    
+    "first.saty" -> "second.satyh" [color="#001267",
+                                    label="@import: second (.satyh)", ];
+    "second.satyh" -> "third.satyh" [color="#001267",
+                                     label="@import: third (.satyh)", ];
+    
+    }
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph --follow-required first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  digraph G {
+    "third.satyh" [shape=box, ];
+    "first.saty" [shape=box, ];
+    "second.satyh" [shape=box, ];
+    
+    
+    "first.saty" -> "second.satyh" [color="#001267",
+                                    label="@import: second (.satyh)", ];
+    "second.satyh" -> "third.satyh" [color="#001267",
+                                     label="@import: third (.satyh)", ];
+    
+    }

--- a/test/testcases/command_debug_depgraph__import_duplex.t
+++ b/test/testcases/command_debug_depgraph__import_duplex.t
@@ -13,27 +13,39 @@ Generate dependency graphs
   Compatibility warning: You have opted in to use experimental features.
   digraph G {
     "third.satyh" [shape=box, ];
-    "first.saty" [shape=box, ];
+    "second" [shape=doubleoctagon, ];
+    "third" [shape=doubleoctagon, ];
     "second.satyh" [shape=box, ];
+    "first.saty" [shape=box, ];
     
     
-    "first.saty" -> "second.satyh" [color="#001267",
-                                    label="@import: second (.satyh)", ];
-    "second.satyh" -> "third.satyh" [color="#001267",
-                                     label="@import: third (.satyh)", ];
+    "second" -> "second.satyh" [color="#002288", fontcolor="#002288",
+                                label=".satyh", ];
+    "third" -> "third.satyh" [color="#002288", fontcolor="#002288",
+                              label=".satyh", ];
+    "second.satyh" -> "third" [color="#004422", fontcolor="#004422",
+                               label="@import: third", ];
+    "first.saty" -> "second" [color="#004422", fontcolor="#004422",
+                              label="@import: second", ];
     
     }
   $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph --follow-required first.saty
   Compatibility warning: You have opted in to use experimental features.
   digraph G {
     "third.satyh" [shape=box, ];
-    "first.saty" [shape=box, ];
+    "second" [shape=doubleoctagon, ];
+    "third" [shape=doubleoctagon, ];
     "second.satyh" [shape=box, ];
+    "first.saty" [shape=box, ];
     
     
-    "first.saty" -> "second.satyh" [color="#001267",
-                                    label="@import: second (.satyh)", ];
-    "second.satyh" -> "third.satyh" [color="#001267",
-                                     label="@import: third (.satyh)", ];
+    "second" -> "second.satyh" [color="#002288", fontcolor="#002288",
+                                label=".satyh", ];
+    "third" -> "third.satyh" [color="#002288", fontcolor="#002288",
+                              label=".satyh", ];
+    "second.satyh" -> "third" [color="#004422", fontcolor="#004422",
+                               label="@import: third", ];
+    "first.saty" -> "second" [color="#004422", fontcolor="#004422",
+                              label="@import: second", ];
     
     }

--- a/test/testcases/command_debug_depgraph__import_simplex.t
+++ b/test/testcases/command_debug_depgraph__import_simplex.t
@@ -1,0 +1,40 @@
+Prepare SATySFi source
+  $ cat >first.saty <<EOF
+  > @import: second1
+  > @import: second2/lib
+  > EOF
+  $ cat >second1.satyh <<EOF
+  > EOF
+  $ mkdir second2
+  $ cat >second2/lib.satyg <<EOF
+  > EOF
+
+Generate dependency graphs
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  digraph G {
+    "second1.satyh" [shape=box, ];
+    "first.saty" [shape=box, ];
+    "second2/lib.satyg" [shape=box, ];
+    
+    
+    "first.saty" -> "second1.satyh" [color="#001267",
+                                     label="@import: second1 (.satyh)", ];
+    "first.saty" -> "second2/lib.satyg" [color="#001267",
+                                         label="@import: second2/lib (.satyg)", ];
+    
+    }
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph --follow-required first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  digraph G {
+    "second1.satyh" [shape=box, ];
+    "first.saty" [shape=box, ];
+    "second2/lib.satyg" [shape=box, ];
+    
+    
+    "first.saty" -> "second1.satyh" [color="#001267",
+                                     label="@import: second1 (.satyh)", ];
+    "first.saty" -> "second2/lib.satyg" [color="#001267",
+                                         label="@import: second2/lib (.satyg)", ];
+    
+    }

--- a/test/testcases/command_debug_depgraph__import_simplex.t
+++ b/test/testcases/command_debug_depgraph__import_simplex.t
@@ -20,13 +20,13 @@ Generate dependency graphs
     "first.saty" [shape=box, ];
     
     
-    "second1" -> "second1.satyh" [color="#002288", fontcolor="#002288",
-                                  label=".satyh", ];
-    "second2/lib" -> "second2/lib.satyg" [color="#002288", fontcolor="#002288",
-                                          label=".satyg", ];
-    "first.saty" -> "second1" [color="#004422", fontcolor="#004422",
+    "second1" -> "second1.satyh" [color="#000000", fontcolor="#000000",
+                                  label=".satyh", style="dashed", ];
+    "second2/lib" -> "second2/lib.satyg" [color="#000000", fontcolor="#000000",
+                                          label=".satyg", style="dashed", ];
+    "first.saty" -> "second1" [color="#002288", fontcolor="#002288",
                                label="@import: second1", ];
-    "first.saty" -> "second2/lib" [color="#004422", fontcolor="#004422",
+    "first.saty" -> "second2/lib" [color="#002288", fontcolor="#002288",
                                    label="@import: second2/lib", ];
     
     }
@@ -40,13 +40,13 @@ Generate dependency graphs
     "first.saty" [shape=box, ];
     
     
-    "second1" -> "second1.satyh" [color="#002288", fontcolor="#002288",
-                                  label=".satyh", ];
-    "second2/lib" -> "second2/lib.satyg" [color="#002288", fontcolor="#002288",
-                                          label=".satyg", ];
-    "first.saty" -> "second1" [color="#004422", fontcolor="#004422",
+    "second1" -> "second1.satyh" [color="#000000", fontcolor="#000000",
+                                  label=".satyh", style="dashed", ];
+    "second2/lib" -> "second2/lib.satyg" [color="#000000", fontcolor="#000000",
+                                          label=".satyg", style="dashed", ];
+    "first.saty" -> "second1" [color="#002288", fontcolor="#002288",
                                label="@import: second1", ];
-    "first.saty" -> "second2/lib" [color="#004422", fontcolor="#004422",
+    "first.saty" -> "second2/lib" [color="#002288", fontcolor="#002288",
                                    label="@import: second2/lib", ];
     
     }

--- a/test/testcases/command_debug_depgraph__import_simplex.t
+++ b/test/testcases/command_debug_depgraph__import_simplex.t
@@ -14,27 +14,39 @@ Generate dependency graphs
   Compatibility warning: You have opted in to use experimental features.
   digraph G {
     "second1.satyh" [shape=box, ];
-    "first.saty" [shape=box, ];
+    "second1" [shape=doubleoctagon, ];
     "second2/lib.satyg" [shape=box, ];
+    "second2/lib" [shape=doubleoctagon, ];
+    "first.saty" [shape=box, ];
     
     
-    "first.saty" -> "second1.satyh" [color="#001267",
-                                     label="@import: second1 (.satyh)", ];
-    "first.saty" -> "second2/lib.satyg" [color="#001267",
-                                         label="@import: second2/lib (.satyg)", ];
+    "second1" -> "second1.satyh" [color="#002288", fontcolor="#002288",
+                                  label=".satyh", ];
+    "second2/lib" -> "second2/lib.satyg" [color="#002288", fontcolor="#002288",
+                                          label=".satyg", ];
+    "first.saty" -> "second1" [color="#004422", fontcolor="#004422",
+                               label="@import: second1", ];
+    "first.saty" -> "second2/lib" [color="#004422", fontcolor="#004422",
+                                   label="@import: second2/lib", ];
     
     }
   $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph --follow-required first.saty
   Compatibility warning: You have opted in to use experimental features.
   digraph G {
     "second1.satyh" [shape=box, ];
-    "first.saty" [shape=box, ];
+    "second1" [shape=doubleoctagon, ];
     "second2/lib.satyg" [shape=box, ];
+    "second2/lib" [shape=doubleoctagon, ];
+    "first.saty" [shape=box, ];
     
     
-    "first.saty" -> "second1.satyh" [color="#001267",
-                                     label="@import: second1 (.satyh)", ];
-    "first.saty" -> "second2/lib.satyg" [color="#001267",
-                                         label="@import: second2/lib (.satyg)", ];
+    "second1" -> "second1.satyh" [color="#002288", fontcolor="#002288",
+                                  label=".satyh", ];
+    "second2/lib" -> "second2/lib.satyg" [color="#002288", fontcolor="#002288",
+                                          label=".satyg", ];
+    "first.saty" -> "second1" [color="#004422", fontcolor="#004422",
+                               label="@import: second1", ];
+    "first.saty" -> "second2/lib" [color="#004422", fontcolor="#004422",
+                                   label="@import: second2/lib", ];
     
     }

--- a/test/testcases/command_debug_depgraph__missing_files.t
+++ b/test/testcases/command_debug_depgraph__missing_files.t
@@ -1,0 +1,29 @@
+Prepare SATySFi source
+  $ cat >first.saty <<EOF
+  > @import: second
+  > @require: lib1
+  > EOF
+  $ mkdir root
+
+Generate dependency graphs
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph --satysfi-root-dirs 'root' --follow-require first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  Cannot read files for “@import: second”
+  Candidate basenames:
+    - second
+  
+  Cannot read files for “@require: lib1”
+  Candidate basenames:
+    - root/dist/packages/lib1
+    - root/local/packages/lib1
+  
+  digraph G {
+    "second" [shape=box, ];
+    "first.saty" [shape=box, ];
+    "lib1" [shape=box, ];
+    
+    
+    "first.saty" -> "second" [color="#001267", label="@import: second", ];
+    "first.saty" -> "lib1" [color="#001267", label="@require: lib1", ];
+    
+    }

--- a/test/testcases/command_debug_depgraph__missing_files.t
+++ b/test/testcases/command_debug_depgraph__missing_files.t
@@ -23,9 +23,9 @@ Generate dependency graphs
     "first.saty" [shape=box, ];
     
     
-    "first.saty" -> "second" [color="#004422", fontcolor="#004422",
+    "first.saty" -> "second" [color="#002288", fontcolor="#002288",
                               label="@import: second", ];
-    "first.saty" -> "lib1" [color="#004422", fontcolor="#004422",
+    "first.saty" -> "lib1" [color="#117722", fontcolor="#117722",
                             label="@require: lib1", ];
     
     }

--- a/test/testcases/command_debug_depgraph__missing_files.t
+++ b/test/testcases/command_debug_depgraph__missing_files.t
@@ -18,12 +18,14 @@ Generate dependency graphs
     - root/local/packages/lib1
   
   digraph G {
-    "second" [shape=box, ];
+    "second" [shape=doubleoctagon, ];
+    "lib1" [shape=ellipse, ];
     "first.saty" [shape=box, ];
-    "lib1" [shape=box, ];
     
     
-    "first.saty" -> "second" [color="#001267", label="@import: second", ];
-    "first.saty" -> "lib1" [color="#001267", label="@require: lib1", ];
+    "first.saty" -> "second" [color="#004422", fontcolor="#004422",
+                              label="@import: second", ];
+    "first.saty" -> "lib1" [color="#004422", fontcolor="#004422",
+                            label="@require: lib1", ];
     
     }

--- a/test/testcases/command_debug_depgraph__require_followed.t
+++ b/test/testcases/command_debug_depgraph__require_followed.t
@@ -1,0 +1,39 @@
+Prepare SATySFi source
+  $ cat >first.saty <<EOF
+  > @import: second
+  > @require: lib1
+  > EOF
+  $ cat >second.satyh <<EOF
+  > @require: lib1
+  > @require: lib2
+  > EOF
+  $ mkdir -p root/dist/packages
+  $ cat >root/dist/packages/lib1.satyh <<EOF
+  > EOF
+  $ mkdir -p root/local/packages
+  $ cat >root/local/packages/lib2.satyg <<EOF
+  > EOF
+
+Generate dependency graphs
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph --satysfi-root-dirs 'root' --follow-require first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  digraph G {
+    "root/local/packages/lib2.satyg" [shape=box, ];
+    "first.saty" [shape=box, ];
+    "root/dist/packages/lib1.satyh" [shape=box, ];
+    "second.satyh" [shape=box, ];
+    
+    
+    "first.saty" -> "root/dist/packages/lib1.satyh" [color="#001267",
+                                                     label="@require: lib1 (.satyh)",
+                                                     ];
+    "first.saty" -> "second.satyh" [color="#001267",
+                                    label="@import: second (.satyh)", ];
+    "second.satyh" -> "root/dist/packages/lib1.satyh" [color="#001267",
+                                                       label="@require: lib1 (.satyh)",
+                                                       ];
+    "second.satyh" -> "root/local/packages/lib2.satyg" [color="#001267",
+                                                        label="@require: lib2 (.satyg)",
+                                                        ];
+    
+    }

--- a/test/testcases/command_debug_depgraph__require_followed.t
+++ b/test/testcases/command_debug_depgraph__require_followed.t
@@ -27,21 +27,21 @@ Generate dependency graphs
     "first.saty" [shape=box, ];
     
     
-    "second" -> "second.satyh" [color="#002288", fontcolor="#002288",
-                                label=".satyh", ];
-    "lib1" -> "root/dist/packages/lib1.satyh" [color="#002288",
-                                               fontcolor="#002288",
-                                               label=".satyh", ];
-    "lib2" -> "root/local/packages/lib2.satyg" [color="#002288",
-                                                fontcolor="#002288",
-                                                label=".satyg", ];
-    "second.satyh" -> "lib1" [color="#004422", fontcolor="#004422",
+    "second" -> "second.satyh" [color="#000000", fontcolor="#000000",
+                                label=".satyh", style="dashed", ];
+    "lib1" -> "root/dist/packages/lib1.satyh" [color="#000000",
+                                               fontcolor="#000000",
+                                               label=".satyh", style="dashed", ];
+    "lib2" -> "root/local/packages/lib2.satyg" [color="#000000",
+                                                fontcolor="#000000",
+                                                label=".satyg", style="dashed", ];
+    "second.satyh" -> "lib1" [color="#117722", fontcolor="#117722",
                               label="@require: lib1", ];
-    "second.satyh" -> "lib2" [color="#004422", fontcolor="#004422",
+    "second.satyh" -> "lib2" [color="#117722", fontcolor="#117722",
                               label="@require: lib2", ];
-    "first.saty" -> "second" [color="#004422", fontcolor="#004422",
+    "first.saty" -> "second" [color="#002288", fontcolor="#002288",
                               label="@import: second", ];
-    "first.saty" -> "lib1" [color="#004422", fontcolor="#004422",
+    "first.saty" -> "lib1" [color="#117722", fontcolor="#117722",
                             label="@require: lib1", ];
     
     }

--- a/test/testcases/command_debug_depgraph__require_followed.t
+++ b/test/testcases/command_debug_depgraph__require_followed.t
@@ -19,21 +19,29 @@ Generate dependency graphs
   Compatibility warning: You have opted in to use experimental features.
   digraph G {
     "root/local/packages/lib2.satyg" [shape=box, ];
-    "first.saty" [shape=box, ];
     "root/dist/packages/lib1.satyh" [shape=box, ];
+    "second" [shape=doubleoctagon, ];
+    "lib1" [shape=ellipse, ];
+    "lib2" [shape=ellipse, ];
     "second.satyh" [shape=box, ];
+    "first.saty" [shape=box, ];
     
     
-    "first.saty" -> "root/dist/packages/lib1.satyh" [color="#001267",
-                                                     label="@require: lib1 (.satyh)",
-                                                     ];
-    "first.saty" -> "second.satyh" [color="#001267",
-                                    label="@import: second (.satyh)", ];
-    "second.satyh" -> "root/dist/packages/lib1.satyh" [color="#001267",
-                                                       label="@require: lib1 (.satyh)",
-                                                       ];
-    "second.satyh" -> "root/local/packages/lib2.satyg" [color="#001267",
-                                                        label="@require: lib2 (.satyg)",
-                                                        ];
+    "second" -> "second.satyh" [color="#002288", fontcolor="#002288",
+                                label=".satyh", ];
+    "lib1" -> "root/dist/packages/lib1.satyh" [color="#002288",
+                                               fontcolor="#002288",
+                                               label=".satyh", ];
+    "lib2" -> "root/local/packages/lib2.satyg" [color="#002288",
+                                                fontcolor="#002288",
+                                                label=".satyg", ];
+    "second.satyh" -> "lib1" [color="#004422", fontcolor="#004422",
+                              label="@require: lib1", ];
+    "second.satyh" -> "lib2" [color="#004422", fontcolor="#004422",
+                              label="@require: lib2", ];
+    "first.saty" -> "second" [color="#004422", fontcolor="#004422",
+                              label="@import: second", ];
+    "first.saty" -> "lib1" [color="#004422", fontcolor="#004422",
+                            label="@require: lib1", ];
     
     }

--- a/test/testcases/command_debug_depgraph__require_unfollowed.t
+++ b/test/testcases/command_debug_depgraph__require_unfollowed.t
@@ -1,0 +1,36 @@
+Prepare SATySFi source
+  $ cat >first.saty <<EOF
+  > @import: second
+  > @require: lib1
+  > EOF
+  $ cat >second.satyh <<EOF
+  > @import: third
+  > @require: lib1
+  > @require: lib2
+  > EOF
+  $ cat >third.satyh <<EOF
+  > @require: lib3
+  > EOF
+
+Generate dependency graphs
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  digraph G {
+    "third.satyh" [shape=box, ];
+    "first.saty" [shape=box, ];
+    "lib2" [shape=box, ];
+    "lib1" [shape=box, ];
+    "lib3" [shape=box, ];
+    "second.satyh" [shape=box, ];
+    
+    
+    "third.satyh" -> "lib3" [color="#001267", label="@require: lib3", ];
+    "first.saty" -> "second.satyh" [color="#001267",
+                                    label="@import: second (.satyh)", ];
+    "first.saty" -> "lib1" [color="#001267", label="@require: lib1", ];
+    "second.satyh" -> "third.satyh" [color="#001267",
+                                     label="@import: third (.satyh)", ];
+    "second.satyh" -> "lib1" [color="#001267", label="@require: lib1", ];
+    "second.satyh" -> "lib2" [color="#001267", label="@require: lib2", ];
+    
+    }

--- a/test/testcases/command_debug_depgraph__require_unfollowed.t
+++ b/test/testcases/command_debug_depgraph__require_unfollowed.t
@@ -26,21 +26,21 @@ Generate dependency graphs
     "first.saty" [shape=box, ];
     
     
-    "third.satyh" -> "lib3" [color="#004422", fontcolor="#004422",
+    "third.satyh" -> "lib3" [color="#117722", fontcolor="#117722",
                              label="@require: lib3", ];
-    "second" -> "second.satyh" [color="#002288", fontcolor="#002288",
-                                label=".satyh", ];
-    "third" -> "third.satyh" [color="#002288", fontcolor="#002288",
-                              label=".satyh", ];
-    "second.satyh" -> "third" [color="#004422", fontcolor="#004422",
+    "second" -> "second.satyh" [color="#000000", fontcolor="#000000",
+                                label=".satyh", style="dashed", ];
+    "third" -> "third.satyh" [color="#000000", fontcolor="#000000",
+                              label=".satyh", style="dashed", ];
+    "second.satyh" -> "third" [color="#002288", fontcolor="#002288",
                                label="@import: third", ];
-    "second.satyh" -> "lib1" [color="#004422", fontcolor="#004422",
+    "second.satyh" -> "lib1" [color="#117722", fontcolor="#117722",
                               label="@require: lib1", ];
-    "second.satyh" -> "lib2" [color="#004422", fontcolor="#004422",
+    "second.satyh" -> "lib2" [color="#117722", fontcolor="#117722",
                               label="@require: lib2", ];
-    "first.saty" -> "second" [color="#004422", fontcolor="#004422",
+    "first.saty" -> "second" [color="#002288", fontcolor="#002288",
                               label="@import: second", ];
-    "first.saty" -> "lib1" [color="#004422", fontcolor="#004422",
+    "first.saty" -> "lib1" [color="#117722", fontcolor="#117722",
                             label="@require: lib1", ];
     
     }

--- a/test/testcases/command_debug_depgraph__require_unfollowed.t
+++ b/test/testcases/command_debug_depgraph__require_unfollowed.t
@@ -17,20 +17,30 @@ Generate dependency graphs
   Compatibility warning: You have opted in to use experimental features.
   digraph G {
     "third.satyh" [shape=box, ];
-    "first.saty" [shape=box, ];
-    "lib2" [shape=box, ];
-    "lib1" [shape=box, ];
-    "lib3" [shape=box, ];
+    "lib3" [shape=ellipse, ];
+    "second" [shape=doubleoctagon, ];
+    "lib1" [shape=ellipse, ];
+    "third" [shape=doubleoctagon, ];
+    "lib2" [shape=ellipse, ];
     "second.satyh" [shape=box, ];
+    "first.saty" [shape=box, ];
     
     
-    "third.satyh" -> "lib3" [color="#001267", label="@require: lib3", ];
-    "first.saty" -> "second.satyh" [color="#001267",
-                                    label="@import: second (.satyh)", ];
-    "first.saty" -> "lib1" [color="#001267", label="@require: lib1", ];
-    "second.satyh" -> "third.satyh" [color="#001267",
-                                     label="@import: third (.satyh)", ];
-    "second.satyh" -> "lib1" [color="#001267", label="@require: lib1", ];
-    "second.satyh" -> "lib2" [color="#001267", label="@require: lib2", ];
+    "third.satyh" -> "lib3" [color="#004422", fontcolor="#004422",
+                             label="@require: lib3", ];
+    "second" -> "second.satyh" [color="#002288", fontcolor="#002288",
+                                label=".satyh", ];
+    "third" -> "third.satyh" [color="#002288", fontcolor="#002288",
+                              label=".satyh", ];
+    "second.satyh" -> "third" [color="#004422", fontcolor="#004422",
+                               label="@import: third", ];
+    "second.satyh" -> "lib1" [color="#004422", fontcolor="#004422",
+                              label="@require: lib1", ];
+    "second.satyh" -> "lib2" [color="#004422", fontcolor="#004422",
+                              label="@require: lib2", ];
+    "first.saty" -> "second" [color="#004422", fontcolor="#004422",
+                              label="@import: second", ];
+    "first.saty" -> "lib1" [color="#004422", fontcolor="#004422",
+                            label="@require: lib1", ];
     
     }


### PR DESCRIPTION
This PR adds module DependencyGraph to a construct dependency graph of SATySFi source files.

This PR also adds `debug depgraph` subcommand to output the dependency graph as a DOT file.

Example ([satysfi-fss](https://github.com/na4zagin3/satysfi-fss)):

![Dependency graph of satysfi-fss](https://user-images.githubusercontent.com/368735/95684827-19284d80-0c2f-11eb-8f60-3ac9f9c08b54.png)


