### PR TITLE
Refactoring: Use unified terminology: depot and registry

### DIFF
--- a/bin/commandLibrary.ml
+++ b/bin/commandLibrary.ml
@@ -27,7 +27,7 @@ let library_list_command_g p_list =
 
 let library_list () =
   Compatibility.optin ();
-  match Setup.try_read_repo () with
+  match Setup.try_read_depot () with
   | Some Environment.{ repo=_; reg; } ->
     [%derive.show: string list] (Registry.list reg) |> print_endline
   | None -> printf "No libraries"
@@ -36,7 +36,7 @@ let library_list () =
 
 let library_show p () =
   Compatibility.optin ();
-  let Environment.{ repo=_; reg; } = Setup.read_repo () in
+  let Environment.{ repo=_; reg; } = Setup.read_depot () in
   Registry.directory reg p
     |> Library.read_dir ~outf
     |> [%sexp_of: Library.t]

--- a/bin/commandLibrary.ml
+++ b/bin/commandLibrary.ml
@@ -27,7 +27,8 @@ let library_list_command_g p_list =
 
 let library_list () =
   Compatibility.optin ();
-  match Setup.try_read_depot () with
+  let env = Setup.read_environment () in
+  match env.depot with
   | Some Environment.{ repo=_; reg; } ->
     [%derive.show: string list] (Registry.list reg) |> print_endline
   | None -> printf "No libraries"
@@ -36,7 +37,7 @@ let library_list () =
 
 let library_show p () =
   Compatibility.optin ();
-  let Environment.{ repo=_; reg; } = Setup.read_depot () in
+  let Environment.{ repo=_; reg; } = Setup.read_depot_exn () in
   Registry.directory reg p
     |> Library.read_dir ~outf
     |> [%sexp_of: Library.t]
@@ -54,16 +55,18 @@ let library_command =
 
 let library_opam_list () =
   Compatibility.optin ();
-  Option.iter Setup.reg_opam ~f:(fun reg_opam ->
-    [%derive.show: string list] (OpamSatysfiRegistry.list reg_opam) |> print_endline
+  let env = Setup.read_environment () in
+  Option.iter env.opam_reg ~f:(fun opam_reg ->
+    [%derive.show: string list] (OpamSatysfiRegistry.list opam_reg) |> print_endline
   )
 let library_opam_list_command =
   library_list_command_g library_opam_list
 
 let library_opam_show p () =
   Compatibility.optin ();
-  Option.iter Setup.reg_opam ~f:(fun reg_opam ->
-    OpamSatysfiRegistry.directory reg_opam p
+  let env = Setup.read_environment () in
+  Option.iter env.opam_reg ~f:(fun opam_reg ->
+    OpamSatysfiRegistry.directory opam_reg p
       |> Library.read_dir ~outf
       |> [%sexp_of: Library.t]
       |> Sexp.to_string_hum

--- a/bin/commandPin.ml
+++ b/bin/commandPin.ml
@@ -11,7 +11,7 @@ let pin_list_command =
       in
       fun () ->
       Compatibility.optin ();
-      let repo = (Setup.read_depot ()).repo in
+      let repo = (Setup.read_depot_exn ()).repo in
       Satyrographos_command.Pin.pin_list ~outf repo
     ]
 
@@ -24,7 +24,7 @@ let pin_dir_command =
       in
       fun () ->
         Compatibility.optin ();
-        let repo = (Setup.read_depot ()).repo in
+        let repo = (Setup.read_depot_exn ()).repo in
         Satyrographos_command.Pin.pin_dir ~outf repo p
     ]
 
@@ -40,7 +40,7 @@ let pin_add_command =
         Compatibility.optin ();
         Printf.printf "Compatibility warning: Although currently Satyrographos simply copies the given directory,\n";
         Printf.printf "it will have a build script to control library installation, which is a breaking change.";
-        let env = Setup.read_depot () in
+        let env = Setup.read_depot_exn () in
         Satyrographos_command.Pin.pin_add ~outf env p url
     ]
 
@@ -53,7 +53,7 @@ let pin_remove_command =
       in
       fun () ->
         Compatibility.optin ();
-        let repo = (Setup.read_depot ()).repo in
+        let repo = (Setup.read_depot_exn ()).repo in
         Satyrographos_command.Pin.pin_remove ~outf repo p
     ]
 

--- a/bin/commandPin.ml
+++ b/bin/commandPin.ml
@@ -11,7 +11,7 @@ let pin_list_command =
       in
       fun () ->
       Compatibility.optin ();
-      let repo = (Setup.read_repo ()).repo in
+      let repo = (Setup.read_depot ()).repo in
       Satyrographos_command.Pin.pin_list ~outf repo
     ]
 
@@ -24,7 +24,7 @@ let pin_dir_command =
       in
       fun () ->
         Compatibility.optin ();
-        let repo = (Setup.read_repo ()).repo in
+        let repo = (Setup.read_depot ()).repo in
         Satyrographos_command.Pin.pin_dir ~outf repo p
     ]
 
@@ -40,7 +40,7 @@ let pin_add_command =
         Compatibility.optin ();
         Printf.printf "Compatibility warning: Although currently Satyrographos simply copies the given directory,\n";
         Printf.printf "it will have a build script to control library installation, which is a breaking change.";
-        let env = Setup.read_repo () in
+        let env = Setup.read_depot () in
         Satyrographos_command.Pin.pin_add ~outf env p url
     ]
 
@@ -53,7 +53,7 @@ let pin_remove_command =
       in
       fun () ->
         Compatibility.optin ();
-        let repo = (Setup.read_repo ()).repo in
+        let repo = (Setup.read_depot ()).repo in
         Satyrographos_command.Pin.pin_remove ~outf repo p
     ]
 

--- a/bin/commandStatus.ml
+++ b/bin/commandStatus.ml
@@ -9,7 +9,8 @@ let outf = Format.std_formatter
 let status () =
   printf "Scheme version: ";
   [%derive.show: int option] Setup.current_scheme_version |> print_endline;
-  Setup.try_read_depot () |> Option.iter ~f:(fun { repo; reg; } ->
+  let env = Setup.read_environment () in
+  env.depot |> Option.iter ~f:(fun { repo; reg; } ->
     printf "Source repository: ";
     [%derive.show: string list] (Repository.list repo) |> print_endline;
     printf "Built library registry: ";

--- a/bin/commandStatus.ml
+++ b/bin/commandStatus.ml
@@ -9,7 +9,7 @@ let outf = Format.std_formatter
 let status () =
   printf "Scheme version: ";
   [%derive.show: int option] Setup.current_scheme_version |> print_endline;
-  Setup.try_read_repo () |> Option.iter ~f:(fun { repo; reg; } ->
+  Setup.try_read_depot () |> Option.iter ~f:(fun { repo; reg; } ->
     printf "Source repository: ";
     [%derive.show: string list] (Repository.list repo) |> print_endline;
     printf "Built library registry: ";

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -5,13 +5,19 @@ module SatysfiDirs = Satyrographos_satysfi.SatysfiDirs
 
 let scheme_version = 1
 
+(** Home directory. TODO Remove this. *)
 let home_dir = match SatysfiDirs.home_dir () with
   | Some(d) -> d
   | None -> failwith "Cannot find home directory"
 
+(** Satyrographos depot directory path. *)
 let root_dir = Sys.getenv "SATYROGRAPHOS_DIR"
   |> Option.value ~default:(Filename.concat home_dir ".satyrographos")
+
+(** Satyrographos source repository directory path. *)
 let repository_dir = SatyrographosDirs.repository_dir root_dir
+
+(** Satyrographos binary registry directory path. *)
 let registry_dir = SatyrographosDirs.registry_dir root_dir
 let metadata_file = SatyrographosDirs.metadata_file root_dir
 

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -12,7 +12,7 @@ let home_dir = match SatysfiDirs.home_dir () with
 let root_dir = Sys.getenv "SATYROGRAPHOS_DIR"
   |> Option.value ~default:(Filename.concat home_dir ".satyrographos")
 let repository_dir = SatyrographosDirs.repository_dir root_dir
-let library_dir = SatyrographosDirs.library_dir root_dir
+let registry_dir = SatyrographosDirs.registry_dir root_dir
 let metadata_file = SatyrographosDirs.metadata_file root_dir
 
 let current_scheme_version = SatyrographosDirs.get_scheme_version root_dir
@@ -32,7 +32,7 @@ let initialize () =
   else begin
     depot_initialized := true;
     Repository.initialize repository_dir metadata_file;
-    Registry.initialize library_dir metadata_file;
+    Registry.initialize registry_dir metadata_file;
     SatyrographosDirs.mark_scheme_version root_dir scheme_version
   end
 
@@ -49,7 +49,7 @@ let try_read_depot () =
     (* Source repository *)
     let repo = Repository.read repository_dir metadata_file in
     (* Binary registry *)
-    let reg = Registry.read library_dir repo metadata_file in
+    let reg = Registry.read registry_dir repo metadata_file in
     Some (Environment.{ repo; reg })
   end
 

--- a/bin/setup.ml
+++ b/bin/setup.ml
@@ -53,13 +53,6 @@ let try_read_depot () =
     Some (Environment.{ repo; reg })
   end
 
-let read_depot () =
-  if depot_exists () |> not
-  then initialize ();
-  match try_read_depot () with
-  | None -> failwith "BUG: Something went wrong."
-  | Some r -> r
-
 let default_target_dir =
   Sys.getenv "SATYSFI_RUNTIME"
   |> Option.value ~default:(Filename.concat home_dir ".satysfi")
@@ -70,3 +63,7 @@ let read_environment () =
   let dist_library_dir = SatysfiDirs.satysfi_dist_dir ~outf:Format.std_formatter in
   Environment.{ depot; opam_reg = reg_opam; dist_library_dir }
 
+let read_depot_exn () =
+  let env = read_environment () in
+  env.Environment.depot
+  |> Option.value_exn ~message:"Satyrographos directory (e.g., ~/.satyrographs) does not exist."

--- a/bin/setup.mli
+++ b/bin/setup.mli
@@ -25,16 +25,8 @@ val depot_exists : unit -> bool
 (** Initialize the depot directory only when it does not exist or is not initialized. *)
 val initialize : unit -> unit
 
-(** OPAM registry. TODO Rename and/or make it private *)
-val reg_opam : Satyrographos.OpamSatysfiRegistry.t option
-
-(** Try to read Satyrographos depot. It returns None if it does not exists.
-    TODO make it private *)
-val try_read_depot : unit -> Satyrographos.Environment.depot option
-
-(** Try to read Satyrographos depot. If the depot does not exists, it returns a new initialized depot.
-    TODO work on Environment.t instead *)
-val read_depot : unit -> Satyrographos.Environment.depot
+(** Try to read Satyrographos depot. If the depot does not exists, throws an error. *)
+val read_depot_exn : unit -> Satyrographos.Environment.depot
 
 (** Default location of target of install subcommand *)
 val default_target_dir : string

--- a/bin/setup.mli
+++ b/bin/setup.mli
@@ -10,8 +10,8 @@ val root_dir : string
 (** Satyrographos source repository directory path. *)
 val repository_dir : string
 
-(** Satyrographos binary registry directory path. TODO Rename. *)
-val library_dir : string
+(** Satyrographos binary registry directory path. *)
+val registry_dir : string
 
 (** Satyrographos metadata file path. *)
 val metadata_file : string

--- a/bin/setup.mli
+++ b/bin/setup.mli
@@ -1,21 +1,6 @@
 (** Satyrographos depot schema version. *)
 val scheme_version : int
 
-(** Home directory. TODO Remove this. *)
-val home_dir : string
-
-(** Satyrographos depot directory path. *)
-val root_dir : string
-
-(** Satyrographos source repository directory path. *)
-val repository_dir : string
-
-(** Satyrographos binary registry directory path. *)
-val registry_dir : string
-
-(** Satyrographos metadata file path. *)
-val metadata_file : string
-
 (** Satyrographos depot schema version of the current depot directory. *)
 val current_scheme_version : int option
 

--- a/bin/setup.mli
+++ b/bin/setup.mli
@@ -19,8 +19,8 @@ val metadata_file : string
 (** Satyrographos depot schema version of the current depot directory. *)
 val current_scheme_version : int option
 
-(** Whether if the current Satyrographos depot exists and it’s in the current supported schema. TODO Rename. *)
-val repository_exists : unit -> bool
+(** Whether if the current Satyrographos depot exists and it’s in the current supported schema. *)
+val depot_exists : unit -> bool
 
 (** Initialize the depot directory only when it does not exist or is not initialized. *)
 val initialize : unit -> unit
@@ -29,12 +29,12 @@ val initialize : unit -> unit
 val reg_opam : Satyrographos.OpamSatysfiRegistry.t option
 
 (** Try to read Satyrographos depot. It returns None if it does not exists.
-    TODO Rename and/or make it private *)
-val try_read_repo : unit -> Satyrographos.Environment.repo option
+    TODO make it private *)
+val try_read_depot : unit -> Satyrographos.Environment.depot option
 
 (** Try to read Satyrographos depot. If the depot does not exists, it returns a new initialized depot.
-    TODO Rename and work on Environment.t instead *)
-val read_repo : unit -> Satyrographos.Environment.repo
+    TODO work on Environment.t instead *)
+val read_depot : unit -> Satyrographos.Environment.depot
 
 (** Default location of target of install subcommand *)
 val default_target_dir : string

--- a/src/command/install.ml
+++ b/src/command/install.ml
@@ -137,9 +137,9 @@ let add_autogen_libraries ~outf ~libraries ~env:(_ : Environment.t) library_map 
 let install d ~outf ~system_font_prefix ?(autogen_libraries=[]) ~libraries ~verbose ?(safe=false) ~copy ~(env: Environment.t) () =
   (* TODO build all *)
   Format.open_vbox 0;
-  let maybe_repo = env.repo in
+  let maybe_depot = env.depot in
   begin if safe
-    then Option.iter maybe_repo ~f:(fun {repo; reg} ->
+    then Option.iter maybe_depot ~f:(fun {repo; reg} ->
       Format.fprintf outf "Updating libraries@,";
       begin match Repository.update_all ~outf repo with
       | Some updated_libraries -> begin
@@ -159,7 +159,7 @@ let install d ~outf ~system_font_prefix ?(autogen_libraries=[]) ~libraries ~verb
         Format.fprintf outf "No libraries built@,"
       end)
   end;
-  let maybe_reg = Option.map maybe_repo ~f:(fun p -> p.reg) in
+  let maybe_reg = Option.map maybe_depot ~f:(fun p -> p.reg) in
   let library_map = get_libraries ~outf ~maybe_reg ~env ~libraries in
   let library_map = match system_font_prefix with
     | None -> Format.fprintf outf "Not gathering system fonts\n"; library_map

--- a/src/command/pin.ml
+++ b/src/command/pin.ml
@@ -9,8 +9,8 @@ let pin_list ~outf:(_: Format.formatter) repo =
 let pin_dir ~outf:(_: Format.formatter) repo p =
   Repository.directory repo p |> print_endline
 
-let pin_add ~outf env p url =
-  let Environment.{ repo; reg; } = env in
+let pin_add ~outf depot p url =
+  let Environment.{ repo; reg; } = depot in
   let (_: string list option) =
   Uri.of_string url
   |> Repository.add ~outf repo p in

--- a/src/command/pin.mli
+++ b/src/command/pin.mli
@@ -9,13 +9,13 @@ val pin_list : outf:Format.formatter -> Repository.t -> unit
 (* TODO Receive env instead of repo *)
 val pin_dir : outf:Format.formatter -> Repository.t -> string -> unit
 
-(** [pin_add ~outf repo package_name url]
+(** [pin_add ~outf depot package_name url]
     Register library [package_name] stored in [url], followed by building all the packages in the repository.
     TODO Build only related packages.
     TODO Error handling.
     TODO Retrieving remote codes. *)
 (* TODO Receive env instead of depot *)
-val pin_add : outf:Format.formatter -> Environment.repo -> string -> string -> unit
+val pin_add : outf:Format.formatter -> Environment.depot -> string -> string -> unit
 
 (** [pin_remove ~outf repo package_name]
     Remove library [package_name] from the repo.

--- a/src/environment.ml
+++ b/src/environment.ml
@@ -1,10 +1,10 @@
-type repo = {
+type depot = {
   repo: Repository.t;
   reg: Registry.t;
 }
 
 type t = {
-  repo: repo option;
+  depot: depot option;
   opam_reg: OpamSatysfiRegistry.t option;
   dist_library_dir: string option;
 }

--- a/src/environment.mli
+++ b/src/environment.mli
@@ -1,5 +1,5 @@
-(** Satyrographos depot. TODO Rename *)
-type repo = {
+(** Satyrographos depot. *)
+type depot = {
 
   repo: Repository.t;
   (** Satyrographos repository, which is a store of sourcecodes. *)
@@ -10,9 +10,8 @@ type repo = {
 
 (** A type represents runtime environment. *)
 type t = {
-  repo: repo option;
-  (** Satyrographos depot. I.e., ~/.satyrograpos.
-      TODO Rename with depot. *)
+  depot: depot option;
+  (** Satyrographos depot. I.e., ~/.satyrograpos. *)
 
   opam_reg: OpamSatysfiRegistry.t option;
   (** OPAM Registry. I.e., ~/.satyrograpos *)

--- a/src/satyrographosDirs.ml
+++ b/src/satyrographosDirs.ml
@@ -1,7 +1,8 @@
 open Core
 
 let repository_dir sg_dir = Filename.concat sg_dir "repo"
-let library_dir sg_dir = Filename.concat sg_dir "libraries"
+(* TODO Rename libraries with registry in the next major version. *)
+let registry_dir sg_dir = Filename.concat sg_dir "libraries"
 let metadata_file sg_dir = Filename.concat sg_dir "metadata"
 let version_file sg_dir = FilePath.concat sg_dir "version"
 
@@ -19,7 +20,7 @@ let get_scheme_version d =
     Option.value_exn line
     |> int_of_string
   in
-  match FileUtil.test FileUtil.Is_file file, FileUtil.test FileUtil.Is_dir (library_dir d) with
+  match FileUtil.test FileUtil.Is_file file, FileUtil.test FileUtil.Is_dir (registry_dir d) with
   | false, false -> None
   | false, true -> Some 0
   | true, false -> Some 0

--- a/test/testcases/command_install__unmanagedDirAlreadyExists.ml
+++ b/test/testcases/command_install__unmanagedDirAlreadyExists.ml
@@ -11,7 +11,7 @@ let env ~dest_dir ~temp_dir : Satyrographos.Environment.t t =
   PrepareDist.empty empty_dist
   >> mkdir (FilePath.concat dest_dir "dest")
   >> return Satyrographos.Environment.{
-    repo = None;
+    depot = None;
     opam_reg = None;
     dist_library_dir = Some empty_dist;
   }

--- a/test/testlib/testLib.ml
+++ b/test/testlib/testLib.ml
@@ -156,7 +156,7 @@ let test_install ?(replacements=[]) setup f : unit t =
 
 let read_env ?repo:_ ?opam_reg ?dist_library_dir () =
   Satyrographos.Environment.{
-    repo = None;
+    depot = None;
     opam_reg = begin match opam_reg with
       | Some opam_reg -> Satyrographos.OpamSatysfiRegistry.read opam_reg
       | None -> None end;


### PR DESCRIPTION
Satyrographos Depot and Satyrographos Registry were confusingly called Repo and Library.  This PR replaces the old usages with the new tems.