### PR TITLE
Microrefactoring of BuildScript related types

### DIFF
--- a/src/buildScript_0_0_2.ml
+++ b/src/buildScript_0_0_2.ml
@@ -10,10 +10,10 @@ let recursively f base_dir src acc =
     f dst src_path acc
   )) acc
 
-let add_files dst src acc = {acc with files=(dst, src) :: acc.files}
-let add_fonts dst src acc = {acc with fonts=(dst, src) :: acc.fonts}
-let add_hashes dst src acc = {acc with hashes=(dst, src) :: acc.hashes}
-let add_packages dst src acc = {acc with packages=(dst, src) :: acc.packages}
+let add_files dst src acc = {acc with files={dst; src} :: acc.files}
+let add_fonts dst src acc = {acc with fonts={dst; src} :: acc.fonts}
+let add_hashes dst src acc = {acc with hashes={dst; src} :: acc.hashes}
+let add_packages dst src acc = {acc with packages={dst; src} :: acc.packages}
 
 type source =
   | File of string * string

--- a/src/buildScript_0_0_2.ml
+++ b/src/buildScript_0_0_2.ml
@@ -10,10 +10,10 @@ let recursively f base_dir src acc =
     f dst src_path acc
   )) acc
 
-let add_files dst src acc = {acc with files={dst; src} :: acc.files}
-let add_fonts dst src acc = {acc with fonts={dst; src} :: acc.fonts}
-let add_hashes dst src acc = {acc with hashes={dst; src} :: acc.hashes}
-let add_packages dst src acc = {acc with packages={dst; src} :: acc.packages}
+let add_files dst src acc = `File {dst; src} :: acc
+let add_fonts dst src acc = `Font {dst; src} :: acc
+let add_hashes dst src acc = `Hash {dst; src} :: acc
+let add_packages dst src acc = `Package {dst; src} :: acc
 
 type source =
   | File of string * string

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -13,24 +13,25 @@ type link = {
 }
 [@@deriving sexp]
 
-type sources = {
-  files: link list
-    [@sexp.omit_nil];
-  fonts: link list
-    [@sexp.omit_nil];
-  hashes: link list
-    [@sexp.omit_nil];
-  packages: link list
-    [@sexp.omit_nil];
-}
+type source = [
+  | `File of link
+  | `Font of link
+  | `Hash of link
+  | `Package of link
+]
 [@@deriving sexp]
 
-let empty_sources = {
-  files=[];
-  fonts=[];
-  hashes=[];
-  packages=[];
-}
+type sources = source list
+[@@deriving sexp]
+
+let pacages_of_sources =
+  let f = function
+    | `Package l -> [l]
+    | _ -> []
+  in
+  List.concat_map ~f
+
+let empty_sources = []
 
 module CompatibilityIdents = Set.Make(String)
 module Compatibility = struct
@@ -137,7 +138,7 @@ let compatibility_treatment (p: library) (l: Library.t) =
       }
     | Satyrographos "0.0.1" ->
       let open Library in
-      let rename_packages = List.map p.sources.packages ~f:(fun {dst=name; _} ->
+      let rename_packages = List.map (pacages_of_sources p.sources) ~f:(fun {dst=name; _} ->
         let old_package_name = name in
         let new_package_name = p.name ^ "/" ^ name in
         Rename.{ old_name = old_package_name; new_name = new_package_name }
@@ -163,30 +164,42 @@ let compatibility_treatment (p: library) (l: Library.t) =
 
 (* Read *)
 let read_library (p: library) ~src_dir =
-  let map_file dst_dir =
-    let append_prefix =
+  let append_prefix dst_dir {dst; src} =
+    let dst_prefix =
       if String.is_empty dst_dir
       then ident
       else Filename.concat dst_dir in
-    List.map ~f:(fun {dst; src} -> {dst=append_prefix dst; src=Filename.concat src_dir src})
+    {dst=dst_prefix dst; src=Filename.concat src_dir src}
   in
-  let other_files = map_file "" p.sources.files in
-  let hashes =
-    map_file "hash" p.sources.hashes
-    |> List.fold ~init:Library.empty ~f:(fun a {dst; src} -> Library.add_hash dst src a)
+  let rebase_file = function
+    | `File l ->
+      `Filename (append_prefix "" l)
+    | `Hash l ->
+      `Hash (append_prefix "hash" l)
+    | `Font l ->
+      `Filename (append_prefix (Filename.concat "fonts" p.name) l)
+    | `Package l ->
+      `Filename (append_prefix (Filename.concat "packages" p.name) l)
   in
-  let fonts = map_file (Filename.concat "fonts" p.name) p.sources.fonts in
-  let packages = map_file (Filename.concat "packages" p.name) p.sources.packages in
-  Library.{ empty with
-    name = Some p.name;
-    version = Some p.version;
-    files =
-      List.concat [other_files; fonts; packages]
-      |> List.map ~f:(fun {dst; src} -> dst, `Filename src)
-      |> Library.LibraryFiles.of_alist_exn;
-    dependencies=p.dependencies;
-  }
-  |> Library.union hashes
+  let to_update_library_function = function
+    | `Hash {dst; src} ->
+      Library.add_hash dst src
+    | `Filename {dst; src} ->
+      Library.add_file dst src
+  in
+  let initial_library =
+    Library.{ empty with
+              name = Some p.name;
+              version = Some p.version;
+              dependencies=p.dependencies;
+            }
+  in
+  let libraries =
+    List.fold p.sources ~init:initial_library ~f:(fun l s ->
+        (rebase_file s |> to_update_library_function) l
+      )
+  in
+  Library.union initial_library libraries
   |> compatibility_treatment p
 
 let read_libraryDoc (p: libraryDoc) ~src_dir =


### PR DESCRIPTION
This PR does microrefactoring of BuildScript related types.

Unfortunately, I didn't come up with a clear structure of `BuildScript_prim.m`.  That will be addressed in another PR.