### PR TITLE
Improve DependencyGraph

### DIFF
--- a/bin/commandDebug.ml
+++ b/bin/commandDebug.ml
@@ -14,6 +14,7 @@ let depgraph_command =
     [%map_open
       let runtime_dirs = flag "--satysfi-root-dirs" (optional string) ~aliases:["C"] ~doc:"DIRs Colon-separated list of SATySFi root directories"
       and _verbose = flag "--verbose" no_arg ~doc:"Make verbose"
+      and mode = flag "--mode" (optional string) ~doc:"SATySFi typesetting mode (e.g., .satyh, .satyh-md, .satyg)"
       and follow_required = flag "--follow-required" no_arg ~aliases:["r"] ~doc:"Follow required package files"
       and satysfi_version = flag "--satysfi-version" (optional (Arg_type.of_alist_exn Version.alist)) ~aliases:["S"] ~doc:"VERSION SATySFi version"
       and satysfi_files = anon (non_empty_sequence_as_list ("FILE" %: string))
@@ -28,12 +29,16 @@ let depgraph_command =
             Option.to_list (user_dir ()) @ runtime_dirs ()
         in
         let outf = Format.err_formatter in
+        let mode = Option.bind ~f:Mode.of_extension_opt mode in
         let satysfi_version =
           (* TODO detect Satysfi version *)
           Option.value ~default:Version.Satysfi_0_0_5 satysfi_version
         in
         let package_root_dirs = SatysfiDirs.expand_package_root_dirs ~satysfi_version runtime_dirs in
         let g = DependencyGraph.dependency_graph ~outf ~package_root_dirs ~satysfi_version ~follow_required satysfi_files in
+        let g =
+          Option.value_map mode ~default:g ~f:(fun mode -> DependencyGraph.subgraph_with_mode ~mode g)
+        in
         DependencyGraph.Dot.fprint_graph Format.std_formatter g
     ]
 

--- a/src/satysfi/dependency.ml
+++ b/src/satysfi/dependency.ml
@@ -84,10 +84,11 @@ let parse_string ~path str =
   parse_directives str
   |> of_directives ~path
 
-let parse_file path =
-  In_channel.read_all path
-  |> parse_directives
-  |> of_directives ~path
+let parse_file_result path =
+  Result.try_with (fun () ->
+      In_channel.read_all path
+    )
+  |> Result.map ~f:(parse_string ~path)
 
 let%expect_test "parse_string: empty" =
   let path = "test.saty" in

--- a/test/testcases/command_debug_depgraph__missing_files.t
+++ b/test/testcases/command_debug_depgraph__missing_files.t
@@ -6,7 +6,7 @@ Prepare SATySFi source
   $ mkdir root
 
 Generate dependency graphs
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph --satysfi-root-dirs 'root' --follow-require first.saty
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph --satysfi-root-dirs 'root' --follow-require first.saty missing.saty
   Compatibility warning: You have opted in to use experimental features.
   Cannot read files for “@import: second”
   Candidate basenames:
@@ -20,6 +20,7 @@ Generate dependency graphs
   digraph G {
     "second" [shape=doubleoctagon, ];
     "lib1" [shape=ellipse, ];
+    "missing.saty" [shape=mdiamond, ];
     "first.saty" [shape=box, ];
     
     

--- a/test/testcases/command_debug_depgraph__subgraph_with_mode.t
+++ b/test/testcases/command_debug_depgraph__subgraph_with_mode.t
@@ -1,0 +1,51 @@
+Prepare SATySFi source
+  $ cat >first.saty <<EOF
+  > @import: second
+  > EOF
+  $ cat >second.satyh <<EOF
+  > EOF
+  $ cat >second.satyh-md <<EOF
+  > EOF
+  $ cat >second.satyg <<EOF
+  > EOF
+
+
+Generate dependency graphs for satyh
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph --mode .satyh first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  digraph G {
+    "second.satyh-md" [shape=box, ];
+    "second" [shape=doubleoctagon, ];
+    "second.satyh" [shape=box, ];
+    "second.satyg" [shape=box, ];
+    "first.saty" [shape=box, ];
+    
+    
+    "second" -> "second.satyg" [color="#000000", fontcolor="#000000",
+                                label=".satyg", style="dashed", ];
+    "second" -> "second.satyh" [color="#000000", fontcolor="#000000",
+                                label=".satyh", style="dashed", ];
+    "first.saty" -> "second" [color="#002288", fontcolor="#002288",
+                              label="@import: second", ];
+    
+    }
+
+Generate dependency graphs for satyh-md
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph --mode .satyh-md first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  digraph G {
+    "second.satyh-md" [shape=box, ];
+    "second" [shape=doubleoctagon, ];
+    "second.satyh" [shape=box, ];
+    "second.satyg" [shape=box, ];
+    "first.saty" [shape=box, ];
+    
+    
+    "second" -> "second.satyg" [color="#000000", fontcolor="#000000",
+                                label=".satyg", style="dashed", ];
+    "second" -> "second.satyh-md" [color="#000000", fontcolor="#000000",
+                                   label=".satyh-md", style="dashed", ];
+    "first.saty" -> "second" [color="#002288", fontcolor="#002288",
+                              label="@import: second", ];
+    
+    }


### PR DESCRIPTION
This PR improves DependencyGraph with

- Adding functions to get a subgraph with specific typesettinng `mode` (e.g., `.satyh`, `.satyh-md`, `.satyg`)
- Having missing files reported in the graph