### PR TITLE
Prepare dependent libraries for each test cases for lint subcommand 

### DIFF
--- a/src/environment.ml
+++ b/src/environment.ml
@@ -9,3 +9,8 @@ type t = {
   dist_library_dir: string option;
 }
 
+let empty = {
+  depot=None;
+  opam_reg=None;
+  dist_library_dir=None;
+}

--- a/src/environment.mli
+++ b/src/environment.mli
@@ -20,3 +20,6 @@ type t = {
   (** A directory with SATySFi dist for the current SATySFi compiler.
       Typically, this points a directory under OPAM reg or /usr/local/share/satysfi/dist. *)
 }
+
+(** An empty runtime environment. *)
+val empty: t

--- a/test/testcases/command_lint__missing_dependencies.ml
+++ b/test/testcases/command_lint__missing_dependencies.ml
@@ -39,5 +39,10 @@ let files =
     satyristes;
   ]
 
+let opam_libs = Satyrographos.Library.[
+    {empty with name = Some "package"};
+    {empty with name = Some "unspecified-package"};
+  ]
+
 let () =
-  TestCommand.test_lint_command files
+  TestCommand.test_lint_command ~opam_libs files

--- a/test/testcases/command_lint__unmatched_names.ml
+++ b/test/testcases/command_lint__unmatched_names.ml
@@ -46,5 +46,9 @@ let files =
     satyristes;
   ]
 
+let opam_libs = Satyrographos.Library.[
+    {empty with name = Some "package"};
+  ]
+
 let () =
-  TestCommand.test_lint_command files
+  TestCommand.test_lint_command ~opam_libs files

--- a/test/testcases/command_lint__unmatched_versions.ml
+++ b/test/testcases/command_lint__unmatched_versions.ml
@@ -76,5 +76,9 @@ let files =
     satyristes;
   ]
 
+let opam_libs = Satyrographos.Library.[
+    {empty with name = Some "package"};
+  ]
+
 let () =
-  TestCommand.test_lint_command files
+  TestCommand.test_lint_command ~opam_libs files

--- a/test/testcases/command_lint__valid.ml
+++ b/test/testcases/command_lint__valid.ml
@@ -26,7 +26,7 @@ let satyristes =
 (library
   (name "package")
   (version "0.1")
-  (sources ())
+  (sources ((package "test.satyh" "test.satyh")))
   (opam "satysfi-package.opam")
   (dependencies ()))
 
@@ -39,11 +39,24 @@ let satyristes =
   (dependencies ((package ()))))
 |}
 
+let test_satyh =
+  "test.satyh", {||}
+
+let opam_libs = Satyrographos.Library.[
+    {empty with
+     name = Some "package";
+     files = LibraryFiles.of_alist_exn [
+         "packages/package/test.satyh", `Content ""
+       ]
+    };
+]
+
 let files =
   [ satysfi_package_opam;
     satysfi_package_doc_opam;
     satyristes;
+    test_satyh;
   ]
 
 let () =
-  TestCommand.test_lint_command files
+  TestCommand.test_lint_command ~opam_libs files

--- a/test/testcases/command_lint__valid_in_specified_location.ml
+++ b/test/testcases/command_lint__valid_in_specified_location.ml
@@ -45,8 +45,12 @@ let files =
     satyristes;
   ]
 
+let opam_libs = Satyrographos.Library.[
+    {empty with name = Some "package"};
+  ]
+
 let () =
   let f cwd =
     ".", Some (FilePath.concat cwd "Satyristes")
   in
-  TestCommand.test_lint_command ~f files
+  TestCommand.test_lint_command ~f ~opam_libs files

--- a/test/testlib/testCommand.ml
+++ b/test/testlib/testCommand.ml
@@ -1,7 +1,8 @@
-let test_lint_command ?(f=fun cwd -> cwd, None) files =
+let test_lint_command ?(f=fun cwd -> cwd, None) ?(satysfi_files=[]) ?opam_libs files =
+  let outf = Format.std_formatter in
   let open Shexp_process in
   let open Shexp_process.Infix in
-  let test_cmd =
+  let test_cmd _env =
     Shexp_process.cwd_logical
     >>= fun cwd ->
     TestLib.run_function (fun ~outf ->
@@ -9,9 +10,38 @@ let test_lint_command ?(f=fun cwd -> cwd, None) files =
         Unix.chdir cwd;
         Satyrographos_command.Lint.lint ~outf ~verbose:false ~buildscript_path:path)
   in
-  let test_cmd test_dir =
-    TestLib.prepare_files test_dir files
-    >> Shexp_process.chdir test_dir test_cmd
+  let test_cmd work_dir reg_dir =
+    let open Satyrographos in
+    let opam_dir = FilePath.concat reg_dir "opam-satysfi" in
+    let dist_library_dir = FilePath.concat reg_dir "satysfi/dist" in
+    let create_opam_reg libs =
+      mkdir opam_dir
+      >> return libs
+      >>= List.iter ~f:(fun (lib: Library.t) ->
+          match lib.name with
+          | None -> return ()
+          | Some name ->
+            let lib_dir = FilePath.concat opam_dir name in
+            Library.write_dir ~outf lib_dir lib
+            |> return
+        )
+    in
+    let env () =
+      Environment.{
+        empty
+        with
+          opam_reg = OpamSatysfiRegistry.read opam_dir;
+          dist_library_dir=Some dist_library_dir
+      }
+    in
+    mkdir ~p:() dist_library_dir
+    >> (Option.map create_opam_reg opam_libs |> Option.value ~default:(return ()))
+    >> TestLib.prepare_files work_dir files
+    >> TestLib.prepare_files reg_dir satysfi_files
+    >>| env
+    >>= (fun env -> Shexp_process.chdir work_dir (test_cmd env))
   in
-  with_temp_dir ~prefix:"Satyrographos" ~suffix:"test_library" test_cmd
+  with_temp_dir ~prefix:"Satyrographos" ~suffix:"test_library" (fun test_dir ->
+      with_temp_dir ~prefix:"Satyrographos" ~suffix:"test_library_regs" (test_cmd test_dir)
+    )
   |> Shexp_process.eval


### PR DESCRIPTION
This PR has lint test cases prepare libraries in the OPAM registry.