### PR TITLE
Let Dune update version number in the command help

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -16,5 +16,6 @@ let total_command =
       "install", CommandInstall.install_command;
     ]
 
+(* %%VERSION_NUM%% is expanded by "dune subst" *)
 let () =
-  Command.run ~version:"0.0.2.7" total_command
+  Command.run ~version:"%%VERSION_NUM%%" total_command

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
 license: "LGPL-3.0-or-later"
 build: [
   ["dune" "subst"] {pinned}
+  ["sed" "-i.bak" "-e" "s/%%%%VERSION_NUM%%%%/%{version}%/" "bin/main.ml"]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [


### PR DESCRIPTION
This PR have `dune subst` substitute version placeholder `%%VERSION_NUM%%` for `opam pin` with a workaround.

Unfortunately `dune exec -- satyrographos --version` does not show a correct version.  This problem will be addresses by a following ticket.

Cf. https://github.com/gfngfn/SATySFi/pull/167