### PR TITLE
Add build subcommand

### DIFF
--- a/bin/commandBuild.ml
+++ b/bin/commandBuild.ml
@@ -1,0 +1,27 @@
+open Core
+
+module StringMap = Map.Make(String)
+
+let outf = Format.std_formatter
+
+let default_script_path () =
+  Filename.concat (FileUtil.pwd ()) "Satyristes"
+
+let build_command =
+  let open Command.Let_syntax in
+  let open RenameOption in
+  let outf = Format.std_formatter in
+  Command.basic
+    ~summary:"Install module into OPAM registory (experimental)"
+    [%map_open
+      let script = flag "--script" (optional string) ~doc:"SCRIPT Install script"
+      and name = anon (maybe ("MODULE_NAME" %: string))
+      and verbose = flag  "--verbose" no_arg ~doc:"Make verbose"
+      in
+      Compatibility.optin ();
+      let buildscript_path = Option.value ~default:(default_script_path ()) script in
+      let env = Setup.read_environment () in
+      (fun () ->
+         Satyrographos_command.Build.build_command ~outf ~buildscript_path ~name ~verbose ~env;
+         reprint_err_warn ())
+    ]

--- a/bin/commandBuild.ml
+++ b/bin/commandBuild.ml
@@ -20,8 +20,14 @@ let build_command =
       in
       Compatibility.optin ();
       let buildscript_path = Option.value ~default:(default_script_path ()) script in
+      let build_dir =
+        FilePath.concat
+          (FilePath.dirname buildscript_path)
+          "_build"
+        |> Option.some
+      in
       let env = Setup.read_environment () in
       (fun () ->
-         Satyrographos_command.Build.build_command ~outf ~buildscript_path ~name ~verbose ~env;
+         Satyrographos_command.Build.build_command ~outf ~build_dir ~buildscript_path ~name ~verbose ~env;
          reprint_err_warn ())
     ]

--- a/bin/commandDebug.ml
+++ b/bin/commandDebug.ml
@@ -38,7 +38,21 @@ let depgraph_command =
         DependencyGraph.Dot.fprint_graph Format.std_formatter g
     ]
 
+let status_project_env =
+  let open Command.Let_syntax in
+  Command.basic
+    ~summary:"Show project envirnment (experimental)"
+    [%map_open
+      let _ = args (* ToDo: Remove this *)
+      in
+      fun () ->
+        let open Satyrographos.Environment in
+        let project_env = get_project_env () in
+        printf !"%{sexp: project_env option}" project_env
+    ]
+
 let debug_command =
   Command.group ~summary:"SATySFi related utilities for debugging Satyrographos (experimental)"
     [ "depgraph", depgraph_command;
+      "project-env", status_project_env;
     ]

--- a/bin/commandSatysfi.ml
+++ b/bin/commandSatysfi.ml
@@ -1,7 +1,5 @@
 open Core
 
-module P = Shexp_process
-
 let satysfi_command =
   let open Command.Let_syntax in
   let readme () =
@@ -26,39 +24,30 @@ let satysfi_command =
           | xs -> Some xs in
         let env = Setup.read_environment () in
         let outf = Format.std_formatter in
-        let setup ~satysfi_dist =
-          Satyrographos_command.Install.install
-            satysfi_dist
-            ~outf
-            ~system_font_prefix:(Option.some_if use_system_fonts Satyrographos.SystemFontLibrary.system_font_prefix)
-            ~autogen_libraries:autogen_library_list
-            ~libraries
-            ~verbose
-            ~copy:false
-            ~env
-            ()
-        in
-          match satysfi_args with
-          | Some args ->
-            let commands satysfi_runtime =
-              let open P in
-              let open P.Infix in
-              let open Satyrographos_command.RunSatysfi in
-              echo "Running SATySFi..."
-              >> echo "=================="
-              >> assert_satysfi_option_C satysfi_runtime
-              >> P.run_exit_code "satysfi" (["-C"; satysfi_runtime] @ args)
-            in
-            let context = P.Context.create() in
-            let result, trace =
-              Satyrographos_command.RunSatysfi.with_env ~outf ~setup commands
-              |> P.Traced.eval_exn ~context in
-            if verbose
-            then begin Format.fprintf outf "Executed commands:@.";
-              Sexp.pp_hum_indent 2 Format.std_formatter trace;
-              Format.fprintf outf "@."
-            end;
-            exit result
-          | None ->
-            Format.fprintf outf "Specify arguments for SATySFi after “--”@."
+        match satysfi_args with
+        | Some args ->
+          let project_env = Satyrographos.Environment.get_project_env () in
+          let cmd =
+            Satyrographos_command.RunSatysfi.satysfi_command
+              ~outf
+              ~project_env
+              ~system_font_prefix:(Option.some_if use_system_fonts Satyrographos.SystemFontLibrary.system_font_prefix)
+              ~autogen_libraries:autogen_library_list
+              ~libraries
+              ~verbose
+              ~env
+              args
+          in
+          let context = Shexp_process.Context.create() in
+          let result, trace =
+            Shexp_process.Traced.eval_exn ~context cmd
+          in
+          if verbose
+          then begin Format.fprintf outf "Executed commands:@.";
+            Sexp.pp_hum_indent 2 Format.std_formatter trace;
+            Format.fprintf outf "@."
+          end;
+          exit result
+        | None ->
+          Format.fprintf outf "Specify arguments for SATySFi after “--”@."
     ]

--- a/bin/dune
+++ b/bin/dune
@@ -14,6 +14,7 @@
    setup
    renameOption
    compatibility
+   commandBuild
    commandDebug
    commandLint
    commandNew

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4,6 +4,7 @@ open Core
 let total_command =
   Command.group ~summary:"Simple SATySFi Package Manager"
     [
+      "build", CommandBuild.build_command;
       "debug", CommandDebug.debug_command;
       "new", CommandNew.new_command;
       "opam", CommandOpam.opam_command;

--- a/src/buildScript_0_0_2.ml
+++ b/src/buildScript_0_0_2.ml
@@ -65,6 +65,13 @@ module Section = struct
     dependencies: (string * unit (* for future extension *)) list
       [@sexp.omit_nil];
   } [@sexpr.list]
+  | Doc of {
+      name: string;
+      workingDirectory: string [@default "."];
+      build: string list list [@sexp.omit_nil];
+      dependencies: (string * unit (* for future extension *)) list
+                    [@sexp.omit_nil];
+    } [@sexpr.list]
   [@@deriving sexp]
 end
 
@@ -104,6 +111,10 @@ let section_to_modules ~base_dir (range, (m : Section.t)) =
       let dependencies = List.map dependencies ~f:fst |> Library.Dependency.of_list in
       let position = Some (position_of_range range) in
       [name, LibraryDoc {name; version; opam; workingDirectory: string; build; sources; dependencies; position; }]
+    | Doc {name; workingDirectory; build; dependencies;} ->
+      let position = Some (position_of_range range) in
+      let dependencies = List.map dependencies ~f:fst |> Library.Dependency.of_list in
+      [name, Doc {name; workingDirectory; build; dependencies; position;}]
 
 let sections_to_modules ~base_dir sections =
   let modules = sections |> List.concat_map ~f:(section_to_modules ~base_dir) in

--- a/src/buildScript_0_0_2.ml
+++ b/src/buildScript_0_0_2.ml
@@ -100,7 +100,7 @@ let section_to_modules ~base_dir (range, (m : Section.t)) =
       [name, Library {name; version; opam; sources; dependencies; compatibility; position; }]
     | LibraryDoc {name; version; opam; workingDirectory: string; build; sources; dependencies;} ->
       if String.suffix name 4 |> String.equal "-doc" |> not
-      then failwithf "libradiDoc must have suffic -doc but got %s" name ();
+      then failwithf "libraryDoc must have suffix -doc but got %s" name ();
       let dependencies = List.map dependencies ~f:fst |> Library.Dependency.of_list in
       let position = Some (position_of_range range) in
       [name, LibraryDoc {name; version; opam; workingDirectory: string; build; sources; dependencies; position; }]

--- a/src/command/build.ml
+++ b/src/command/build.ml
@@ -13,7 +13,7 @@ let read_module ~outf ~verbose ~build_module ~buildscript_path =
   end;
   (src_dir, p)
 
-let build_command ~satysfi_runtime = function
+let parse_build_command ~satysfi_runtime = function
       | "make" :: args ->
         let command = P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args) in
         ProcessUtil.redirect_to_stdout ~prefix:"make" command
@@ -25,24 +25,79 @@ let run_build_commands ~outf ~verbose ~libraries ~workingDir ~env ~system_font_p
   let setup ~satysfi_dist =
     Install.install satysfi_dist ~outf ~system_font_prefix ~autogen_libraries ~libraries ~verbose ~safe:true ~copy:false ~env ()
   in
-  let commands satysfi_runtime = P.List.iter buildCommands ~f:(build_command ~satysfi_runtime) in
+  let commands satysfi_runtime = P.List.iter buildCommands ~f:(parse_build_command ~satysfi_runtime) in
   P.(chdir workingDir (RunSatysfi.with_env ~outf ~setup commands))
 
 let build ~outf ~verbose ~build_module ~buildscript_path ~system_font_prefix ~autogen_libraries ~env =
   let src_dir, p = read_module ~outf ~verbose ~build_module ~buildscript_path in
 
-  match build_module with
-  | BuildScript.LibraryDoc build_module ->
+  let build workingDirectory build_commands =
     let context = P.Context.create() in
-    let workingDir = Filename.concat src_dir build_module.workingDirectory in
+    let workingDir = Filename.concat src_dir workingDirectory in
     let libraries = Library.Dependency.to_list p.dependencies |> Some in
     let _, trace =
-      run_build_commands ~outf ~verbose ~workingDir ~libraries ~system_font_prefix ~autogen_libraries ~env build_module.build
+      run_build_commands ~outf ~verbose ~workingDir ~libraries ~system_font_prefix ~autogen_libraries ~env build_commands
       |> P.Traced.eval_exn ~context in
     if verbose
     then begin Format.fprintf outf "Executed commands:@.";
       Sexp.pp_hum_indent 2 Format.std_formatter trace;
       Format.fprintf outf "@."
     end
+  in
+
+  match build_module with
+  | BuildScript.Doc build_module ->
+    build build_module.workingDirectory build_module.build
+  | BuildScript.LibraryDoc build_module ->
+    build build_module.workingDirectory build_module.build
   | BuildScript.Library _ ->
     ()
+
+
+let opam_pin_project ~(buildscript: BuildScript.t) ~buildscript_path =
+  let open P.Infix in
+  let workdir cwd =
+    FilePath.make_absolute cwd buildscript_path
+    |> FilePath.dirname
+  in
+  P.cwd_logical >>= fun cwd ->
+  Map.to_alist buildscript
+  |> P.List.iter ~f:(fun (_, l) ->
+      BuildScript.get_opam_opt l
+      |> Option.value_map ~default:(P.return ()) ~f:(fun opam_path ->
+          let basedir = workdir cwd in
+          let opam =
+            OpamFilename.create (OpamFilename.Dir.of_string basedir) (OpamFilename.Base.of_string opam_path)
+            |> OpamFile.make
+            |> OpamFile.OPAM.read
+          in
+          let opam_name =
+            Lint.get_opam_name ~opam ~opam_path
+          in
+          P.run "opam" ["pin"; "add"; "--yes"; opam_name; "file://" ^ workdir cwd]
+        )
+    )
+
+
+let build_command ~outf ~buildscript_path ~name ~verbose ~env =
+  let f ~buildscript~build_module =
+    let system_font_prefix = None in
+    let autogen_libraries = [] in
+    opam_pin_project ~buildscript ~buildscript_path
+    |> P.eval ;
+    build ~outf ~verbose ~build_module ~buildscript_path ~system_font_prefix ~autogen_libraries ~env
+  in
+  let buildscript = BuildScript.load buildscript_path in
+  match name with
+  | None -> begin
+      if Map.length buildscript = 1
+      then let build_module = Map.nth_exn buildscript 0 |> snd in
+        f ~buildscript ~build_module
+      else failwith "Please specify module name"
+    end
+  | Some name ->
+    match Map.find buildscript name with
+    | Some build_module ->
+      f ~buildscript ~build_module
+    | _ ->
+      failwithf "Build file does not contains library %s" name ()

--- a/src/command/build.ml
+++ b/src/command/build.ml
@@ -1,0 +1,48 @@
+open Core
+open Satyrographos
+
+module P = Shexp_process
+
+let read_module ~outf ~verbose ~build_module ~buildscript_path =
+  let src_dir = Filename.dirname buildscript_path in
+  let p = BuildScript.read_module ~src_dir build_module in
+  if verbose
+  then begin Format.fprintf outf "Read library:@.";
+    [%sexp_of: Library.t] p |> Sexp.pp_hum outf;
+    Format.fprintf outf "@."
+  end;
+  (src_dir, p)
+
+let build_command ~satysfi_runtime = function
+      | "make" :: args ->
+        let command = P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args) in
+        ProcessUtil.redirect_to_stdout ~prefix:"make" command
+      | "satysfi" :: args ->
+        RunSatysfi.run_satysfi ~satysfi_runtime args
+      | cmd -> failwithf "command %s is not yet supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()
+
+let run_build_commands ~outf ~verbose ~libraries ~workingDir ~env ~system_font_prefix ~autogen_libraries buildCommands =
+  let setup ~satysfi_dist =
+    Install.install satysfi_dist ~outf ~system_font_prefix ~autogen_libraries ~libraries ~verbose ~safe:true ~copy:false ~env ()
+  in
+  let commands satysfi_runtime = P.List.iter buildCommands ~f:(build_command ~satysfi_runtime) in
+  P.(chdir workingDir (RunSatysfi.with_env ~outf ~setup commands))
+
+let build ~outf ~verbose ~build_module ~buildscript_path ~system_font_prefix ~autogen_libraries ~env =
+  let src_dir, p = read_module ~outf ~verbose ~build_module ~buildscript_path in
+
+  match build_module with
+  | BuildScript.LibraryDoc build_module ->
+    let context = P.Context.create() in
+    let workingDir = Filename.concat src_dir build_module.workingDirectory in
+    let libraries = Library.Dependency.to_list p.dependencies |> Some in
+    let _, trace =
+      run_build_commands ~outf ~verbose ~workingDir ~libraries ~system_font_prefix ~autogen_libraries ~env build_module.build
+      |> P.Traced.eval_exn ~context in
+    if verbose
+    then begin Format.fprintf outf "Executed commands:@.";
+      Sexp.pp_hum_indent 2 Format.std_formatter trace;
+      Format.fprintf outf "@."
+    end
+  | BuildScript.Library _ ->
+    ()

--- a/src/command/opam.ml
+++ b/src/command/opam.ml
@@ -58,4 +58,3 @@ let with_build_script f ~outf ~prefix ~buildscript_path ~name ~verbose ~env () =
         f ~outf ~verbose ~prefix ~build_module ~buildscript_path ~env
       | _ ->
         failwithf "Build file does not contains library %s" name ()
-

--- a/src/command/opam.ml
+++ b/src/command/opam.ml
@@ -1,9 +1,6 @@
 open Core
 open Satyrographos
 
-module Process = Shexp_process
-module P = Process
-
 module StringMap = Map.Make(String)
 
 let library_dir prefix (buildscript: BuildScript.m) =
@@ -13,7 +10,15 @@ let library_dir prefix (buildscript: BuildScript.m) =
 let build_opam ~outf ~verbose ~prefix:_ ~build_module ~buildscript_path ~env =
   let system_font_prefix = None in
   let autogen_libraries = [] in
-  Build.build ~outf ~verbose ~build_module ~buildscript_path ~system_font_prefix ~autogen_libraries ~env
+  Build.build
+    ~outf
+    ~verbose
+    ~build_module
+    ~buildscript_path
+    ~build_dir:None
+    ~system_font_prefix
+    ~autogen_libraries
+    ~env
 
 let install_opam ~outf ~verbose ~prefix ~build_module ~buildscript_path ~env:_ =
   let _, p = Build.read_module ~outf ~verbose ~build_module ~buildscript_path in

--- a/src/command/opam.ml
+++ b/src/command/opam.ml
@@ -10,51 +10,13 @@ let library_dir prefix (buildscript: BuildScript.m) =
   let libdir = Filename.concat prefix "share/satysfi" in
   Filename.concat libdir (BuildScript.get_name buildscript)
 
-let read_module ~outf ~verbose ~build_module ~buildscript_path =
-  let src_dir = Filename.dirname buildscript_path in
-  let p = BuildScript.read_module ~src_dir build_module in
-  if verbose
-  then begin Format.fprintf outf "Read library:@.";
-    [%sexp_of: Library.t] p |> Sexp.pp_hum outf;
-    Format.fprintf outf "@."
-  end;
-  (src_dir, p)
-
-let run_build_commands ~outf ~verbose ~libraries ~workingDir ~env buildCommands =
-  let setup ~satysfi_dist =
-    Install.install satysfi_dist ~outf ~system_font_prefix:None ~autogen_libraries:[] ~libraries ~verbose ~safe:true ~copy:false ~env ()
-  in
-  let commands satysfi_runtime = P.List.iter buildCommands ~f:(function
-    | "make" :: args ->
-      let command = P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args) in
-      ProcessUtil.redirect_to_stdout ~prefix:"make" command
-    | "satysfi" :: args ->
-      RunSatysfi.run_satysfi ~satysfi_runtime args
-    | cmd -> failwithf "command %s is not yet supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()
-  ) in
-  P.(chdir workingDir (RunSatysfi.with_env ~outf ~setup commands))
-
 let build_opam ~outf ~verbose ~prefix:_ ~build_module ~buildscript_path ~env =
-  let src_dir, p = read_module ~outf ~verbose ~build_module ~buildscript_path in
-
-  match build_module with
-  | BuildScript.LibraryDoc build_module ->
-    let context = Process.Context.create() in
-    let workingDir = Filename.concat src_dir build_module.workingDirectory in
-    let libraries = Library.Dependency.to_list p.dependencies |> Some in
-    let _, trace =
-      run_build_commands ~outf ~verbose ~workingDir ~libraries ~env build_module.build
-      |> P.Traced.eval_exn ~context in
-    if verbose
-    then begin Format.fprintf outf "Executed commands:@.";
-      Sexp.pp_hum_indent 2 Format.std_formatter trace;
-      Format.fprintf outf "@."
-    end
-  | BuildScript.Library _ ->
-    Format.fprintf outf "Building modules is not yet supported"
+  let system_font_prefix = None in
+  let autogen_libraries = [] in
+  Build.build ~outf ~verbose ~build_module ~buildscript_path ~system_font_prefix ~autogen_libraries ~env
 
 let install_opam ~outf ~verbose ~prefix ~build_module ~buildscript_path ~env:_ =
-  let _, p = read_module ~outf ~verbose ~build_module ~buildscript_path in
+  let _, p = Build.read_module ~outf ~verbose ~build_module ~buildscript_path in
   let dir = library_dir prefix build_module in
   Library.write_dir ~outf ~verbose ~symlink:false dir p
 

--- a/src/environment.ml
+++ b/src/environment.ml
@@ -14,3 +14,37 @@ let empty = {
   opam_reg=None;
   dist_library_dir=None;
 }
+
+open Core
+
+type project_env = {
+  buildscript_path: string;
+  satysfi_runtime_dir: string;
+}
+[@@deriving sexp]
+
+module P = Shexp_process
+
+let get_satysfi_runtime_dir pe =
+  pe.satysfi_runtime_dir
+
+let get_satysfi_dist_dir pe =
+  FilePath.concat (get_satysfi_runtime_dir pe) "dist"
+
+let project_env_name = "SATYROGRAPHOS_PROJECT"
+let set_project_env_cmd pe c =
+  let serialized =
+    [%sexp_of: project_env] pe
+    |> Sexp.to_string_mach
+  in
+  P.set_env project_env_name serialized c
+
+let get_project_env_cmd =
+  let open P.Infix in
+  P.get_env project_env_name
+  >>| Option.map ~f:(fun str -> Sexp.of_string_conv_exn str [%of_sexp: project_env])
+
+let get_project_env () =
+  Sys.getenv project_env_name
+  |> Option.map ~f:(fun str -> Sexp.of_string_conv_exn str [%of_sexp: project_env])
+

--- a/src/environment.mli
+++ b/src/environment.mli
@@ -23,3 +23,21 @@ type t = {
 
 (** An empty runtime environment. *)
 val empty: t
+
+(** Environment for child Satyrographos processes *)
+type project_env = {
+  buildscript_path: string;
+  satysfi_runtime_dir: string;
+}
+[@@deriving sexp]
+
+(* TODO Rename with satysfi_root_dir *)
+val get_satysfi_runtime_dir : project_env -> string
+
+val get_satysfi_dist_dir : project_env -> string
+
+val set_project_env_cmd : project_env -> 'a Shexp_process.t -> 'a Shexp_process.t
+
+val get_project_env_cmd : project_env option Shexp_process.t
+
+val get_project_env : unit -> project_env option

--- a/test/testcases/command_build__doc_make.expected
+++ b/test/testcases/command_build__doc_make.expected
@@ -18,6 +18,7 @@ make out> ./dist/packages
 make out> ./dist/packages/grcnum
 make out> ./dist/packages/grcnum/grcnum.satyh
 make out> ==============================
+make out> satyrographos debug project-env | grep -e 'pkg/Satyristes' >/dev/null || (satyrographos debug project-env ; exit 1)
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
 Reading opam libraries: (base class-greek fonts-theano grcnum)
@@ -44,9 +45,6 @@ Installation completed!
 ------------------------------------------------------------
 ------------------------------------------------------------
 Command invoked:
-opam pin add --yes satysfi-grcnum file://@@temp_dir@@/pkg
+opam var share
 Command invoked:
-satysfi -C @@temp_dir@@/pkg/_build/satysfi --version
-Command invoked:
-satysfi -C @@temp_dir@@/pkg/_build/satysfi doc-example.saty -o doc-example-ja.pdf
-doc-example.saty -> doc-example-ja.pdf
+opam var share

--- a/test/testcases/command_build__doc_make.ml
+++ b/test/testcases/command_build__doc_make.ml
@@ -8,35 +8,13 @@ open Shexp_process
 let satyristes =
 {|
 (version "0.0.2")
-(library
-  (name "grcnum")
-  (version "0.2")
-  (sources
-    ((package "grcnum.satyh" "./grcnum.satyh")
-     (font "grcnum-font.ttf" "./font.ttf")
-     (hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
-     ; (file "doc/grcnum.md" "README.md")
-    ))
-  (opam "satysfi-grcnum.opam")
-  (dependencies ((fonts-theano ())))
-  (compatibility ((satyrographos 0.0.1))))
-(libraryDoc
-  (name "grcnum-doc")
-  (version "0.2")
+(doc
+  (name "example-doc")
   (build
-    ((satysfi "doc-grcnum.saty" "-o" "doc-grcnum-ja.pdf")
-     (make "build-doc")))
-  (sources
-    ((doc "doc-grcnum-ja.pdf" "./doc-grcnum-ja.pdf")))
-  (opam "satysfi-grcnum-doc.opam")
+    ((make "build-doc")))
   (dependencies ((grcnum ())
                  (fonts-theano ()))))
 |}
-
-let fontHash =
-{|{
-  "grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>
-}|}
 
 let makefile =
 {|
@@ -47,6 +25,7 @@ build-doc:
 	@echo "=============================="
 	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
 	@echo "=============================="
+	satyrographos debug project-env | grep -e 'pkg/Satyristes' >/dev/null || (satyrographos debug project-env ; exit 1)
 |}
 
 let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
@@ -56,10 +35,7 @@ let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
     PrepareDist.empty pkg_dir
     >> stdout_to (FilePath.concat pkg_dir "Satyristes") (echo satyristes)
     >> stdout_to (FilePath.concat pkg_dir "README.md") (echo "@@README.md@@")
-    >> stdout_to (FilePath.concat pkg_dir "fonts.satysfi-hash") (echo fontHash)
-    >> stdout_to (FilePath.concat pkg_dir "grcnum.satyh") (echo "@@grcnum.satyh@@")
-    >> stdout_to (FilePath.concat pkg_dir "font.ttf") (echo "@@font.ttf@@")
-    >> stdout_to (FilePath.concat pkg_dir "doc-grcnum.saty") (echo "@@doc-grcnum.saty@@")
+    >> stdout_to (FilePath.concat pkg_dir "doc-example.saty") (echo "@@doc-example.saty@@")
     >> stdout_to (FilePath.concat pkg_dir "Makefile") (echo makefile)
   in
   let empty_dist = FilePath.concat temp_dir "empty_dist" in
@@ -81,17 +57,15 @@ let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
 
 let () =
   let verbose = false in
-  let main env ~dest_dir ~temp_dir ~outf =
-    let name = Some "grcnum-doc" in
-    let dest_dir = FilePath.concat dest_dir "dest" in
-    let open Satyrographos_command.Opam in
-    with_build_script
-      build_opam
+  let main env ~dest_dir:_ ~temp_dir ~outf =
+    let name = Some "example-doc" in
+    (* let dest_dir = FilePath.concat dest_dir "dest" in *)
+    Satyrographos_command.Build.build_command
       ~outf
       ~verbose
-      ~prefix:dest_dir
       ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
+      ~build_dir:(FilePath.concat temp_dir "pkg/_build" |> Option.some)
       ~env
       ~name
-      () in
+  in
   eval (test_install env main)

--- a/test/testcases/command_build__doc_satysfi.expected
+++ b/test/testcases/command_build__doc_satysfi.expected
@@ -1,0 +1,51 @@
+Installing packages
+------------------------------------------------------------
+make out> Target: build-doc
+make out> Files under $SATYSFI_RUNTIME
+make out> ==============================
+make out> .
+make out> ./dist
+make out> ./dist/.satyrographos
+make out> ./dist/fonts
+make out> ./dist/fonts/fonts-theano
+make out> ./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
+make out> ./dist/fonts/fonts-theano/TheanoModern-Regular.otf
+make out> ./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+make out> ./dist/hash
+make out> ./dist/hash/fonts.satysfi-hash
+make out> ./dist/metadata
+make out> ./dist/packages
+make out> ./dist/packages/grcnum
+make out> ./dist/packages/grcnum/grcnum.satyh
+make out> ==============================
+Reading runtime dist: @@temp_dir@@/empty_dist
+Read user libraries: ()
+Reading opam libraries: (base class-greek fonts-theano grcnum)
+Not gathering system fonts
+Installing libraries: (dist fonts-theano grcnum)
+Removing destination @@with_env@@/dist
+Installation completed!
+
+[1;33mCompatibility notice[0m for library fonts-theano:
+
+  Fonts have been renamed.
+  
+    TheanoDidot -> fonts-theano:TheanoDidot
+    TheanoModern -> fonts-theano:TheanoModern
+    TheanoOldStyle -> fonts-theano:TheanoOldStyle
+
+[1;33mCompatibility notice[0m for library grcnum:
+
+  Packages have been renamed.
+  
+    grcnum.satyh -> grcnum/grcnum.satyh
+Setting up SATySFi env at @@with_env@@ 
+------------------------------------------------------------
+@@dest_dir@@
+------------------------------------------------------------
+------------------------------------------------------------
+Command invoked:
+satysfi -C @@with_env@@ --version
+Command invoked:
+satysfi -C @@with_env@@ doc-example.saty -o doc-example-ja.pdf
+doc-example.saty -> doc-example-ja.pdf

--- a/test/testcases/command_build__doc_satysfi.expected
+++ b/test/testcases/command_build__doc_satysfi.expected
@@ -23,7 +23,7 @@ Read user libraries: ()
 Reading opam libraries: (base class-greek fonts-theano grcnum)
 Not gathering system fonts
 Installing libraries: (dist fonts-theano grcnum)
-Removing destination @@with_env@@/dist
+Removing destination @@temp_dir@@/pkg/_build/satysfi/dist
 Installation completed!
 
 [1;33mCompatibility notice[0m for library fonts-theano:
@@ -39,13 +39,12 @@ Installation completed!
   Packages have been renamed.
   
     grcnum.satyh -> grcnum/grcnum.satyh
-Setting up SATySFi env at @@with_env@@ 
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------
 ------------------------------------------------------------
 Command invoked:
-satysfi -C @@with_env@@ --version
+satysfi -C @@temp_dir@@/pkg/_build/satysfi --version
 Command invoked:
-satysfi -C @@with_env@@ doc-example.saty -o doc-example-ja.pdf
+satysfi -C @@temp_dir@@/pkg/_build/satysfi doc-example.saty -o doc-example-ja.pdf
 doc-example.saty -> doc-example-ja.pdf

--- a/test/testcases/command_build__doc_satysfi.ml
+++ b/test/testcases/command_build__doc_satysfi.ml
@@ -1,0 +1,70 @@
+module StdList = List
+
+open Satyrographos_testlib
+open TestLib
+
+open Shexp_process
+
+let satyristes =
+{|
+(version "0.0.2")
+(doc
+  (name "example-doc")
+  (build
+    ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
+     (make "build-doc")))
+  (dependencies ((grcnum ())
+                 (fonts-theano ()))))
+|}
+
+let makefile =
+{|
+PHONY: build-doc
+build-doc:
+	@echo "Target: build-doc"
+	@echo 'Files under $$SATYSFI_RUNTIME'
+	@echo "=============================="
+	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
+	@echo "=============================="
+|}
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let pkg_dir = FilePath.concat temp_dir "pkg" in
+  let prepare_pkg =
+    PrepareDist.empty pkg_dir
+    >> stdout_to (FilePath.concat pkg_dir "Satyristes") (echo satyristes)
+    >> stdout_to (FilePath.concat pkg_dir "README.md") (echo "@@README.md@@")
+    >> stdout_to (FilePath.concat pkg_dir "doc-example.saty") (echo "@@doc-example.saty@@")
+    >> stdout_to (FilePath.concat pkg_dir "Makefile") (echo makefile)
+  in
+  let empty_dist = FilePath.concat temp_dir "empty_dist" in
+  let prepare_dist = PrepareDist.empty empty_dist in
+  let opam_reg = FilePath.concat temp_dir "opam_reg" in
+  let log_file = exec_log_file_path temp_dir in
+  let prepare_opam_reg =
+    PrepareOpamReg.(prepare opam_reg theanoFiles)
+    >> PrepareOpamReg.(prepare opam_reg grcnumFiles)
+    >> PrepareOpamReg.(prepare opam_reg classGreekFiles)
+    >> PrepareOpamReg.(prepare opam_reg baseFiles)
+  in
+  let bin = FilePath.concat temp_dir "bin" in
+  prepare_pkg
+  >> prepare_dist
+  >> prepare_opam_reg
+  >> PrepareBin.prepare_bin bin log_file
+  >>| read_env ~opam_reg ~dist_library_dir:empty_dist
+
+let () =
+  let verbose = false in
+  let main env ~dest_dir:_ ~temp_dir ~outf =
+    let name = Some "example-doc" in
+    (* let dest_dir = FilePath.concat dest_dir "dest" in *)
+    Satyrographos_command.Build.build_command
+      ~outf
+      ~verbose
+      ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
+      ~env
+      ~name
+  in
+  eval (test_install env main)

--- a/test/testcases/command_build__doc_satysfi.ml
+++ b/test/testcases/command_build__doc_satysfi.ml
@@ -64,6 +64,7 @@ let () =
       ~outf
       ~verbose
       ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
+      ~build_dir:(FilePath.concat temp_dir "pkg/_build" |> Option.some)
       ~env
       ~name
   in

--- a/test/testcases/command_build__doc_with_libraries.expected
+++ b/test/testcases/command_build__doc_with_libraries.expected
@@ -1,0 +1,53 @@
+Installing packages
+------------------------------------------------------------
+make out> Target: build-doc
+make out> Files under $SATYSFI_RUNTIME
+make out> ==============================
+make out> .
+make out> ./dist
+make out> ./dist/.satyrographos
+make out> ./dist/fonts
+make out> ./dist/fonts/fonts-theano
+make out> ./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
+make out> ./dist/fonts/fonts-theano/TheanoModern-Regular.otf
+make out> ./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+make out> ./dist/hash
+make out> ./dist/hash/fonts.satysfi-hash
+make out> ./dist/metadata
+make out> ./dist/packages
+make out> ./dist/packages/grcnum
+make out> ./dist/packages/grcnum/grcnum.satyh
+make out> ==============================
+Reading runtime dist: @@temp_dir@@/empty_dist
+Read user libraries: ()
+Reading opam libraries: (base class-greek fonts-theano grcnum)
+Not gathering system fonts
+Installing libraries: (dist fonts-theano grcnum)
+Removing destination @@with_env@@/dist
+Installation completed!
+
+[1;33mCompatibility notice[0m for library fonts-theano:
+
+  Fonts have been renamed.
+  
+    TheanoDidot -> fonts-theano:TheanoDidot
+    TheanoModern -> fonts-theano:TheanoModern
+    TheanoOldStyle -> fonts-theano:TheanoOldStyle
+
+[1;33mCompatibility notice[0m for library grcnum:
+
+  Packages have been renamed.
+  
+    grcnum.satyh -> grcnum/grcnum.satyh
+Setting up SATySFi env at @@with_env@@ 
+------------------------------------------------------------
+@@dest_dir@@
+------------------------------------------------------------
+------------------------------------------------------------
+Command invoked:
+opam pin add --yes satysfi-grcnum file://@@temp_dir@@/pkg
+Command invoked:
+satysfi -C @@with_env@@ --version
+Command invoked:
+satysfi -C @@with_env@@ doc-example.saty -o doc-example-ja.pdf
+doc-example.saty -> doc-example-ja.pdf

--- a/test/testcases/command_build__doc_with_libraries.ml
+++ b/test/testcases/command_build__doc_with_libraries.ml
@@ -105,6 +105,7 @@ let () =
       ~outf
       ~verbose
       ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
+      ~build_dir:(FilePath.concat temp_dir "pkg/_build" |> Option.some)
       ~env
       ~name
   in

--- a/test/testcases/command_build__doc_with_libraries.ml
+++ b/test/testcases/command_build__doc_with_libraries.ml
@@ -1,0 +1,111 @@
+module StdList = List
+
+open Satyrographos_testlib
+open TestLib
+
+open Shexp_process
+
+let satyristes =
+{|
+(version "0.0.2")
+(library
+  (name "grcnum")
+  (version "0.2")
+  (sources
+    ((package "grcnum.satyh" "./grcnum.satyh")
+     (font "grcnum-font.ttf" "./font.ttf")
+     (hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
+     ; (file "doc/grcnum.md" "README.md")
+    ))
+  (opam "satysfi-grcnum.opam")
+  (dependencies ((fonts-theano ()))))
+
+(doc
+  (name "example-doc")
+  (build
+    ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
+     (make "build-doc")))
+  (dependencies ((grcnum ())
+                 (fonts-theano ()))))
+|}
+
+let satysfi_grcnum_opam =
+  "satysfi-grcnum.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-grcnum"
+    ~version:"0.1"
+    ()
+
+let fontHash =
+{|{
+  "grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>
+}|}
+
+let makefile =
+{|
+PHONY: build-doc
+build-doc:
+	@echo "Target: build-doc"
+	@echo 'Files under $$SATYSFI_RUNTIME'
+	@echo "=============================="
+	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
+	@echo "=============================="
+|}
+
+let files =
+  [
+    satysfi_grcnum_opam;
+    "Satyristes", satyristes;
+    "README.md", "@@README.md@@";
+    "fonts.satysfi-hash", fontHash;
+    "grcnum.satyh", "@@grcnum.satyh@@";
+    "font.ttf", "@@font.ttf@@";
+    "doc-grcnum.saty", "@@doc-grcnum.saty@@";
+    "doc-example.saty", "@@doc-example.saty@@";
+    "Makefile", makefile;
+  ]
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let pkg_dir = FilePath.concat temp_dir "pkg" in
+  let prepare_pkg =
+    PrepareDist.empty pkg_dir
+    >> prepare_files pkg_dir files
+    >> stdout_to (FilePath.concat pkg_dir "Satyristes") (echo satyristes)
+    >> stdout_to (FilePath.concat pkg_dir "README.md") (echo "@@README.md@@")
+    >> stdout_to (FilePath.concat pkg_dir "fonts.satysfi-hash") (echo fontHash)
+    >> stdout_to (FilePath.concat pkg_dir "grcnum.satyh") (echo "@@grcnum.satyh@@")
+    >> stdout_to (FilePath.concat pkg_dir "font.ttf") (echo "@@font.ttf@@")
+    >> stdout_to (FilePath.concat pkg_dir "doc-grcnum.saty") (echo "@@doc-grcnum.saty@@")
+    >> stdout_to (FilePath.concat pkg_dir "doc-example.saty") (echo "@@doc-example.saty@@")
+    >> stdout_to (FilePath.concat pkg_dir "Makefile") (echo makefile)
+  in
+  let empty_dist = FilePath.concat temp_dir "empty_dist" in
+  let prepare_dist = PrepareDist.empty empty_dist in
+  let opam_reg = FilePath.concat temp_dir "opam_reg" in
+  let log_file = exec_log_file_path temp_dir in
+  let prepare_opam_reg =
+    PrepareOpamReg.(prepare opam_reg theanoFiles)
+    >> PrepareOpamReg.(prepare opam_reg grcnumFiles)
+    >> PrepareOpamReg.(prepare opam_reg classGreekFiles)
+    >> PrepareOpamReg.(prepare opam_reg baseFiles)
+  in
+  let bin = FilePath.concat temp_dir "bin" in
+  prepare_pkg
+  >> prepare_dist
+  >> prepare_opam_reg
+  >> PrepareBin.prepare_bin bin log_file
+  >>| read_env ~opam_reg ~dist_library_dir:empty_dist
+
+let () =
+  let verbose = false in
+  let main env ~dest_dir:_ ~temp_dir ~outf =
+    let name = Some "example-doc" in
+    (* let dest_dir = FilePath.concat dest_dir "dest" in *)
+    Satyrographos_command.Build.build_command
+      ~outf
+      ~verbose
+      ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
+      ~env
+      ~name
+  in
+  eval (test_install env main)

--- a/test/testcases/command_opam_build__doc_satysfi.expected
+++ b/test/testcases/command_opam_build__doc_satysfi.expected
@@ -23,7 +23,7 @@ Read user libraries: ()
 Reading opam libraries: (base class-greek fonts-theano grcnum)
 Not gathering system fonts
 Installing libraries: (dist fonts-theano grcnum)
-Removing destination @@with_env@@/dist
+Removing destination @@build@@/satysfi/dist
 Installation completed!
 
 [1;33mCompatibility notice[0m for library fonts-theano:
@@ -39,13 +39,12 @@ Installation completed!
   Packages have been renamed.
   
     grcnum.satyh -> grcnum/grcnum.satyh
-Setting up SATySFi env at @@with_env@@ 
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------
 ------------------------------------------------------------
 Command invoked:
-satysfi -C @@with_env@@ --version
+satysfi -C @@build@@/satysfi --version
 Command invoked:
-satysfi -C @@with_env@@ doc-grcnum.saty -o doc-grcnum-ja.pdf
+satysfi -C @@build@@/satysfi doc-grcnum.saty -o doc-grcnum-ja.pdf
 doc-grcnum.saty -> doc-grcnum-ja.pdf

--- a/test/testcases/command_satysfi__with_project_env.expected
+++ b/test/testcases/command_satysfi__with_project_env.expected
@@ -1,0 +1,9 @@
+Running SATySFi...
+==================
+------------------------------------------------------------
+Command invoked:
+satysfi -C @@satysfi@@/pkg/_build/satysfi --version
+Command invoked:
+satysfi -C @@satysfi@@/pkg/_build/satysfi @@satysfi@@/pkg/doc-example.saty -o @@satysfi@@/pkg/doc-example.pdf
+@@satysfi@@/pkg/doc-example.saty -> @@satysfi@@/pkg/doc-example.pdf
+------------------------------------------------------------

--- a/test/testcases/command_satysfi__with_project_env.ml
+++ b/test/testcases/command_satysfi__with_project_env.ml
@@ -1,0 +1,95 @@
+module StdList = List
+
+open Satyrographos_testlib
+open Core
+
+open Shexp_process
+
+let satyristes =
+{|
+(version "0.0.2")
+(library
+  (name "grcnum")
+  (version "0.2")
+  (sources
+    ((package "grcnum.satyh" "./grcnum.satyh")
+     (font "grcnum-font.ttf" "./font.ttf")
+     (hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
+     (file "doc/grcnum.md" "README.md")
+     (fontDir "font")
+     (packageDir "src")
+    ))
+  (opam "satysfi-grcnum.opam")
+  (dependencies ((fonts-theano ())))
+  (compatibility ((satyrographos 0.0.1))))
+(libraryDoc
+  (name "grcnum-doc")
+  (version "0.2")
+  (build
+    ((satysfi "doc-grcnum.saty" "-o" "doc-grcnum-ja.pdf")))
+  (sources
+    ((doc "doc-grcnum-ja.pdf" "./doc-grcnum-ja.pdf")))
+  (opam "satysfi-grcnum-doc.opam")
+  (dependencies ((grcnum ())
+                 (fonts-theano ()))))
+|}
+
+let () =
+  let main ~outf ~temp_dir =
+    let open Shexp_process.Infix in
+    let log_file = FilePath.concat temp_dir "exec.log" in
+    let pkg_dir = FilePath.concat temp_dir "pkg" in
+    let prepare_pkg =
+      PrepareDist.empty pkg_dir
+      >> stdout_to (FilePath.concat pkg_dir "Satyristes") (echo satyristes)
+      >> stdout_to (FilePath.concat pkg_dir "README.md") (echo "@@README.md@@")
+      >> stdout_to (FilePath.concat pkg_dir "doc-example.saty") (echo "@@doc-example.saty@@")
+    in
+    let empty_dist = FilePath.concat temp_dir "empty_dist" in
+    let prepare_dist = PrepareDist.empty empty_dist in
+    let opam_reg = FilePath.concat temp_dir "opam_reg" in
+    let bin_dir = FilePath.concat temp_dir "bin" in
+    let system_font_prefix = None in
+    let autogen_libraries = [] in
+    let libraries = Some [] in
+    let verbose = true in
+    let project_env = Some Satyrographos.Environment.{
+        buildscript_path = FilePath.concat pkg_dir "Satyristes";
+        satysfi_runtime_dir = FilePath.concat pkg_dir "_build/satysfi";
+      }
+    in
+    let cmd =
+      PrepareBin.prepare_bin bin_dir log_file
+      >> prepare_pkg
+      >> prepare_dist
+      >>| TestLib.read_env ~opam_reg ~dist_library_dir:empty_dist
+      >>= fun env ->
+      Satyrographos_command.RunSatysfi.satysfi_command
+        ~outf
+        ~system_font_prefix
+        ~autogen_libraries
+        ~libraries
+        ~verbose
+        ~project_env
+        ~env
+        [FilePath.concat pkg_dir "doc-example.saty"; "-o"; FilePath.concat pkg_dir "doc-example.pdf";]
+      >>= (fun exit_code ->
+          if exit_code <> 0
+          then sprintf "Non zero exit code: %d" exit_code |> echo
+          else return ())
+      >> TestLib.echo_line
+      >> stdin_from log_file (iter_lines echo)
+      >> TestLib.echo_line
+    in
+    TestLib.with_bin_dir bin_dir cmd
+  in
+  let open Shexp_process.Infix in
+  eval (
+    Shexp_process.with_temp_dir ~prefix:"Satyrographos" ~suffix:"satysfi" (fun temp_dir ->
+        TestLib.with_formatter_map (fun outf ->
+            main ~outf ~temp_dir
+          )
+      )
+    |- TestLib.censor_tempdirs
+  )
+

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -1,5 +1,6 @@
 (tests
  (names
+   command_build__doc_make
    command_build__doc_satysfi
    command_build__doc_with_libraries
    command_install__distWithBrokenHash
@@ -38,6 +39,7 @@
    command_opam_install__library_missingHash
    command_opam_install__library_missingPackage
    command_opam_install__library_recursive
+   command_satysfi__with_project_env
    library_write_dir__content
  )
  (preprocess (pps ppx_deriving.std ppx_jane))

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -1,5 +1,7 @@
 (tests
  (names
+   command_build__doc_satysfi
+   command_build__doc_with_libraries
    command_install__distWithBrokenHash
    command_install__distWithNonHashUnderHashDir
    command_install__emptyDist

--- a/test/testlib/testLib.ml
+++ b/test/testlib/testLib.ml
@@ -60,6 +60,14 @@ let with_formatter ?(where=Std_io.Stdout) f =
   echo ~where ~n:() (Buffer.contents buf)
   >> return v
 
+let with_formatter_map ?(where=Std_io.Stdout) f =
+  let buf = Buffer.create 100 in
+  let fmt = Format.make_formatter (Buffer.add_substring buf) ignore in
+  f fmt
+  >>= fun v ->
+  echo ~where ~n:() (Buffer.contents buf)
+  >> return v
+
 let echo_line =
   echo "------------------------------------------------------------"
 
@@ -218,3 +226,8 @@ install: [
    "--script" "%%{build}%%/Satyristes"]
 ]
 |} synopsis name version description depends satysfi_name
+
+let with_bin_dir bin_dir cmd =
+  get_env "PATH"
+  >>= fun path ->
+  set_env "PATH" (bin_dir ^ ":" ^ Option.get path) cmd

--- a/test/testlib/testLib.mli
+++ b/test/testlib/testLib.mli
@@ -18,6 +18,9 @@ val with_formatter : ?where:Std_io.t -> (Format.formatter -> 'a) -> 'a t
 (** [with_formatter ~where f] returns a Shexp process which executes [f] with a formatter which redirect to
     the given Shexp IO [where], whose default value is [Stdout] *)
 
+val with_formatter_map : ?where:Std_io.t -> (Format.formatter -> 'a t) -> 'a t
+(** [with_formatter_map ~where f] is similar to [with_formatter] but [f] returns a Shexp process *)
+
 val echo_line : unit t
 (** A Shexp process which output a horizontal line to Stdout. *)
 
@@ -45,3 +48,6 @@ val opam_file_for_test :
   ?name:string ->
   ?version:string ->
   ?description:string -> ?depends:string -> ?satysfi_name:string -> unit -> string
+
+val with_bin_dir : string -> 'a t -> 'a t
+(** [with_bin_dir bin_dir cmd] runs [cmd] with adding [bin_dir] to the first of PATH *)


### PR DESCRIPTION
This PR adds `build <module-name>` subcommand which does

- Run `opam pin add --yes <opam-package>name; "file://<package-directory>"` for each library or libraryDoc module in the Satyristes
- If the module `<module-name>` has `build` section, Satyrographos executes it.

On the same time behaviors of some existing features are also changed.

- When Satyrographos executes a `make` clause in `build` sections, it runs make command with `SATYROGRAPHOS_PROJECT` environment variable, which has a path to SATySFi Root Directory.
- When `SATYROGRAPHOS_PROJECT` environment variable exists, `satysfi` subcommand read packages from SATySFi Root Directory specified by the environment variable rather than creating one in the temp directory.
- New module type `doc` is added to Satyristes.
