### PR TITLE
Add "util deps-make" subcommand

### DIFF
--- a/bin/commandDebug.ml
+++ b/bin/commandDebug.ml
@@ -30,10 +30,8 @@ let depgraph_command =
         in
         let outf = Format.err_formatter in
         let mode = Option.bind ~f:Mode.of_extension_opt mode in
-        let package_root_dirs = SatysfiDirs.expand_package_root_dirs ~satysfi_version runtime_dirs in
-        let g = DependencyGraph.dependency_graph ~outf ~package_root_dirs ~satysfi_version ~follow_required satysfi_files in
         let g =
-          Option.value_map mode ~default:g ~f:(fun mode -> DependencyGraph.subgraph_with_mode ~mode g)
+          CommandUtil.dependency_graph ~outf ~runtime_dirs ~mode ~follow_required ~satysfi_version ~satysfi_files
         in
         DependencyGraph.Dot.fprint_graph Format.std_formatter g
     ]

--- a/bin/dune
+++ b/bin/dune
@@ -24,5 +24,6 @@
    commandPin
    commandSatysfi
    commandStatus
+   commandUtil
    main)
  )

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -13,6 +13,7 @@ let total_command =
       "lint", CommandLint.lint_command;
       "satysfi", CommandSatysfi.satysfi_command;
       "status", CommandStatus.status_command;
+      "util", CommandUtil.util_command;
       "pin", CommandPin.pin_command;
       "install", CommandInstall.install_command;
     ]

--- a/src/satysfi/mode.ml
+++ b/src/satysfi/mode.ml
@@ -26,6 +26,14 @@ let to_extension = function
   | Generic ->
     ".satyg"
 
+let to_output_extension_opt = function
+  | Pdf ->
+    Some ".pdf"
+  | Text mode ->
+    Some (sprintf ".%s" mode)
+  | Generic ->
+    None
+
 let ( <=: ) a b = match a, b with
   | Pdf, Pdf -> true
   | Text a, Text b when String.equal a b -> true

--- a/test/testcases/command_build__doc_make.expected
+++ b/test/testcases/command_build__doc_make.expected
@@ -18,7 +18,7 @@ make out> ./dist/packages
 make out> ./dist/packages/grcnum
 make out> ./dist/packages/grcnum/grcnum.satyh
 make out> ==============================
-make out> satyrographos debug project-env | grep -e 'pkg/Satyristes' >/dev/null || (export ; whereis satyrographos satysfi opam)
+make out> 0
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
 Reading opam libraries: (base class-greek fonts-theano grcnum)
@@ -43,8 +43,3 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------
-------------------------------------------------------------
-Command invoked:
-opam var share
-Command invoked:
-opam var share

--- a/test/testcases/command_build__doc_make.ml
+++ b/test/testcases/command_build__doc_make.ml
@@ -25,7 +25,7 @@ build-doc:
 	@echo "=============================="
 	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
 	@echo "=============================="
-	satyrographos debug project-env | grep -e 'pkg/Satyristes' >/dev/null || (export ; whereis satyrographos satysfi opam)
+	@echo "$(SATYROGRAPHOS_PROJECT)" | grep -e 'pkg/Satyristes' >/dev/null ; echo "$$?"
 |}
 
 let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =

--- a/test/testcases/command_debug_depgraph__empty.t
+++ b/test/testcases/command_debug_depgraph__empty.t
@@ -19,3 +19,14 @@ Generate dependency graphs
     
     
     }
+
+Dep files
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d --output-extension .pdf --follow-required empty.saty
+  Compatibility warning: You have opted in to use experimental features.
+  $ cat deps.d
+  empty.pdf: empty.saty
+  
+  deps.d: empty.saty
+  
+  empty.saty:
+  

--- a/test/testcases/command_debug_depgraph__import_duplex.t
+++ b/test/testcases/command_debug_depgraph__import_duplex.t
@@ -49,3 +49,18 @@ Generate dependency graphs
                               label="@import: second", ];
     
     }
+
+Dep files
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d --output-extension .pdf --follow-required first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  $ cat deps.d
+  first.pdf: first.saty third.satyh second.satyh
+  
+  deps.d: first.saty third.satyh second.satyh
+  
+  first.saty:
+  
+  second.satyh:
+  
+  third.satyh:
+  

--- a/test/testcases/command_debug_depgraph__import_simplex.t
+++ b/test/testcases/command_debug_depgraph__import_simplex.t
@@ -50,3 +50,18 @@ Generate dependency graphs
                                    label="@import: second2/lib", ];
     
     }
+
+Dep files
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d --output-extension .pdf --follow-required first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  $ cat deps.d
+  first.pdf: first.saty second2/lib.satyg second1.satyh
+  
+  deps.d: first.saty second2/lib.satyg second1.satyh
+  
+  first.saty:
+  
+  second1.satyh:
+  
+  second2/lib.satyg:
+  

--- a/test/testcases/command_debug_depgraph__missing_files.t
+++ b/test/testcases/command_debug_depgraph__missing_files.t
@@ -30,3 +30,27 @@ Generate dependency graphs
                             label="@require: lib1", ];
     
     }
+
+Dep files
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d --output-extension .pdf --follow-required first.saty 2>&1 | sed -e "s!$HOME!@@HOME@@!g"
+  Compatibility warning: You have opted in to use experimental features.
+  Cannot read files for “@import: second”
+  Candidate basenames:
+    - second
+  
+  Cannot read files for “@require: lib1”
+  Candidate basenames:
+    - @@HOME@@/.satysfi/dist/packages/lib1
+    - /usr/local/share/satysfi/dist/packages/lib1
+    - /usr/share/satysfi/dist/packages/lib1
+    - @@HOME@@/.satysfi/local/packages/lib1
+    - /usr/local/share/satysfi/local/packages/lib1
+    - /usr/share/satysfi/local/packages/lib1
+  
+  $ cat deps.d
+  first.pdf: first.saty
+  
+  deps.d: first.saty
+  
+  first.saty:
+  

--- a/test/testcases/command_debug_depgraph__require_followed.t
+++ b/test/testcases/command_debug_depgraph__require_followed.t
@@ -45,3 +45,20 @@ Generate dependency graphs
                             label="@require: lib1", ];
     
     }
+
+Dep files
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make --satysfi-root-dirs 'root' -S 0.0.5 --depfile deps.d --output-extension .pdf --follow-required first.saty 2>&1 | sed -e "s!$HOME!@@HOME@@!g"
+  Compatibility warning: You have opted in to use experimental features.
+  $ cat deps.d
+  first.pdf: first.saty second.satyh root/local/packages/lib2.satyg root/dist/packages/lib1.satyh
+  
+  deps.d: first.saty second.satyh root/local/packages/lib2.satyg root/dist/packages/lib1.satyh
+  
+  first.saty:
+  
+  root/dist/packages/lib1.satyh:
+  
+  root/local/packages/lib2.satyg:
+  
+  second.satyh:
+  

--- a/test/testcases/command_debug_depgraph__require_unfollowed.t
+++ b/test/testcases/command_debug_depgraph__require_unfollowed.t
@@ -44,3 +44,18 @@ Generate dependency graphs
                             label="@require: lib1", ];
     
     }
+
+Dep files
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make --satysfi-root-dirs 'root' -S 0.0.5 --depfile deps.d --output-extension .pdf first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  $ cat deps.d
+  first.pdf: first.saty third.satyh second.satyh
+  
+  deps.d: first.saty third.satyh second.satyh
+  
+  first.saty:
+  
+  second.satyh:
+  
+  third.satyh:
+  

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -44,7 +44,6 @@
  )
  (preprocess (pps ppx_deriving.std ppx_jane))
  (libraries core re satyrographos_command satyrographos_testlib shexp.process uri)
- (deps %{bin:satyrographos})
  )
 
 (cram


### PR DESCRIPTION
This PR adds `util deps-make` subcommand, which produces dependency files for Make.