### PR TITLE
Add Script lang 0.0.3

### DIFF
--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -6,11 +6,17 @@ let load f =
   let sexp = Sexp.load_sexp ~strict:false f in
   match sexp with
   | Sexp.List Sexp.[Atom "version"; Atom "0.0.2"] ->
-    BuildScript_0_0_2.load f
+    Lang_0_0_2 (BuildScript_0_0_2.load f)
+  | Sexp.List Sexp.[Atom "lang"; Atom "0.0.3"] ->
+    Format.fprintf Format.err_formatter "WARNING: Script lang 0.0.3 is under development.@.";
+    Lang_0_0_3 (BuildScript_0_0_3.load f)
   | _ ->
     failwith {|Satyrographos file should start with a lang version specifier.
 
-Add the following line to the file.
+Add one of the following lines to the file.
 
-    (version 0.0.2)|}
+    (version 0.0.2)
+
+    (lang 0.0.3)
+|}
 

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -85,7 +85,15 @@ type m =
 module StringMap = Map.Make(String)
 module StringSet = Set.Make(String)
 
-type t = m StringMap.t [@@deriving sexp]
+type t =
+  | Lang_0_0_2 of m StringMap.t
+  | Lang_0_0_3 of m StringMap.t
+[@@deriving sexp]
+
+let get_module_map = function
+  | Lang_0_0_2 module_map
+  | Lang_0_0_3 module_map ->
+    module_map
 
 let library_to_opam_file name =
   let name = OpamPackage.Name.of_string ("satysfi-" ^ name) in

--- a/src/command/lint.ml
+++ b/src/command/lint.ml
@@ -382,9 +382,12 @@ let lint ~outf ~satysfi_version ~verbose ~buildscript_path ~(env : Environment.t
   let buildscript_basename = FilePath.basename buildscript_path in
   let buildscript = BuildScript.load buildscript_path in
   let problems =
-    Map.to_alist buildscript
-    |> List.concat_map ~f:(fun (_, m) ->
-        lint_module ~outf ~verbose ~satysfi_version ~basedir ~buildscript_basename ~env m)
+    match buildscript with
+    | BuildScript.Lang_0_0_2 module_map
+    | BuildScript.Lang_0_0_3 module_map ->
+      Map.to_alist module_map
+      |> List.concat_map ~f:(fun (_, m) ->
+          lint_module ~outf ~verbose ~satysfi_version ~basedir ~buildscript_basename ~env m)
   in
   show_problems ~outf ~basedir problems;
   List.length problems

--- a/test/testcases/command_build__doc_make.ml
+++ b/test/testcases/command_build__doc_make.ml
@@ -7,7 +7,7 @@ open Shexp_process
 
 let satyristes =
 {|
-(version "0.0.2")
+(lang "0.0.3")
 (doc
   (name "example-doc")
   (build

--- a/test/testcases/command_build__doc_satysfi.ml
+++ b/test/testcases/command_build__doc_satysfi.ml
@@ -7,7 +7,7 @@ open Shexp_process
 
 let satyristes =
 {|
-(version "0.0.2")
+(lang "0.0.3")
 (doc
   (name "example-doc")
   (build

--- a/test/testcases/command_build__doc_with_libraries.ml
+++ b/test/testcases/command_build__doc_with_libraries.ml
@@ -7,7 +7,7 @@ open Shexp_process
 
 let satyristes =
 {|
-(version "0.0.2")
+(lang "0.0.3")
 (library
   (name "grcnum")
   (version "0.2")


### PR DESCRIPTION
This script simply adds Build Script lang version 0.0.3, copying version 0.0.2, and remove `doc` module support from version 0.0.2.