### PR TITLE
Improve commandline options of util deps-make subcommand

### DIFF
--- a/test/testcases/command_debug_depgraph__empty.t
+++ b/test/testcases/command_debug_depgraph__empty.t
@@ -21,12 +21,10 @@ Generate dependency graphs
     }
 
 Dep files
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d --output-extension .pdf --follow-required empty.saty
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d -o empty.pdf --follow-required empty.saty
   Compatibility warning: You have opted in to use experimental features.
   $ cat deps.d
   empty.pdf: empty.saty
   
   deps.d: empty.saty
-  
-  empty.saty:
   

--- a/test/testcases/command_debug_depgraph__import_duplex.t
+++ b/test/testcases/command_debug_depgraph__import_duplex.t
@@ -51,16 +51,10 @@ Generate dependency graphs
     }
 
 Dep files
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d --output-extension .pdf --follow-required first.saty
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d -o first.pdf --follow-required first.saty
   Compatibility warning: You have opted in to use experimental features.
   $ cat deps.d
   first.pdf: first.saty third.satyh second.satyh
   
   deps.d: first.saty third.satyh second.satyh
-  
-  first.saty:
-  
-  second.satyh:
-  
-  third.satyh:
   

--- a/test/testcases/command_debug_depgraph__import_simplex.t
+++ b/test/testcases/command_debug_depgraph__import_simplex.t
@@ -52,16 +52,10 @@ Generate dependency graphs
     }
 
 Dep files
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d --output-extension .pdf --follow-required first.saty
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d -o first.pdf --follow-required first.saty
   Compatibility warning: You have opted in to use experimental features.
   $ cat deps.d
   first.pdf: first.saty second2/lib.satyg second1.satyh
   
   deps.d: first.saty second2/lib.satyg second1.satyh
-  
-  first.saty:
-  
-  second1.satyh:
-  
-  second2/lib.satyg:
   

--- a/test/testcases/command_debug_depgraph__missing_files.t
+++ b/test/testcases/command_debug_depgraph__missing_files.t
@@ -32,7 +32,7 @@ Generate dependency graphs
     }
 
 Dep files
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d --output-extension .pdf --follow-required first.saty 2>&1 | sed -e "s!$HOME!@@HOME@@!g"
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --depfile deps.d -o first.pdf --follow-required first.saty 2>&1 | sed -e "s!$HOME!@@HOME@@!g"
   Compatibility warning: You have opted in to use experimental features.
   Cannot read files for “@import: second”
   Candidate basenames:
@@ -51,6 +51,4 @@ Dep files
   first.pdf: first.saty
   
   deps.d: first.saty
-  
-  first.saty:
   

--- a/test/testcases/command_debug_depgraph__require_followed.t
+++ b/test/testcases/command_debug_depgraph__require_followed.t
@@ -47,18 +47,10 @@ Generate dependency graphs
     }
 
 Dep files
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make --satysfi-root-dirs 'root' -S 0.0.5 --depfile deps.d --output-extension .pdf --follow-required first.saty 2>&1 | sed -e "s!$HOME!@@HOME@@!g"
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make --satysfi-root-dirs 'root' -S 0.0.5 --depfile deps.d -o first.pdf --follow-required first.saty 2>&1 | sed -e "s!$HOME!@@HOME@@!g"
   Compatibility warning: You have opted in to use experimental features.
   $ cat deps.d
   first.pdf: first.saty second.satyh root/local/packages/lib2.satyg root/dist/packages/lib1.satyh
   
   deps.d: first.saty second.satyh root/local/packages/lib2.satyg root/dist/packages/lib1.satyh
-  
-  first.saty:
-  
-  root/dist/packages/lib1.satyh:
-  
-  root/local/packages/lib2.satyg:
-  
-  second.satyh:
   

--- a/test/testcases/command_debug_depgraph__require_unfollowed.t
+++ b/test/testcases/command_debug_depgraph__require_unfollowed.t
@@ -46,16 +46,10 @@ Generate dependency graphs
     }
 
 Dep files
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make --satysfi-root-dirs 'root' -S 0.0.5 --depfile deps.d --output-extension .pdf first.saty
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make --satysfi-root-dirs 'root' -S 0.0.5 --depfile deps.d -o first.pdf first.saty
   Compatibility warning: You have opted in to use experimental features.
   $ cat deps.d
   first.pdf: first.saty third.satyh second.satyh
   
   deps.d: first.saty third.satyh second.satyh
-  
-  first.saty:
-  
-  second.satyh:
-  
-  third.satyh:
   

--- a/test/testcases/command_util_deps_make__output_stdout.t
+++ b/test/testcases/command_util_deps_make__output_stdout.t
@@ -1,0 +1,21 @@
+Prepare SATySFi source
+  $ cat >first.saty <<EOF
+  > @import: second1
+  > @import: second2/lib
+  > EOF
+  $ cat >second1.satyh <<EOF
+  > EOF
+  $ mkdir second2
+  $ cat >second2/lib.satyg <<EOF
+  > EOF
+
+Dep files
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 -o first.pdf --follow-required first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  first.pdf: first.saty second2/lib.satyg second1.satyh
+  
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 -o first.pdf --follow-required first.saty >stdout.txt
+  Compatibility warning: You have opted in to use experimental features.
+  $ cat stdout.txt
+  first.pdf: first.saty second2/lib.satyg second1.satyh
+  

--- a/test/testcases/command_util_deps_make__phony_targets.t
+++ b/test/testcases/command_util_deps_make__phony_targets.t
@@ -1,0 +1,25 @@
+Prepare SATySFi source
+  $ cat >first.saty <<EOF
+  > @import: second1
+  > @import: second2/lib
+  > EOF
+  $ cat >second1.satyh <<EOF
+  > EOF
+  $ mkdir second2
+  $ cat >second2/lib.satyg <<EOF
+  > EOF
+
+Dep files
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos util deps-make -S 0.0.5 --phony-targets --depfile deps.d -o first.pdf --follow-required first.saty
+  Compatibility warning: You have opted in to use experimental features.
+  $ cat deps.d
+  first.pdf: first.saty second2/lib.satyg second1.satyh
+  
+  deps.d: first.saty second2/lib.satyg second1.satyh
+  
+  first.saty:
+  
+  second1.satyh:
+  
+  second2/lib.satyg:
+  


### PR DESCRIPTION
- adds alias `-f` to `--depfile` option
- adds `--phony-target` option to toggle adding phony targets
- replaces `--output-extension` (alias `-e`) option with `--target` (alias `-o`)
  to specify a whole filename instead of an extension

This PR follows up https://github.com/na4zagin3/satyrographos/pull/197