### PR TITLE
Use more intuitive mode names in commandline options

### DIFF
--- a/bin/commandDebug.ml
+++ b/bin/commandDebug.ml
@@ -29,7 +29,7 @@ let depgraph_command =
             Option.to_list (user_dir ()) @ runtime_dirs ()
         in
         let outf = Format.err_formatter in
-        let mode = Option.bind ~f:Mode.of_extension_opt mode in
+        let mode = Option.map ~f:Mode.of_string_exn mode in
         let g =
           CommandUtil.dependency_graph ~outf ~runtime_dirs ~mode ~follow_required ~satysfi_version ~satysfi_files
         in

--- a/bin/commandUtil.ml
+++ b/bin/commandUtil.ml
@@ -45,7 +45,7 @@ let deps_make_command =
         in
         let outf = Format.err_formatter in
         let mode =
-          Option.bind ~f:Mode.of_extension_opt mode
+          Option.map ~f:Mode.of_string_exn mode
           |> Option.value ~default:Mode.Pdf
         in
         let g =

--- a/test/testcases/command_debug_depgraph__subgraph_with_mode.t
+++ b/test/testcases/command_debug_depgraph__subgraph_with_mode.t
@@ -11,7 +11,7 @@ Prepare SATySFi source
 
 
 Generate dependency graphs for satyh
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph -S 0.0.5 --mode .satyh first.saty
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph -S 0.0.5 --mode pdf first.saty
   Compatibility warning: You have opted in to use experimental features.
   digraph G {
     "second.satyh-md" [shape=box, ];
@@ -29,7 +29,7 @@ Generate dependency graphs for satyh
     }
 
 Generate dependency graphs for satyh-md
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph -S 0.0.5 --mode .satyh-md first.saty
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph -S 0.0.5 --mode text-md first.saty
   Compatibility warning: You have opted in to use experimental features.
   digraph G {
     "second.satyh-md" [shape=box, ];


### PR DESCRIPTION
Instead of extensions (e.g., `.satyh`, `.satyh-md`, `.satyg`), use more
intuitive names (e.g., `pdf`, `text-md`, `generic`).