### PR TITLE
Remove compatibility notices for Satyrographos 0.0.1 libraries

### DIFF
--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -120,6 +120,11 @@ let export_opam_package = function
 let export_opam bs =
   StringMap.iter bs ~f:export_opam_package
 
+let get_compatibility_opt = function
+  | Library l -> Some l.compatibility
+  | LibraryDoc _ -> None
+  | Doc _ -> None
+
 let get_dependencies_opt = function
   | Library l -> Some l.dependencies
   | LibraryDoc l -> Some l.dependencies
@@ -163,15 +168,7 @@ let compatibility_treatment (p: library) (l: Library.t) =
         }
       }
     | Satyrographos "0.0.1" ->
-      let open Library in
-      let rename_packages = List.map (pacages_of_sources p.sources) ~f:(fun {dst=name; _} ->
-        let old_package_name = name in
-        let new_package_name = p.name ^ "/" ^ name in
-        Rename.{ old_name = old_package_name; new_name = new_package_name }
-      ) |> RenameSet.of_list in
-      Compatibility.{ empty with
-        rename_packages
-      }
+      Library.Compatibility.empty
     | unknown_symbol -> begin
       let unknown_symbol =
       unknown_symbol

--- a/test/testcases/command_lint__compatibility_satyrographos_0_0_1.expected
+++ b/test/testcases/command_lint__compatibility_satyrographos_0_0_1.expected
@@ -1,0 +1,5 @@
+@@test_library@@/Satyristes:3:1: (module package):
+Warning:
+  Compatibility warnings for Satyrographos 0.0.1 libraries are no longer effective.
+
+1 problem(s) found.

--- a/test/testcases/command_lint__compatibility_satyrographos_0_0_1.ml
+++ b/test/testcases/command_lint__compatibility_satyrographos_0_0_1.ml
@@ -1,0 +1,42 @@
+open Core
+open Satyrographos_testlib
+
+let satysfi_package_opam =
+  "satysfi-package.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package"
+    ~version:"0.1"
+    ()
+
+let satyristes =
+  "Satyristes", sprintf
+    {|(version "0.0.2")
+
+(library
+  (name "package")
+  (version "0.1")
+  (sources ((package "test.satyh" "test.satyh")))
+  (opam "satysfi-package.opam")
+  (dependencies ())
+  (compatibility ((satyrographos 0.0.1))))
+|}
+
+let test_satyh =
+  "test.satyh", {||}
+
+let opam_libs = Satyrographos.Library.[
+    {empty with
+     name = Some "package";
+     files = LibraryFiles.of_alist_exn [
+         "packages/package/test.satyh", `Content ""
+       ]
+    };
+]
+
+let files =
+  [ satysfi_package_opam;
+    satyristes;
+    test_satyh;
+  ]
+
+let () =
+  TestCommand.test_lint_command ~opam_libs files

--- a/test/testcases/command_opam_install__library.expected
+++ b/test/testcases/command_opam_install__library.expected
@@ -13,9 +13,6 @@ Read library:
   ((doc/grcnum.md (Filename @@temp_dir@@/pkg/README.md))
    (fonts/grcnum/grcnum-font.ttf (Filename @@temp_dir@@/pkg/font.ttf))
    (packages/grcnum/grcnum.satyh (Filename @@temp_dir@@/pkg/grcnum.satyh))))
- (compatibility
-  ((rename_packages
-    (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
  (dependencies (fonts-theano)))
 Copying @@temp_dir@@/pkg/README.md to @@dest_dir@@/dest/share/satysfi/grcnum/doc/grcnum.md
 Copying @@temp_dir@@/pkg/font.ttf to @@dest_dir@@/dest/share/satysfi/grcnum/fonts/grcnum/grcnum-font.ttf
@@ -50,11 +47,8 @@ diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash @@dest_
 > {"grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>}
 \ No newline at end of file
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/metadata @@dest_dir@@/dest/share/satysfi/grcnum/metadata
-0a1,5
-> ((version 1) (libraryName grcnum) (libraryVersion 0.2)
->  (compatibility
->   ((rename_packages
->     (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
+0a1,2
+> ((version 1) (libraryName grcnum) (libraryVersion 0.2) (compatibility ())
 >  (dependencies ((fonts-theano ()))))
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/packages/grcnum/grcnum.satyh @@dest_dir@@/dest/share/satysfi/grcnum/packages/grcnum/grcnum.satyh
 0a1

--- a/test/testcases/command_opam_install__library_recursive.expected
+++ b/test/testcases/command_opam_install__library_recursive.expected
@@ -32,17 +32,6 @@ Read library:
    (packages/grcnum/a/file.satyh
     (Filename @@temp_dir@@/pkg/src/a/file.satyh))
    (packages/grcnum/grcnum.satyh (Filename @@temp_dir@@/pkg/grcnum.satyh))))
- (compatibility
-  ((rename_packages
-    (((new_name grcnum/a/b-1/c-1/file1.satyh)
-      (old_name a/b-1/c-1/file1.satyh))
-     ((new_name grcnum/a/b-1/c-1/file2.satyh)
-      (old_name a/b-1/c-1/file2.satyh))
-     ((new_name grcnum/a/b-1/c-2/file1.satyh)
-      (old_name a/b-1/c-2/file1.satyh))
-     ((new_name grcnum/a/b-1/file.satyh) (old_name a/b-1/file.satyh))
-     ((new_name grcnum/a/file.satyh) (old_name a/file.satyh))
-     ((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
  (dependencies (fonts-theano)))
 Copying @@temp_dir@@/pkg/README.md to @@dest_dir@@/dest/share/satysfi/grcnum/doc/grcnum.md
 Copying @@temp_dir@@/pkg/font/a/b-1/c-1/file1.ttf to @@dest_dir@@/dest/share/satysfi/grcnum/fonts/grcnum/a/b-1/c-1/file1.ttf
@@ -120,19 +109,8 @@ diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash @@dest_
 > {"grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>}
 \ No newline at end of file
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/metadata @@dest_dir@@/dest/share/satysfi/grcnum/metadata
-0a1,13
-> ((version 1) (libraryName grcnum) (libraryVersion 0.2)
->  (compatibility
->   ((rename_packages
->     (((new_name grcnum/a/b-1/c-1/file1.satyh)
->       (old_name a/b-1/c-1/file1.satyh))
->      ((new_name grcnum/a/b-1/c-1/file2.satyh)
->       (old_name a/b-1/c-1/file2.satyh))
->      ((new_name grcnum/a/b-1/c-2/file1.satyh)
->       (old_name a/b-1/c-2/file1.satyh))
->      ((new_name grcnum/a/b-1/file.satyh) (old_name a/b-1/file.satyh))
->      ((new_name grcnum/a/file.satyh) (old_name a/file.satyh))
->      ((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))))
+0a1,2
+> ((version 1) (libraryName grcnum) (libraryVersion 0.2) (compatibility ())
 >  (dependencies ((fonts-theano ()))))
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/packages/grcnum/a/b-1/c-1/file1.satyh @@dest_dir@@/dest/share/satysfi/grcnum/packages/grcnum/a/b-1/c-1/file1.satyh
 0a1

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -19,6 +19,7 @@
    command_install_l__thirdParties_brokenDependency
    command_install_l__transitive
    command_lint__acyclic_for_each_mode
+   command_lint__compatibility_satyrographos_0_0_1
    command_lint__cyclic_dependencies
    command_lint__insufficient_dependencies
    command_lint__insufficient_dependencies_for_some_modes


### PR DESCRIPTION
This PR removes compatibility notices for Satyrographos 0.0.1 libraries, with adding a lint rule for that.