### PR TITLE
Don't add a prefix to each line of command outputs

### DIFF
--- a/src/command/build.ml
+++ b/src/command/build.ml
@@ -15,10 +15,9 @@ let read_module ~outf ~verbose ~build_module ~buildscript_path =
 
 let parse_build_command ~satysfi_runtime = function
   | "make" :: args ->
-    let command = P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args) in
-    ProcessUtil.redirect_to_stdout ~prefix:"make" command
+    P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args)
   | "satysfi" :: args ->
-    RunSatysfi.run_satysfi ~satysfi_runtime args
+    RunSatysfi.run_satysfi_command ~satysfi_runtime args
   | cmd -> failwithf "command %s is not yet supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()
 
 let run_build_commands ~workingDir ~project_env buildCommands =
@@ -114,12 +113,14 @@ let opam_pin_project ~(buildscript: BuildScript.t) ~buildscript_path =
 
 
 let build_command ~outf ~buildscript_path ~name ~verbose ~env =
-  let f ~buildscript~build_module =
+  let f ~buildscript ~build_module ~build_dir =
     let system_font_prefix = None in
     let autogen_libraries = [] in
     opam_pin_project ~buildscript ~buildscript_path
     |> P.eval ;
-    build ~outf ~verbose ~build_module ~buildscript_path ~system_font_prefix ~autogen_libraries ~env
+    Format.fprintf outf "@.================@.";
+    build ~outf ~verbose ~build_module ~buildscript_path ~system_font_prefix ~autogen_libraries ~env ~build_dir;
+    Format.fprintf outf "@.================@."
   in
   let buildscript = BuildScript.load buildscript_path in
   let module_map = BuildScript.get_module_map buildscript in

--- a/src/command/runSatysfi.ml
+++ b/src/command/runSatysfi.ml
@@ -61,11 +61,6 @@ let run_satysfi_command ~satysfi_runtime args =
   assert_satysfi_option_C satysfi_runtime
   >> P.run "satysfi" (["-C"; satysfi_runtime] @ args)
 
-let run_satysfi ~satysfi_runtime args =
-  let command =
-    run_satysfi_command ~satysfi_runtime args in
-  ProcessUtil.redirect_to_stdout ~prefix:"satysfi" command
-
 let satysfi_command ~outf ~system_font_prefix ~autogen_libraries ~libraries ~verbose ~project_env ~env args =
   let setup ~satysfi_dist =
     Install.install

--- a/test/testcases/command_build__doc_make.expected
+++ b/test/testcases/command_build__doc_make.expected
@@ -1,24 +1,26 @@
 Installing packages
 ------------------------------------------------------------
-make out> Target: build-doc
-make out> Files under $SATYSFI_RUNTIME
-make out> ==============================
-make out> .
-make out> ./dist
-make out> ./dist/.satyrographos
-make out> ./dist/fonts
-make out> ./dist/fonts/fonts-theano
-make out> ./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
-make out> ./dist/fonts/fonts-theano/TheanoModern-Regular.otf
-make out> ./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
-make out> ./dist/hash
-make out> ./dist/hash/fonts.satysfi-hash
-make out> ./dist/metadata
-make out> ./dist/packages
-make out> ./dist/packages/grcnum
-make out> ./dist/packages/grcnum/grcnum.satyh
-make out> ==============================
-make out> 0
+Target: build-doc
+Files under $SATYSFI_RUNTIME
+==============================
+.
+./dist
+./dist/.satyrographos
+./dist/fonts
+./dist/fonts/fonts-theano
+./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
+./dist/fonts/fonts-theano/TheanoModern-Regular.otf
+./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+./dist/hash
+./dist/hash/fonts.satysfi-hash
+./dist/metadata
+./dist/packages
+./dist/packages/grcnum
+./dist/packages/grcnum/grcnum.satyh
+==============================
+0
+
+================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
 Reading opam libraries: (base class-greek fonts-theano grcnum)
@@ -40,6 +42,8 @@ Installation completed!
   Packages have been renamed.
   
     grcnum.satyh -> grcnum/grcnum.satyh
+
+================
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------

--- a/test/testcases/command_build__doc_satysfi.expected
+++ b/test/testcases/command_build__doc_satysfi.expected
@@ -1,23 +1,25 @@
 Installing packages
 ------------------------------------------------------------
-make out> Target: build-doc
-make out> Files under $SATYSFI_RUNTIME
-make out> ==============================
-make out> .
-make out> ./dist
-make out> ./dist/.satyrographos
-make out> ./dist/fonts
-make out> ./dist/fonts/fonts-theano
-make out> ./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
-make out> ./dist/fonts/fonts-theano/TheanoModern-Regular.otf
-make out> ./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
-make out> ./dist/hash
-make out> ./dist/hash/fonts.satysfi-hash
-make out> ./dist/metadata
-make out> ./dist/packages
-make out> ./dist/packages/grcnum
-make out> ./dist/packages/grcnum/grcnum.satyh
-make out> ==============================
+Target: build-doc
+Files under $SATYSFI_RUNTIME
+==============================
+.
+./dist
+./dist/.satyrographos
+./dist/fonts
+./dist/fonts/fonts-theano
+./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
+./dist/fonts/fonts-theano/TheanoModern-Regular.otf
+./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+./dist/hash
+./dist/hash/fonts.satysfi-hash
+./dist/metadata
+./dist/packages
+./dist/packages/grcnum
+./dist/packages/grcnum/grcnum.satyh
+==============================
+
+================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
 Reading opam libraries: (base class-greek fonts-theano grcnum)
@@ -39,6 +41,8 @@ Installation completed!
   Packages have been renamed.
   
     grcnum.satyh -> grcnum/grcnum.satyh
+
+================
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------

--- a/test/testcases/command_build__doc_with_libraries.expected
+++ b/test/testcases/command_build__doc_with_libraries.expected
@@ -1,23 +1,25 @@
 Installing packages
 ------------------------------------------------------------
-make out> Target: build-doc
-make out> Files under $SATYSFI_RUNTIME
-make out> ==============================
-make out> .
-make out> ./dist
-make out> ./dist/.satyrographos
-make out> ./dist/fonts
-make out> ./dist/fonts/fonts-theano
-make out> ./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
-make out> ./dist/fonts/fonts-theano/TheanoModern-Regular.otf
-make out> ./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
-make out> ./dist/hash
-make out> ./dist/hash/fonts.satysfi-hash
-make out> ./dist/metadata
-make out> ./dist/packages
-make out> ./dist/packages/grcnum
-make out> ./dist/packages/grcnum/grcnum.satyh
-make out> ==============================
+Target: build-doc
+Files under $SATYSFI_RUNTIME
+==============================
+.
+./dist
+./dist/.satyrographos
+./dist/fonts
+./dist/fonts/fonts-theano
+./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
+./dist/fonts/fonts-theano/TheanoModern-Regular.otf
+./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+./dist/hash
+./dist/hash/fonts.satysfi-hash
+./dist/metadata
+./dist/packages
+./dist/packages/grcnum
+./dist/packages/grcnum/grcnum.satyh
+==============================
+
+================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
 Reading opam libraries: (base class-greek fonts-theano grcnum)
@@ -39,6 +41,8 @@ Installation completed!
   Packages have been renamed.
   
     grcnum.satyh -> grcnum/grcnum.satyh
+
+================
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------

--- a/test/testcases/command_opam_build__doc_satysfi.expected
+++ b/test/testcases/command_opam_build__doc_satysfi.expected
@@ -1,23 +1,23 @@
 Installing packages
 ------------------------------------------------------------
-make out> Target: build-doc
-make out> Files under $SATYSFI_RUNTIME
-make out> ==============================
-make out> .
-make out> ./dist
-make out> ./dist/.satyrographos
-make out> ./dist/fonts
-make out> ./dist/fonts/fonts-theano
-make out> ./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
-make out> ./dist/fonts/fonts-theano/TheanoModern-Regular.otf
-make out> ./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
-make out> ./dist/hash
-make out> ./dist/hash/fonts.satysfi-hash
-make out> ./dist/metadata
-make out> ./dist/packages
-make out> ./dist/packages/grcnum
-make out> ./dist/packages/grcnum/grcnum.satyh
-make out> ==============================
+Target: build-doc
+Files under $SATYSFI_RUNTIME
+==============================
+.
+./dist
+./dist/.satyrographos
+./dist/fonts
+./dist/fonts/fonts-theano
+./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
+./dist/fonts/fonts-theano/TheanoModern-Regular.otf
+./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+./dist/hash
+./dist/hash/fonts.satysfi-hash
+./dist/metadata
+./dist/packages
+./dist/packages/grcnum
+./dist/packages/grcnum/grcnum.satyh
+==============================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
 Reading opam libraries: (base class-greek fonts-theano grcnum)


### PR DESCRIPTION
This PR removes prefixes (e.g., `make out>`) that were attached to make/satysfi command output lines.