### PR TITLE
Add migrate subcommand

### DIFF
--- a/bin/commandMigrate.ml
+++ b/bin/commandMigrate.ml
@@ -1,0 +1,51 @@
+open Core
+
+let templates =
+  Satyrographos_template.Template.templates
+
+let template_map =
+  Satyrographos_command.New.template_map
+
+let help_templates () =
+  Satyrographos_command.New.template_descriptions
+  |> List.map ~f:(fun (k, d) -> Printf.sprintf "  %s : %s" k d)
+  |> String.concat ~sep:"\n"
+
+let migrate_command =
+  let open Command.Let_syntax in
+  let open RenameOption in
+  let readme () =
+    sprintf {|
+Migrate an old project format for a new format.
+
+Please take a backup beforehand.
+
+|}
+  in
+  Command.basic
+    ~summary:"Migrate an old project format for a new format"
+    ~readme
+    [%map_open
+      let buildscript_path = flag "--script" (optional string) ~doc:"SCRIPT Install script"
+      in
+      fun () ->
+        Compatibility.optin ();
+        let outf = Format.std_formatter in
+        Format.fprintf outf "*WARNING*@.";
+        Format.fprintf outf "Before migration, please ensure that `satyrographos lint` reports no problems.@ Otherwise, address them.@.";
+        Format.fprintf outf "Additionally, please take a backup (e.g., committing changes to the git repo) beforehand.@.";
+        Format.fprintf outf "Type “yes” if you are ready to proceed.@.";
+        Format.fprintf outf "[yes/NO] ";
+        Format.print_flush ();
+        let response =
+          In_channel.(input_line stdin)
+          |> Option.map ~f:String.strip
+        in
+        begin if [%equal: string option] response (Some "yes")
+        then Satyrographos_command.Migrate.migrate
+            ~outf
+            ~buildscript_path
+        else Format.fprintf outf !"Canceled.@."
+        end;
+        reprint_err_warn ()
+    ]

--- a/bin/dune
+++ b/bin/dune
@@ -17,6 +17,7 @@
    commandBuild
    commandDebug
    commandLint
+   commandMigrate
    commandNew
    commandInstall
    commandLibrary

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -11,6 +11,7 @@ let total_command =
       "library", CommandLibrary.library_command;
       "library-opam", CommandLibrary.library_opam_command;
       "lint", CommandLint.lint_command;
+      "migrate", CommandMigrate.migrate_command;
       "satysfi", CommandSatysfi.satysfi_command;
       "status", CommandStatus.status_command;
       "util", CommandUtil.util_command;

--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -7,7 +7,8 @@ let load f =
   match sexp with
   | Sexp.List Sexp.[Atom "version"; Atom "0.0.2"] ->
     Lang_0_0_2 (BuildScript_0_0_2.load f)
-  | Sexp.List Sexp.[Atom "lang"; Atom "0.0.3"] ->
+  | Sexp.List Sexp.[Atom "lang"; Atom "0.0.3"]
+  | Sexp.List Sexp.[Atom "Lang"; Atom "0.0.3"] ->
     Format.fprintf Format.err_formatter "WARNING: Script lang 0.0.3 is under development.@.";
     Lang_0_0_3 (BuildScript_0_0_3.load f)
   | _ ->

--- a/src/buildScript_0_0_2.ml
+++ b/src/buildScript_0_0_2.ml
@@ -82,6 +82,13 @@ let load_sections f =
   Sexp.Annotated.load_sexps f
   |> List.map ~f:(fun e -> Sexp.Annotated.get_range e, Sexp.Annotated.get_sexp e |> [%of_sexp: Section.t])
 
+let parse_build_command = function
+  | "make" :: args ->
+    Make args
+  | "satysfi" :: args ->
+    Satysfi args
+  | cmd -> failwithf "command %s is not yet supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()
+
 let section_to_modules ~base_dir (range, (m : Section.t)) =
   match m with
   | Section.Version "0.0.2" -> []
@@ -111,6 +118,9 @@ let section_to_modules ~base_dir (range, (m : Section.t)) =
           | Doc (dst, src) -> add_doc dst src acc
         end sources in
       let position = Some (position_of_range range) in
+      let build =
+        List.map ~f:parse_build_command build
+      in
       [name, LibraryDoc {name; version; opam; workingDirectory: string; build; sources; dependencies; position; }]
 
 let sections_to_modules ~base_dir sections =

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -59,12 +59,21 @@ type documentSource = [
 ]
 [@@deriving sexp]
 
+type build_command =
+  | Satysfi of string list
+  | Make of string list
+[@@deriving sexp]
+
+type build =
+  build_command list
+[@@deriving sexp]
+
 type libraryDoc = {
   name: string;
   version: string;
   opam: string;
   workingDirectory: string;
-  build: string list list [@sexp.omit_nil];
+  build: build [@sexp.omit_nil];
   sources: documentSource list [@sexp.omit_nil];
   dependencies: Library.Dependency.t [@sexp.omit_nil];
   position: position option;
@@ -73,7 +82,7 @@ type libraryDoc = {
 type doc = {
   name: string;
   workingDirectory: string;
-  build: string list list [@sexp.omit_nil];
+  build: build [@sexp.omit_nil];
   dependencies: Library.Dependency.t [@sexp.omit_nil];
   position: position option;
 } [@@deriving sexp]

--- a/src/command/build.ml
+++ b/src/command/build.ml
@@ -14,11 +14,10 @@ let read_module ~outf ~verbose ~build_module ~buildscript_path =
   (src_dir, p)
 
 let parse_build_command ~satysfi_runtime = function
-  | "make" :: args ->
+  | BuildScript.Make args ->
     P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args)
-  | "satysfi" :: args ->
+  | BuildScript.Satysfi args ->
     RunSatysfi.run_satysfi_command ~satysfi_runtime args
-  | cmd -> failwithf "command %s is not yet supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()
 
 let run_build_commands ~workingDir ~project_env buildCommands =
   let commands satysfi_runtime = P.List.iter buildCommands ~f:(parse_build_command ~satysfi_runtime) in

--- a/src/command/migrate.ml
+++ b/src/command/migrate.ml
@@ -1,0 +1,32 @@
+open Core
+
+open Satyrographos
+
+let migrate_0_0_2 ~outf:_ ~buildscript_path  =
+  let sections2 =
+    Sexp.load_sexps_conv_exn
+      buildscript_path
+      [%of_sexp: BuildScript_0_0_2.Section.t]
+  in
+  let sections3 =
+    List.map
+      sections2
+      ~f:BuildScript_0_0_3.migrate_from_0_0_2
+  in
+  BuildScript_0_0_3.save_sections
+    buildscript_path
+    sections3
+
+let migrate ~outf ~buildscript_path =
+  let buildscript_path = Option.value ~default:"Satyristes" buildscript_path in
+  let buildscript_path =
+    let cwd = FileUtil.pwd () in
+    FilePath.make_absolute cwd buildscript_path
+  in
+  let buildscript = BuildScript.load buildscript_path in
+  match buildscript with
+  | BuildScript.Lang_0_0_3 _ ->
+    Format.fprintf outf "Nothing to migrate.@."
+  | BuildScript.Lang_0_0_2 _ ->
+    migrate_0_0_2 ~outf ~buildscript_path;
+    Format.fprintf outf "Done.@."

--- a/test/testcases/command_migrate__build_0_0_2.t
+++ b/test/testcases/command_migrate__build_0_0_2.t
@@ -1,0 +1,78 @@
+Prepare a Satyrographos 0.0.2 library
+  $ mkdir test-lib
+  $ cat > test-lib/Satyristes <<EOF
+  > (version 0.0.2)
+  > (library
+  >   (name "package")
+  >   (version "0.1")
+  >   (sources (
+  >     (package "test.satyh" "test.satyh")
+  >     (font "test.satyh" "test.satyh")
+  >     (hash "fonts.satysfi-hash" "fonts.satysfi-hash")
+  >     (font "TheanoDidot-Regular.otf" "theano/TheanoDidot-Regular.otf")
+  >     (file "md/mdja2.satysfi-md" "mdja2.satysfi-md")
+  >     ))
+  >   (opam "satysfi-package.opam")
+  >   (compatibility ((renameFont fonts-theano:TheanoDidot TheanoDidot)
+  >                   (satyrographos 0.0.1)))
+  >   (dependencies ((fss ()))))
+  > 
+  > (libraryDoc
+  >   (name "package-doc")
+  >   (version "0.1")
+  >   (build ())
+  >   (sources ())
+  >   (opam "satysfi-package-doc.opam")
+  >   (dependencies ((package ()))))
+  > EOF
+
+  $ cd test-lib
+
+Default is NO
+  $ printf "\n" | SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos migrate
+  Compatibility warning: You have opted in to use experimental features.
+  *WARNING*
+  Before migration, please ensure that `satyrographos lint` reports no problems.
+  Otherwise, address them.
+  Additionally, please take a backup (e.g., committing changes to the git repo) beforehand.
+  Type “yes” if you are ready to proceed.
+  [yes/NO] Canceled.
+
+Migrate the library
+  $ printf "yes\n\n" | SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos migrate
+  Compatibility warning: You have opted in to use experimental features.
+  *WARNING*
+  Before migration, please ensure that `satyrographos lint` reports no problems.
+  Otherwise, address them.
+  Additionally, please take a backup (e.g., committing changes to the git repo) beforehand.
+  Type “yes” if you are ready to proceed.
+  [yes/NO] Done.
+
+Dump generated files
+  $ mkdir ../empty-dir
+  $ diff -Nr ../empty-dir .
+  diff -Nr ../empty-dir/Satyristes ./Satyristes
+  0a1,11
+  > (Lang 0.0.3)
+  > (Library (name package) (version 0.1) (opam satysfi-package.opam)
+  >  (sources
+  >   ((Package test.satyh test.satyh) (Font test.satyh test.satyh)
+  >    (Hash fonts.satysfi-hash fonts.satysfi-hash)
+  >    (Font TheanoDidot-Regular.otf theano/TheanoDidot-Regular.otf)
+  >    (File md/mdja2.satysfi-md mdja2.satysfi-md)))
+  >  (dependencies ((fss ())))
+  >  (compatibility ((RenameFont fonts-theano:TheanoDidot TheanoDidot))))
+  > (LibraryDoc (name package-doc) (version 0.1) (opam satysfi-package-doc.opam)
+  >  (workingDirectory .) (dependencies ((package ()))))
+  [1]
+
+Migration is idempotent
+  $ printf "yes\n\n" | SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos migrate
+  Compatibility warning: You have opted in to use experimental features.
+  *WARNING*
+  Before migration, please ensure that `satyrographos lint` reports no problems.
+  Otherwise, address them.
+  Additionally, please take a backup (e.g., committing changes to the git repo) beforehand.
+  Type “yes” if you are ready to proceed.
+  [yes/NO] WARNING: Script lang 0.0.3 is under development.
+  Nothing to migrate.


### PR DESCRIPTION
This PR adds `migrate` subcommand, which converts a Satyrographos 0.0.2 project for a Satyrographos 0.0.3 project.