### PR TITLE
Add (run ...) build command to LibraryDoc and Doc modules

### DIFF
--- a/src/buildScript.ml
+++ b/src/buildScript.ml
@@ -6,11 +6,11 @@ let load f =
   let sexp = Sexp.load_sexp ~strict:false f in
   match sexp with
   | Sexp.List Sexp.[Atom "version"; Atom "0.0.2"] ->
-    Lang_0_0_2 (BuildScript_0_0_2.load f)
+    Script_0_0_2 (BuildScript_0_0_2.load f)
   | Sexp.List Sexp.[Atom "lang"; Atom "0.0.3"]
   | Sexp.List Sexp.[Atom "Lang"; Atom "0.0.3"] ->
     Format.fprintf Format.err_formatter "WARNING: Script lang 0.0.3 is under development.@.";
-    Lang_0_0_3 (BuildScript_0_0_3.load f)
+    Script_0_0_3 (BuildScript_0_0_3.load f)
   | _ ->
     failwith {|Satyrographos file should start with a lang version specifier.
 

--- a/src/buildScript_0_0_3.ml
+++ b/src/buildScript_0_0_3.ml
@@ -90,11 +90,15 @@ let load_sections f =
   |> List.map ~f:(fun e -> Sexp.Annotated.get_range e, Sexp.Annotated.get_sexp e |> [%of_sexp: Section.t])
 
 let parse_build_command = function
+  | "run" :: cmd :: args ->
+    Run (cmd, args)
+  | "run" :: _ ->
+    failwithf "run command requires a executable name like (run <cmd> <args>...)" ()
   | "make" :: args ->
     Make args
   | "satysfi" :: args ->
     Satysfi args
-  | cmd -> failwithf "command %s is not yet supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()
+  | cmd -> failwithf "command %s is not supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()
 
 let section_to_modules ~base_dir (range, (m : Section.t)) =
   match m with

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -102,6 +102,15 @@ type t =
   | Script_0_0_3 of m StringMap.t
 [@@deriving sexp]
 
+type version =
+  | Lang_0_0_2
+  | Lang_0_0_3
+[@@deriving sexp, equal]
+
+let buildscript_version : t -> version = function
+  | Script_0_0_2 _ -> Lang_0_0_2
+  | Script_0_0_3 _ -> Lang_0_0_3
+
 let get_module_map = function
   | Script_0_0_2 module_map
   | Script_0_0_3 module_map ->
@@ -131,6 +140,11 @@ let export_opam_package = function
 
 let export_opam bs =
   StringMap.iter bs ~f:export_opam_package
+
+let get_build_opt = function
+  | Library _ -> None
+  | LibraryDoc l -> Some l.build
+  | Doc l -> Some l.build
 
 let get_compatibility_opt = function
   | Library l -> Some l.compatibility

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -97,13 +97,13 @@ module StringMap = Map.Make(String)
 module StringSet = Set.Make(String)
 
 type t =
-  | Lang_0_0_2 of m StringMap.t
-  | Lang_0_0_3 of m StringMap.t
+  | Script_0_0_2 of m StringMap.t
+  | Script_0_0_3 of m StringMap.t
 [@@deriving sexp]
 
 let get_module_map = function
-  | Lang_0_0_2 module_map
-  | Lang_0_0_3 module_map ->
+  | Script_0_0_2 module_map
+  | Script_0_0_3 module_map ->
     module_map
 
 let library_to_opam_file name =

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -62,6 +62,7 @@ type documentSource = [
 type build_command =
   | Satysfi of string list
   | Make of string list
+  | Run of string * string list
 [@@deriving sexp]
 
 type build =

--- a/src/command/build.ml
+++ b/src/command/build.ml
@@ -14,6 +14,8 @@ let read_module ~outf ~verbose ~build_module ~buildscript_path =
   (src_dir, p)
 
 let parse_build_command ~satysfi_runtime = function
+  | BuildScript.Run (cmd, args) ->
+    P.run cmd args
   | BuildScript.Make args ->
     P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args)
   | BuildScript.Satysfi args ->

--- a/src/command/lint.ml
+++ b/src/command/lint.ml
@@ -51,8 +51,8 @@ let lint ~outf ~satysfi_version ~warning_expr ~verbose ~buildscript_path ~(env :
   let buildscript = BuildScript.load buildscript_path in
   let problems =
     match buildscript with
-    | BuildScript.Lang_0_0_2 module_map
-    | BuildScript.Lang_0_0_3 module_map ->
+    | BuildScript.Script_0_0_2 module_map
+    | BuildScript.Script_0_0_3 module_map ->
       Map.to_alist module_map
       |> List.concat_map ~f:(fun (_, m) ->
           lint_module ~outf ~verbose ~satysfi_version ~basedir ~buildscript_basename ~env m)

--- a/src/command/lint_problem.ml
+++ b/src/command/lint_problem.ml
@@ -4,6 +4,7 @@ type problem =
   | ExceptionDuringSettingUpEnv of Exn.t
   | InternalBug of string
   | InternalException of Exn.t * string
+  | LibraryBuildDeprecatedMakeCommand
   | LibraryMissingFile
   | LibraryVersionShouldNotBeEmpty
   | LibraryVersionShouldEndWithAnAlphanum of string
@@ -35,6 +36,8 @@ let problem_class = function
     "internal/bug"
   | InternalException _ ->
     "internal/exception"
+  | LibraryBuildDeprecatedMakeCommand ->
+    "lib/build/deprecated/make"
   | LibraryMissingFile ->
     "lib/missing-file"
   | LibraryVersionShouldNotBeEmpty
@@ -73,6 +76,9 @@ let show_problem ~outf = function
       exn;
     Format.fprintf outf
       "@;%s" stacktrace
+  | LibraryBuildDeprecatedMakeCommand ->
+    Format.fprintf outf
+      "(make <args>...) build command has been deprecated.@ Please use (run make <args>...) instead and then `satyrographos satysfi ...` command instead of `satysfi -C $SATYSFI_RUNTIME ...`."
   | LibraryMissingFile ->
     Format.fprintf outf
       "Missing file"

--- a/src/command/migrate.ml
+++ b/src/command/migrate.ml
@@ -25,8 +25,8 @@ let migrate ~outf ~buildscript_path =
   in
   let buildscript = BuildScript.load buildscript_path in
   match buildscript with
-  | BuildScript.Lang_0_0_3 _ ->
+  | BuildScript.Script_0_0_3 _ ->
     Format.fprintf outf "Nothing to migrate.@."
-  | BuildScript.Lang_0_0_2 _ ->
+  | BuildScript.Script_0_0_2 _ ->
     migrate_0_0_2 ~outf ~buildscript_path;
     Format.fprintf outf "Done.@."

--- a/src/template/templateDocMakeEn.ml
+++ b/src/template/templateDocMakeEn.ml
@@ -163,7 +163,7 @@ let satyristes_template =
 
 (doc
   (name  "main")
-  (build ((make)))
+  (build ((run make)))
   (dependencies
    (;; Standard library
     (dist ())


### PR DESCRIPTION
This PR adds (run ...) build command to LibraryDoc and Doc modules.

A new warning `lib/build/deprecated/make` is also added. That will warn when `(make ...)` is used in build script language 0.0.3.

This is a part of https://github.com/na4zagin3/satyrographos/issues/168