### PR TITLE
Cache only downloaded files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ matrix:
 cache:
   directories:
     - $HOME/ocaml
-    - $HOME/.opam
+    - $HOME/.opam/archives
+    - $HOME/.opam/download-cache


### PR DESCRIPTION
As OPAM rebuilds everything for each time in Travis, we can only cache the downloaded files.