### PR TITLE
Have get_current_version return None when SATySFi is not installed

### DIFF
--- a/src/satysfi/version.ml
+++ b/src/satysfi/version.ml
@@ -111,7 +111,8 @@ let get_current_version_cmd =
   >>| parse_version_output
 
 let get_current_version () =
-  Shexp_process.eval get_current_version_cmd
+  Option.try_with_join (fun () ->
+      Shexp_process.eval get_current_version_cmd)
 
 let flag =
   let open Command.Let_syntax in


### PR DESCRIPTION
This PR has get_current_version return None when SATySFi is not installed.  Otherwise, `satysfi lint` command fails with an improper message when SATySFi is not installed.