### PR TITLE
Add doc-omake@en and doc-omake@ja templates

### DIFF
--- a/src/template/template.ml
+++ b/src/template/template.ml
@@ -45,5 +45,7 @@ let create_files ~basedir vars templ =
 let templates = [
   Template_docMake_en.template;
   Template_docMake_ja.template;
+  Template_docOmake_en.template;
+  Template_docOmake_ja.template;
   Template_lib.template;
 ]

--- a/src/template/template_docOmake_en.ml
+++ b/src/template/template_docOmake_en.ml
@@ -1,0 +1,64 @@
+let satyristes_template =
+"Satyristes",
+{|(lang "0.0.3")
+
+(doc
+  (name  "main")
+  (build ((run omake)))
+  (dependencies
+   (;; Standard library
+    (dist ())
+    ;; Third-party library
+    (fss ())
+    )))
+|}
+
+let omakefile_template =
+  "OMakefile",
+  {|# SATySFi/Satyrographos rules
+%.pdf: %.saty
+    satyrographos satysfi -- -o $@ $<
+.SCANNER: %.pdf: %.saty :value: $(digest $&)
+    satyrographos util deps-make -o $@ --mode pdf $<
+
+.DEFAULT: main.pdf
+|}
+
+let omakeroot_template =
+  "OMakeroot",
+  {|open build/C
+open build/OCaml
+open build/LaTeX
+
+DefineCommandVars()
+
+.SUBDIRS: .
+|}
+
+let readme_template =
+"README.md",
+{|# @@library@@
+
+A great document.
+
+## Requirement
+
+Needs OMake to build this project.
+
+## How to compile?
+
+Run `satyrographos build`.
+|}
+
+let files = [
+  Template_docMake_en.main_saty_template;
+  Template_docMake_en.local_satyh_template;
+  satyristes_template;
+  Template_docMake_en.gitignore_template;
+  omakefile_template;
+  omakeroot_template;
+  readme_template;
+]
+
+let template =
+  "doc-omake@en", ("Document with OMakefile (en)", files)

--- a/src/template/template_docOmake_ja.ml
+++ b/src/template/template_docOmake_ja.ml
@@ -1,0 +1,42 @@
+let satyristes_template =
+"Satyristes",
+{|(lang "0.0.3")
+
+(doc
+  (name  "main")
+  (build ((run omake)))
+  (dependencies
+   (;; Standard library
+    (dist ())
+    ;; Third-party library
+    (fss ())
+    )))
+|}
+
+let readme_template =
+  "README.md",
+  {|# @@library@@
+
+素敵な文書
+
+## 依存
+
+この文書の処理にはOMakeを要する。
+
+## 処理方法
+
+`satyrographos build`コマンドを走らせること。
+|}
+
+let files = [
+  Template_docMake_ja.main_saty_template;
+  Template_docMake_ja.local_satyh_template;
+  satyristes_template;
+  Template_docMake_en.gitignore_template;
+  Template_docOmake_en.omakefile_template;
+  Template_docOmake_en.omakeroot_template;
+  readme_template;
+]
+
+let template =
+  "doc-omake@ja", ("Document with OMakefile (ja)", files)

--- a/test/testcases/command_new__doc_omake.t
+++ b/test/testcases/command_new__doc_omake.t
@@ -1,0 +1,39 @@
+Create a new document with doc-omake@en template
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new doc-omake@en --license CC-BY-4.0 test-doc-en
+  Compatibility warning: You have opted in to use experimental features.
+  Name: test-doc-en
+  License: CC-BY-4.0
+  Created a new library/document.
+
+Try to build when there is satysfi command
+  $ if command satysfi --version >/dev/null 2>&1 && command omake --version >/dev/null 2>&1 && opam list -i --silent satysfi-dist && opam list -i --silent satysfi-fss ; then
+  >   cd test-doc-en
+  >   SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos build >build.log 2>&1
+  >   [ -f main.pdf ] || cat build.log
+  >   cd ..
+  > fi
+
+Create a new document with doc-omake@ja template
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new doc-omake@ja --license CC-BY-4.0 test-doc-ja
+  Compatibility warning: You have opted in to use experimental features.
+  Name: test-doc-ja
+  License: CC-BY-4.0
+  Created a new library/document.
+
+Try to build when there is satysfi command
+  $ if command satysfi --version >/dev/null 2>&1 && command omake --version >/dev/null 2>&1 && opam list -i --silent satysfi-dist && opam list -i --silent satysfi-fss ; then
+  >   cd test-doc-ja
+  >   SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos build >build.log 2>&1
+  >   [ -f main.pdf ] || cat build.log
+  >   cd ..
+  > fi
+
+Ensure there are no warnings
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos lint -W '-lib/dep/exception-during-setup' --script test-doc-en/Satyristes --satysfi-version 0.0.5
+  Compatibility warning: You have opted in to use experimental features.
+  WARNING: Script lang 0.0.3 is under development.
+  0 problem(s) found.
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos lint -W '-lib/dep/exception-during-setup' --script test-doc-ja/Satyristes --satysfi-version 0.0.5
+  Compatibility warning: You have opted in to use experimental features.
+  WARNING: Script lang 0.0.3 is under development.
+  0 problem(s) found.


### PR DESCRIPTION
This PR adds document templates `doc-omake@en` and `doc-omake@ja` using OMake for build management.