### PR TITLE
Add lockdown subcommand to save/restore OPAM package dependencies

### DIFF
--- a/bin/commandLockdown.ml
+++ b/bin/commandLockdown.ml
@@ -1,0 +1,65 @@
+open Core
+
+module StringMap = Map.Make(String)
+
+let outf = Format.std_formatter
+
+let default_script_path () =
+  Filename.concat (FileUtil.pwd ()) "Satyristes"
+
+let lockdown_file_path ~buildscript_path =
+  FilePath.concat
+    (FilePath.dirname buildscript_path)
+    "lockdown.yaml"
+
+let lockdown_save_command =
+  let open Command.Let_syntax in
+  let open RenameOption in
+  let _outf = Format.std_formatter in
+  Command.basic
+    ~summary:"Save the current environment to the lockdown file (experimental)"
+    [%map_open
+      let script = flag "--script" (optional string) ~doc:"SCRIPT Install script"
+      and verbose = flag  "--verbose" no_arg ~doc:"Make verbose"
+      in
+      Compatibility.optin ();
+      let buildscript_path = Option.value ~default:(default_script_path ()) script in
+      let _build_dir =
+        FilePath.concat
+          (FilePath.dirname buildscript_path)
+          "_build"
+        |> Option.some
+      in
+      let _env = Setup.read_environment () in
+      (fun () ->
+         Satyrographos_command.Lockdown.save_lockdown
+           ~verbose
+           ~buildscript_path;
+         reprint_err_warn ())
+    ]
+
+let lockdown_restore_command =
+  let open Command.Let_syntax in
+  let open RenameOption in
+  let _outf = Format.std_formatter in
+  Command.basic
+    ~summary:"Restore the environment from the lockdown file (experimental)"
+    [%map_open
+      let script = flag "--script" (optional string) ~doc:"SCRIPT Install script"
+      and verbose = flag  "--verbose" no_arg ~doc:"Make verbose"
+      in
+      Compatibility.optin ();
+      let buildscript_path = Option.value ~default:(default_script_path ()) script in
+      let _env = Setup.read_environment () in
+      (fun () ->
+         Satyrographos_command.Lockdown.restore_lockdown
+           ~verbose
+           ~buildscript_path;
+         reprint_err_warn ())
+    ]
+
+let lockdown_command =
+  Command.group ~summary:"Manage the lockdown file (experimental)"
+    [ "save", lockdown_save_command;
+      "restore", lockdown_restore_command;
+    ]

--- a/bin/dune
+++ b/bin/dune
@@ -6,6 +6,7 @@
    core
    satyrographos_template
    satyrographos_command
+   satyrographos_lockdown
    satyrographos_satysfi
    shexp.process
    uri
@@ -17,6 +18,7 @@
    commandBuild
    commandDebug
    commandLint
+   commandLockdown
    commandMigrate
    commandNew
    commandInstall

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -11,6 +11,7 @@ let total_command =
       "library", CommandLibrary.library_command;
       "library-opam", CommandLibrary.library_opam_command;
       "lint", CommandLint.lint_command;
+      "lockdown", CommandLockdown.lockdown_command;
       "migrate", CommandMigrate.migrate_command;
       "satysfi", CommandSatysfi.satysfi_command;
       "status", CommandStatus.status_command;

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -25,6 +25,7 @@ depends: [
   "json-derivers"
   "menhir"
   "ppx_deriving"
+  "ppx_deriving_yojson"
   "ocamlgraph"
   "opam-format" {>= "2.0" & < "2.1"}
   "opam-state" {>= "2.0" & < "2.1"}
@@ -32,6 +33,7 @@ depends: [
   "stringext" {with-test}
   "uri" {>= "3.0.0"}
   "uri-sexp" {>= "3.0.0"}
+  "yaml" {>= "2.0" & < "3.0"}
   "yojson"
 
   # Janestreet Libs

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -188,6 +188,21 @@ let get_version_opt = function
   | LibraryDoc l -> Some l.version
   | Doc _ -> None
 
+let get_opam_dependencies_of_module m =
+  get_dependencies_opt m
+  |> Option.value ~default:Library.Dependency.empty
+  |> Library.Dependency.to_list
+  |> List.map ~f:(fun name -> "satysfi-" ^ name)
+
+let get_opam_dependencies l =
+  get_module_map l
+  |> StringMap.to_sequence
+  |> Sequence.map ~f:(snd)
+  |> Sequence.map ~f:(get_opam_dependencies_of_module)
+  |> Sequence.map ~f:(StringSet.of_list)
+  |> Sequence.fold ~init:StringSet.empty ~f:StringSet.union
+  |> StringSet.to_list
+
 (* Compatibility treatment *)
 let compatibility_treatment (m: m) (l: Library.t) =
   let f = function

--- a/src/command/dune
+++ b/src/command/dune
@@ -10,5 +10,6 @@
    opam-state
    satyrographos
    satyrographos_autogen
+   satyrographos_lockdown
    satyrographos_template
    shexp.process))

--- a/src/command/lockdown.ml
+++ b/src/command/lockdown.ml
@@ -1,0 +1,23 @@
+
+let lockdown_file_path ~buildscript_path =
+  FilePath.concat
+    (FilePath.dirname buildscript_path)
+    "lockdown.yaml"
+
+let save_lockdown ~verbose ~buildscript_path =
+  let buildscript = Satyrographos.BuildScript.load buildscript_path in
+  let lockdown =
+    Satyrographos_lockdown.Lockdown.generate_lockdown
+      ~verbose
+      ~buildscript
+  in
+  Satyrographos_lockdown.LockdownFile.save_file_exn
+    (lockdown_file_path ~buildscript_path)
+    lockdown
+
+let restore_lockdown ~verbose ~buildscript_path =
+  let lockdown =
+    Satyrographos_lockdown.LockdownFile.load_file_exn
+      (lockdown_file_path ~buildscript_path);
+  in
+  Satyrographos_lockdown.Lockdown.restore_lockdown ~verbose lockdown;

--- a/src/lockdown/dune
+++ b/src/lockdown/dune
@@ -1,0 +1,13 @@
+(library
+ (name satyrographos_lockdown)
+ (inline_tests)
+ (preprocess (staged_pps ppx_deriving.std ppx_deriving_yojson ppx_jane))
+ (libraries
+   core
+   fileutils
+   ocamlgraph
+   re
+   satyrographos
+   shexp.process
+   yaml
+))

--- a/src/lockdown/lockdown.ml
+++ b/src/lockdown/lockdown.ml
@@ -1,0 +1,17 @@
+let generate_lockdown ~verbose ~buildscript =
+  let open Satyrographos in
+  let dependent_opam_packages =
+    BuildScript.get_opam_dependencies buildscript
+  in
+  LockdownFile.make
+    ~dependencies:
+      (LockdownFile.Opam
+         (OpamDependencies.get_opam_dependencies ~verbose dependent_opam_packages))
+
+let restore_lockdown ~verbose (lockdown : LockdownFile.t) =
+  begin match lockdown.dependencies with
+      LockdownFile.Opam opam_dependencies ->
+      OpamDependencies.restore_opam_dependencies
+        ~verbose
+        opam_dependencies
+  end

--- a/src/lockdown/lockdownFile.ml
+++ b/src/lockdown/lockdownFile.ml
@@ -1,0 +1,50 @@
+open Core
+
+let version = "0.0.3"
+
+type opam_package = {
+  name: string;
+  version: string;
+}
+[@@deriving equal, sexp, yojson]
+
+type opam_dependencies = {
+  packages: opam_package list;
+}
+[@@deriving equal, sexp, yojson]
+
+type dependencies =
+  | Opam of opam_dependencies
+[@@deriving equal, sexp, yojson]
+
+type t = {
+  satyrographos: string;
+  dependencies: dependencies;
+}
+[@@deriving equal, sexp, yojson]
+
+
+let make ~dependencies = {
+  satyrographos = version;
+  dependencies;
+}
+
+let save_file_exn f ld =
+  Out_channel.with_file f ~f:(fun oc ->
+      let str =
+        to_yojson ld
+        |> YamlYojson.yaml_of_yojson
+        |> Yaml.yaml_to_string
+      in
+      str
+      |> Rresult.R.error_msg_to_invalid_arg
+      |> Out_channel.output_string oc
+    )
+
+let load_file_exn f =
+  In_channel.read_all f
+  |> Yaml.yaml_of_string
+  |> Rresult.R.error_msg_to_invalid_arg
+  |> YamlYojson.yojson_of_yaml
+  |> of_yojson
+  |> Result.ok_or_failwith

--- a/src/lockdown/opamDependencies.ml
+++ b/src/lockdown/opamDependencies.ml
@@ -1,0 +1,63 @@
+open Core
+
+open LockdownFile
+module P = Shexp_process
+
+let opam_installed_transitive_dependencies_com ~verbose:_ packages =
+  let open P.Infix in
+  let cmd =
+    P.run "opam" [
+      "list";
+      "-i";
+      "--color=never";
+      "--columns";
+      "name,installed-version";
+      "--separator=,";
+      "--recursive";
+      "--required-by"; String.concat ~sep:"," packages]
+    |> P.capture_unit [P.Std_io.Stdout]
+    >>| String.split_lines
+    >>| List.filter ~f:(fun l -> String.is_prefix ~prefix:"#" l |> not)
+    >>| List.filter_map ~f:(fun l ->
+        match String.split_on_chars ~on:[','] l with
+        | [name; version] -> Some {
+            name = String.strip name;
+            version = String.strip version;
+          }
+        | [""] | [] -> None
+        | _ ->
+          failwithf
+            "BUG: Unrecognizable package information from OPAM: %S"
+            l
+            ()
+      )
+  in
+  P.echo "Gathering OPAM package information..."
+  >> cmd
+
+let get_opam_dependencies ~verbose packages =
+  let packages =
+    opam_installed_transitive_dependencies_com ~verbose packages
+    |> P.eval
+  in
+  { packages; }
+
+let restore_opam_dependencies_com ~verbose (dependencies : opam_dependencies) =
+  let packages =
+    dependencies.packages
+    |> List.map ~f:(fun {name; version;} ->
+        sprintf "%s.%s" name version)
+  in
+  [
+    ["install"; "--yes";];
+    if verbose
+    then ["--verbose";]
+    else [];
+    packages;
+  ]
+  |> List.concat
+  |> P.run "opam"
+
+let restore_opam_dependencies ~verbose (dependencies : opam_dependencies) =
+  restore_opam_dependencies_com ~verbose dependencies
+  |> P.eval

--- a/src/lockdown/yamlYojson.ml
+++ b/src/lockdown/yamlYojson.ml
@@ -1,0 +1,164 @@
+open Core
+
+let rec yaml_of_yojson =
+  let label s = Yaml.{
+    anchor = None;
+    tag = None;
+    value = s;
+    plain_implicit = true;
+    quoted_implicit = true;
+    style = `Any;
+  }
+  in
+  function
+  | `Assoc (lvs) ->
+    `O (List.map lvs ~f:(fun (l, v) ->
+        label l, yaml_of_yojson v
+      ))
+  | `Bool b ->
+    `Scalar Yaml.{
+    anchor = None;
+    tag = Some "tag:yaml.org,2002:bool";
+    value = string_of_bool b;
+    plain_implicit = true;
+    quoted_implicit = false;
+    style = `Plain;
+  }
+  | `Float f ->
+    `Scalar Yaml.{
+      anchor = None;
+      tag = Some "tag:yaml.org,2002:float";
+      value = string_of_float f;
+      plain_implicit = true;
+      quoted_implicit = false;
+      style = `Plain;
+    }
+  | `Int i ->
+    `Scalar Yaml.{
+      anchor = None;
+      tag = Some "tag:yaml.org,2002:int";
+      value = string_of_int i;
+      plain_implicit = true;
+      quoted_implicit = false;
+      style = `Plain;
+    }
+  | `Intlit i ->
+    `Scalar Yaml.{
+      anchor = None;
+      tag = Some "tag:yaml.org,2002:int";
+      value = i;
+      plain_implicit = true;
+      quoted_implicit = false;
+      style = `Plain;
+    }
+  | `List xs ->
+    `A (List.map ~f:yaml_of_yojson xs)
+  | `Null ->
+    `Scalar Yaml.{
+      anchor = None;
+      tag = Some "tag:yaml.org,2002:null";
+      value = "null";
+      plain_implicit = true;
+      quoted_implicit = false;
+      style = `Plain;
+    }
+  | `String s ->
+    begin match Option.try_with (fun () ->
+        Yojson.Safe.from_string s
+      )
+      with
+      | None ->
+        `Scalar Yaml.{
+            anchor = None;
+            tag = Some "tag:yaml.org,2002:str";
+            value = s;
+            plain_implicit = true;
+            quoted_implicit = true;
+            style = `Any;
+          }
+      | Some _ ->
+        `Scalar Yaml.{
+            anchor = None;
+            tag = Some "tag:yaml.org,2002:str";
+            value = s;
+            plain_implicit = false;
+            quoted_implicit = true;
+            style = `Any;
+          }
+    end
+  | `Tuple _ ->
+    failwithf "Non standard JSON is not accepted." ()
+  | `Variant _ ->
+    failwithf "Non standard JSON is not accepted." ()
+
+let rec yojson_of_yaml =
+  function
+  | `O (lvs) ->
+    `Assoc (List.map lvs ~f:(fun (l, v) ->
+        l.Yaml.value, yojson_of_yaml v
+      ))
+  | `Scalar {Yaml.tag = Some "tag:yaml.org,2002:bool"; value = v; _} ->
+    `Bool (bool_of_string v)
+  | `Scalar {Yaml.tag = Some "tag:yaml.org,2002:float"; value = v; _} ->
+    `Float (float_of_string v)
+  | `Scalar {Yaml.tag = Some "tag:yaml.org,2002:int"; value = v; _} ->
+      begin match int_of_string_opt v with
+      | None -> `Intlit v
+      | Some i -> `Int i
+      end
+  | `A ys ->
+    `List (List.map ~f:yojson_of_yaml ys)
+  | `Scalar {Yaml.tag = Some "tag:yaml.org,2002:null"; value = _; _}
+  | `Scalar {Yaml.plain_implicit = true; value = "null"; _} ->
+    `Null
+  | `Scalar {Yaml.tag = Some "tag:yaml.org,2002:str"; value = v; _} ->
+    `String v
+  | `Scalar {Yaml.style = (`Double_quoted | `Single_quoted | `Folded); value = v; _} ->
+    `String v
+  | `Scalar {Yaml.plain_implicit = true; value = s; _} ->
+    let v = Option.try_with (fun () ->
+        Yojson.Safe.from_string s
+      )
+    in
+    begin match v with
+    | Some (`Bool _ as v)
+    | Some (`Float _ as v)
+    | Some (`Int _ as v)
+    | Some (`Intlit _ as v) ->
+      v
+    | _ ->
+      `String s
+    end
+  | y ->
+    failwithf !"Unknown YAML object: %{sexp: Yaml.yaml}" y ()
+
+let%test_unit "yaml_of_yojson: roundtrip" =
+  let test json =
+    let yaml = yaml_of_yojson json in
+    let result = yojson_of_yaml yaml in
+    if Yojson.Safe.equal json result
+    then ()
+    else failwithf "Round trip failed\nOriginal: %s\n\nYaml: %s\n\nConverted: %s"
+        (Yojson.Safe.to_string json)
+        (Yaml.yaml_to_string yaml |> Rresult.R.get_ok)
+        (Yojson.Safe.to_string result)
+        ()
+  in
+  let test_str json_str =
+    Yojson.Safe.from_string json_str
+    |> test
+  in
+  test_str "null";
+  test_str "1";
+  test_str "1.0";
+  test_str "true";
+  test_str "false";
+  test_str {|""|};
+  test_str {|"1"|};
+  test_str {|"1.0"|};
+  test_str {|"true"|};
+  test_str {|"false"|};
+  test_str {|100000000000000000000000000000000000000000|};
+  test_str {|"null"|};
+  test_str {|"{a:b}"|};
+  test_str {|{"a":true}|};

--- a/test/testcases/command_lockdown_restore__opam.expected
+++ b/test/testcases/command_lockdown_restore__opam.expected
@@ -1,0 +1,236 @@
+Installing packages
+------------------------------------------------------------
+Gathering OPAM package information...
+------------------------------------------------------------
+@@temp_dir@@/pkg
+@@temp_dir@@/pkg/Makefile
+@@temp_dir@@/pkg/README.md
+@@temp_dir@@/pkg/Satyristes
+@@temp_dir@@/pkg/doc-example.saty
+@@temp_dir@@/pkg/doc-grcnum.saty
+@@temp_dir@@/pkg/font.ttf
+@@temp_dir@@/pkg/fonts.satysfi-hash
+@@temp_dir@@/pkg/grcnum.satyh
+@@temp_dir@@/pkg/lockdown.yaml
+@@temp_dir@@/pkg/satysfi-grcnum.opam
+------------------------------------------------------------
+diff -Nr @@empty_dir@@/Makefile @@temp_dir@@/pkg/Makefile
+0a1,9
+> 
+> PHONY: build-doc
+> build-doc:
+> 	@echo "Target: build-doc"
+> 	@echo 'Files under $$SATYSFI_RUNTIME'
+> 	@echo "=============================="
+> 	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
+> 	@echo "=============================="
+> 
+diff -Nr @@empty_dir@@/README.md @@temp_dir@@/pkg/README.md
+0a1
+> @@README.md@@
+diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
+0a1,22
+> 
+> (lang "0.0.3")
+> (library
+>   (name "grcnum")
+>   (version "0.2")
+>   (sources
+>     ((package "grcnum.satyh" "./grcnum.satyh")
+>      (font "grcnum-font.ttf" "./font.ttf" ())
+>      (hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
+>      ; (file "doc/grcnum.md" "README.md")
+>     ))
+>   (opam "satysfi-grcnum.opam")
+>   (dependencies ((fonts-theano ()))))
+> 
+> (doc
+>   (name "example-doc")
+>   (build
+>     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
+>      (make "build-doc")))
+>   (dependencies ((grcnum ())
+>                  (fonts-theano ()))))
+> 
+diff -Nr @@empty_dir@@/doc-example.saty @@temp_dir@@/pkg/doc-example.saty
+0a1
+> @@doc-example.saty@@
+diff -Nr @@empty_dir@@/doc-grcnum.saty @@temp_dir@@/pkg/doc-grcnum.saty
+0a1
+> @@doc-grcnum.saty@@
+diff -Nr @@empty_dir@@/font.ttf @@temp_dir@@/pkg/font.ttf
+0a1
+> @@font.ttf@@
+diff -Nr @@empty_dir@@/fonts.satysfi-hash @@temp_dir@@/pkg/fonts.satysfi-hash
+0a1,3
+> {
+>   "grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>
+> }
+diff -Nr @@empty_dir@@/grcnum.satyh @@temp_dir@@/pkg/grcnum.satyh
+0a1
+> @@grcnum.satyh@@
+diff -Nr @@empty_dir@@/lockdown.yaml @@temp_dir@@/pkg/lockdown.yaml
+0a1,10
+> satyrographos: 0.0.3
+> dependencies:
+> - Opam
+> - packages:
+>   - name: ocaml
+>     version: 4.09.0
+>   - name: satyrographos
+>     version: 0.0.2.7
+>   - name: satysfi
+>     version: 0.0.5+dev2020.09.05
+diff -Nr @@empty_dir@@/satysfi-grcnum.opam @@temp_dir@@/pkg/satysfi-grcnum.opam
+0a1,30
+> opam-version: "2.0"
+> synopsis: "Test Package"
+> name: "satysfi-grcnum"
+> version: "0.1"
+> description: """
+> Test package for SATySFi
+> """
+> maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> license: "LGPL-3.0-or-later"
+> homepage: "https://github.com/na4zagin3/satysfi-fss"
+> dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
+> bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
+> depends: [
+> 
+>   "satysfi" {>= "0.0.5" & < "0.0.6"}
+>   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+> 
+>   "satysfi-base" {>= "1.3.0" & < "2"}
+>   "satysfi-fonts-junicode" {>= "1" & < "2"}
+> 
+> ]
+> build: [ ]
+> install: [
+>   ["satyrographos" "opam" "install"
+>    "--name" "test-package"
+>    "--prefix" "%{prefix}%"
+>    "--script" "%{build}%/Satyristes"]
+> ]
+> 
+------------------------------------------------------------
+Command invoked:
+opam list -i --color=never --columns name,installed-version --separator=, --recursive --required-by satysfi-fonts-theano,satysfi-grcnum
+Installing packages
+------------------------------------------------------------
+------------------------------------------------------------
+@@temp_dir@@/pkg
+@@temp_dir@@/pkg/Makefile
+@@temp_dir@@/pkg/README.md
+@@temp_dir@@/pkg/Satyristes
+@@temp_dir@@/pkg/doc-example.saty
+@@temp_dir@@/pkg/doc-grcnum.saty
+@@temp_dir@@/pkg/font.ttf
+@@temp_dir@@/pkg/fonts.satysfi-hash
+@@temp_dir@@/pkg/grcnum.satyh
+@@temp_dir@@/pkg/lockdown.yaml
+@@temp_dir@@/pkg/satysfi-grcnum.opam
+------------------------------------------------------------
+diff -Nr @@empty_dir@@/Makefile @@temp_dir@@/pkg/Makefile
+0a1,9
+> 
+> PHONY: build-doc
+> build-doc:
+> 	@echo "Target: build-doc"
+> 	@echo 'Files under $$SATYSFI_RUNTIME'
+> 	@echo "=============================="
+> 	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
+> 	@echo "=============================="
+> 
+diff -Nr @@empty_dir@@/README.md @@temp_dir@@/pkg/README.md
+0a1
+> @@README.md@@
+diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
+0a1,22
+> 
+> (lang "0.0.3")
+> (library
+>   (name "grcnum")
+>   (version "0.2")
+>   (sources
+>     ((package "grcnum.satyh" "./grcnum.satyh")
+>      (font "grcnum-font.ttf" "./font.ttf" ())
+>      (hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
+>      ; (file "doc/grcnum.md" "README.md")
+>     ))
+>   (opam "satysfi-grcnum.opam")
+>   (dependencies ((fonts-theano ()))))
+> 
+> (doc
+>   (name "example-doc")
+>   (build
+>     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
+>      (make "build-doc")))
+>   (dependencies ((grcnum ())
+>                  (fonts-theano ()))))
+> 
+diff -Nr @@empty_dir@@/doc-example.saty @@temp_dir@@/pkg/doc-example.saty
+0a1
+> @@doc-example.saty@@
+diff -Nr @@empty_dir@@/doc-grcnum.saty @@temp_dir@@/pkg/doc-grcnum.saty
+0a1
+> @@doc-grcnum.saty@@
+diff -Nr @@empty_dir@@/font.ttf @@temp_dir@@/pkg/font.ttf
+0a1
+> @@font.ttf@@
+diff -Nr @@empty_dir@@/fonts.satysfi-hash @@temp_dir@@/pkg/fonts.satysfi-hash
+0a1,3
+> {
+>   "grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>
+> }
+diff -Nr @@empty_dir@@/grcnum.satyh @@temp_dir@@/pkg/grcnum.satyh
+0a1
+> @@grcnum.satyh@@
+diff -Nr @@empty_dir@@/lockdown.yaml @@temp_dir@@/pkg/lockdown.yaml
+0a1,11
+> satyrographos: 0.0.3
+> dependencies:
+> - Opam
+> - packages:
+>   - name: ocaml
+>     version: 4.09.0
+>   - name: satyrographos
+>     version: 0.0.2.7
+>   - name: satysfi
+>     version: 0.0.5+dev2020.09.05
+> 
+diff -Nr @@empty_dir@@/satysfi-grcnum.opam @@temp_dir@@/pkg/satysfi-grcnum.opam
+0a1,30
+> opam-version: "2.0"
+> synopsis: "Test Package"
+> name: "satysfi-grcnum"
+> version: "0.1"
+> description: """
+> Test package for SATySFi
+> """
+> maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> license: "LGPL-3.0-or-later"
+> homepage: "https://github.com/na4zagin3/satysfi-fss"
+> dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
+> bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
+> depends: [
+> 
+>   "satysfi" {>= "0.0.5" & < "0.0.6"}
+>   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+> 
+>   "satysfi-base" {>= "1.3.0" & < "2"}
+>   "satysfi-fonts-junicode" {>= "1" & < "2"}
+> 
+> ]
+> build: [ ]
+> install: [
+>   ["satyrographos" "opam" "install"
+>    "--name" "test-package"
+>    "--prefix" "%{prefix}%"
+>    "--script" "%{build}%/Satyristes"]
+> ]
+> 
+------------------------------------------------------------
+Command invoked:
+opam install --yes ocaml.4.09.0 satyrographos.0.0.2.7 satysfi.0.0.5+dev2020.09.05

--- a/test/testcases/command_lockdown_restore__opam.ml
+++ b/test/testcases/command_lockdown_restore__opam.ml
@@ -1,0 +1,64 @@
+module StdList = List
+
+open Satyrographos_testlib
+open TestLib
+
+open Shexp_process
+
+let lockdown_yaml =
+{|satyrographos: 0.0.3
+dependencies:
+- Opam
+- packages:
+  - name: ocaml
+    version: 4.09.0
+  - name: satyrographos
+    version: 0.0.2.7
+  - name: satysfi
+    version: 0.0.5+dev2020.09.05
+|}
+
+
+let files =
+  Command_lockdown_save__opam.files @ [
+    "lockdown.yaml", lockdown_yaml;
+  ]
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let pkg_dir = FilePath.concat temp_dir "pkg" in
+  let prepare_pkg =
+    PrepareDist.empty pkg_dir
+    >> prepare_files pkg_dir files
+  in
+  let empty_dist = FilePath.concat temp_dir "empty_dist" in
+  let prepare_dist = PrepareDist.empty empty_dist in
+  let opam_reg = FilePath.concat temp_dir "opam_reg" in
+  let log_file = exec_log_file_path temp_dir in
+  let prepare_opam_reg =
+    PrepareOpamReg.(prepare opam_reg theanoFiles)
+    >> PrepareOpamReg.(prepare opam_reg grcnumFiles)
+    >> PrepareOpamReg.(prepare opam_reg classGreekFiles)
+    >> PrepareOpamReg.(prepare opam_reg baseFiles)
+  in
+  let bin = FilePath.concat temp_dir "bin" in
+  prepare_pkg
+  >> prepare_dist
+  >> prepare_opam_reg
+  >> PrepareBin.prepare_bin bin log_file
+  >>| read_env ~opam_reg ~dist_library_dir:empty_dist
+
+let () =
+  let verbose = false in
+  let main _env ~dest_dir:_ ~temp_dir ~outf:_ =
+    let _name = Some "example-doc" in
+    (* let dest_dir = FilePath.concat dest_dir "dest" in *)
+    Satyrographos_command.Lockdown.restore_lockdown
+      ~verbose
+      ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
+  in
+  let post_dump_dirs ~dest_dir:_ ~temp_dir =
+    let pkg_dir = FilePath.concat temp_dir "pkg" in
+    [pkg_dir]
+  in
+  eval (test_install ~post_dump_dirs env main)

--- a/test/testcases/command_lockdown_save__invalid_opam_response.expected
+++ b/test/testcases/command_lockdown_save__invalid_opam_response.expected
@@ -1,0 +1,226 @@
+Installing packages
+------------------------------------------------------------
+Gathering OPAM package information...
+------------------------------------------------------------
+@@temp_dir@@/pkg
+@@temp_dir@@/pkg/Makefile
+@@temp_dir@@/pkg/README.md
+@@temp_dir@@/pkg/Satyristes
+@@temp_dir@@/pkg/doc-example.saty
+@@temp_dir@@/pkg/doc-grcnum.saty
+@@temp_dir@@/pkg/font.ttf
+@@temp_dir@@/pkg/fonts.satysfi-hash
+@@temp_dir@@/pkg/grcnum.satyh
+@@temp_dir@@/pkg/lockdown.yaml
+@@temp_dir@@/pkg/satysfi-grcnum.opam
+------------------------------------------------------------
+diff -Nr @@empty_dir@@/Makefile @@temp_dir@@/pkg/Makefile
+0a1,9
+> 
+> PHONY: build-doc
+> build-doc:
+> 	@echo "Target: build-doc"
+> 	@echo 'Files under $$SATYSFI_RUNTIME'
+> 	@echo "=============================="
+> 	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
+> 	@echo "=============================="
+> 
+diff -Nr @@empty_dir@@/README.md @@temp_dir@@/pkg/README.md
+0a1
+> @@README.md@@
+diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
+0a1,22
+> 
+> (lang "0.0.3")
+> (library
+>   (name "grcnum")
+>   (version "0.2")
+>   (sources
+>     ((package "grcnum.satyh" "./grcnum.satyh")
+>      (font "grcnum-font.ttf" "./font.ttf" ())
+>      (hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
+>      ; (file "doc/grcnum.md" "README.md")
+>     ))
+>   (opam "satysfi-grcnum.opam")
+>   (dependencies ((fonts-theano ()))))
+> 
+> (doc
+>   (name "example-doc")
+>   (build
+>     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
+>      (make "build-doc")))
+>   (dependencies ((grcnum ())
+>                  (fonts-theano ()))))
+> 
+diff -Nr @@empty_dir@@/doc-example.saty @@temp_dir@@/pkg/doc-example.saty
+0a1
+> @@doc-example.saty@@
+diff -Nr @@empty_dir@@/doc-grcnum.saty @@temp_dir@@/pkg/doc-grcnum.saty
+0a1
+> @@doc-grcnum.saty@@
+diff -Nr @@empty_dir@@/font.ttf @@temp_dir@@/pkg/font.ttf
+0a1
+> @@font.ttf@@
+diff -Nr @@empty_dir@@/fonts.satysfi-hash @@temp_dir@@/pkg/fonts.satysfi-hash
+0a1,3
+> {
+>   "grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>
+> }
+diff -Nr @@empty_dir@@/grcnum.satyh @@temp_dir@@/pkg/grcnum.satyh
+0a1
+> @@grcnum.satyh@@
+diff -Nr @@empty_dir@@/lockdown.yaml @@temp_dir@@/pkg/lockdown.yaml
+0a1,10
+> satyrographos: 0.0.3
+> dependencies:
+> - Opam
+> - packages:
+>   - name: ocaml
+>     version: 4.09.0
+>   - name: satyrographos
+>     version: 0.0.2.7
+>   - name: satysfi
+>     version: 0.0.5+dev2020.09.05
+diff -Nr @@empty_dir@@/satysfi-grcnum.opam @@temp_dir@@/pkg/satysfi-grcnum.opam
+0a1,30
+> opam-version: "2.0"
+> synopsis: "Test Package"
+> name: "satysfi-grcnum"
+> version: "0.1"
+> description: """
+> Test package for SATySFi
+> """
+> maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> license: "LGPL-3.0-or-later"
+> homepage: "https://github.com/na4zagin3/satysfi-fss"
+> dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
+> bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
+> depends: [
+> 
+>   "satysfi" {>= "0.0.5" & < "0.0.6"}
+>   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+> 
+>   "satysfi-base" {>= "1.3.0" & < "2"}
+>   "satysfi-fonts-junicode" {>= "1" & < "2"}
+> 
+> ]
+> build: [ ]
+> install: [
+>   ["satyrographos" "opam" "install"
+>    "--name" "test-package"
+>    "--prefix" "%{prefix}%"
+>    "--script" "%{build}%/Satyristes"]
+> ]
+> 
+------------------------------------------------------------
+Command invoked:
+opam list -i --color=never --columns name,installed-version --separator=, --recursive --required-by satysfi-fonts-theano,satysfi-grcnum
+Installing packages
+------------------------------------------------------------
+Gathering OPAM package information...
+Exception:
+(Failure
+  "BUG: Unrecognizable package information from OPAM: \"***invalid,response,!!!\"")
+------------------------------------------------------------
+@@temp_dir@@/pkg
+@@temp_dir@@/pkg/Makefile
+@@temp_dir@@/pkg/README.md
+@@temp_dir@@/pkg/Satyristes
+@@temp_dir@@/pkg/doc-example.saty
+@@temp_dir@@/pkg/doc-grcnum.saty
+@@temp_dir@@/pkg/font.ttf
+@@temp_dir@@/pkg/fonts.satysfi-hash
+@@temp_dir@@/pkg/grcnum.satyh
+@@temp_dir@@/pkg/satysfi-grcnum.opam
+------------------------------------------------------------
+diff -Nr @@empty_dir@@/Makefile @@temp_dir@@/pkg/Makefile
+0a1,9
+> 
+> PHONY: build-doc
+> build-doc:
+> 	@echo "Target: build-doc"
+> 	@echo 'Files under $$SATYSFI_RUNTIME'
+> 	@echo "=============================="
+> 	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
+> 	@echo "=============================="
+> 
+diff -Nr @@empty_dir@@/README.md @@temp_dir@@/pkg/README.md
+0a1
+> @@README.md@@
+diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
+0a1,22
+> 
+> (lang "0.0.3")
+> (library
+>   (name "grcnum")
+>   (version "0.2")
+>   (sources
+>     ((package "grcnum.satyh" "./grcnum.satyh")
+>      (font "grcnum-font.ttf" "./font.ttf" ())
+>      (hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
+>      ; (file "doc/grcnum.md" "README.md")
+>     ))
+>   (opam "satysfi-grcnum.opam")
+>   (dependencies ((fonts-theano ()))))
+> 
+> (doc
+>   (name "example-doc")
+>   (build
+>     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
+>      (make "build-doc")))
+>   (dependencies ((grcnum ())
+>                  (fonts-theano ()))))
+> 
+diff -Nr @@empty_dir@@/doc-example.saty @@temp_dir@@/pkg/doc-example.saty
+0a1
+> @@doc-example.saty@@
+diff -Nr @@empty_dir@@/doc-grcnum.saty @@temp_dir@@/pkg/doc-grcnum.saty
+0a1
+> @@doc-grcnum.saty@@
+diff -Nr @@empty_dir@@/font.ttf @@temp_dir@@/pkg/font.ttf
+0a1
+> @@font.ttf@@
+diff -Nr @@empty_dir@@/fonts.satysfi-hash @@temp_dir@@/pkg/fonts.satysfi-hash
+0a1,3
+> {
+>   "grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>
+> }
+diff -Nr @@empty_dir@@/grcnum.satyh @@temp_dir@@/pkg/grcnum.satyh
+0a1
+> @@grcnum.satyh@@
+diff -Nr @@empty_dir@@/satysfi-grcnum.opam @@temp_dir@@/pkg/satysfi-grcnum.opam
+0a1,30
+> opam-version: "2.0"
+> synopsis: "Test Package"
+> name: "satysfi-grcnum"
+> version: "0.1"
+> description: """
+> Test package for SATySFi
+> """
+> maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> license: "LGPL-3.0-or-later"
+> homepage: "https://github.com/na4zagin3/satysfi-fss"
+> dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
+> bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
+> depends: [
+> 
+>   "satysfi" {>= "0.0.5" & < "0.0.6"}
+>   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+> 
+>   "satysfi-base" {>= "1.3.0" & < "2"}
+>   "satysfi-fonts-junicode" {>= "1" & < "2"}
+> 
+> ]
+> build: [ ]
+> install: [
+>   ["satyrographos" "opam" "install"
+>    "--name" "test-package"
+>    "--prefix" "%{prefix}%"
+>    "--script" "%{build}%/Satyristes"]
+> ]
+> 
+------------------------------------------------------------
+Command invoked:
+opam list -i --color=never --columns name,installed-version --separator=, --recursive --required-by satysfi-fonts-theano,satysfi-grcnum

--- a/test/testcases/command_lockdown_save__invalid_opam_response.ml
+++ b/test/testcases/command_lockdown_save__invalid_opam_response.ml
@@ -1,0 +1,52 @@
+module StdList = List
+
+open Satyrographos_testlib
+open TestLib
+
+open Shexp_process
+
+let files =
+  Command_lockdown_save__opam.files
+
+let opam_response = {
+  PrepareBin.list_result = {|***invalid,response,!!!|}
+}
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let pkg_dir = FilePath.concat temp_dir "pkg" in
+  let prepare_pkg =
+    PrepareDist.empty pkg_dir
+    >> prepare_files pkg_dir files
+  in
+  let empty_dist = FilePath.concat temp_dir "empty_dist" in
+  let prepare_dist = PrepareDist.empty empty_dist in
+  let opam_reg = FilePath.concat temp_dir "opam_reg" in
+  let log_file = exec_log_file_path temp_dir in
+  let prepare_opam_reg =
+    PrepareOpamReg.(prepare opam_reg theanoFiles)
+    >> PrepareOpamReg.(prepare opam_reg grcnumFiles)
+    >> PrepareOpamReg.(prepare opam_reg classGreekFiles)
+    >> PrepareOpamReg.(prepare opam_reg baseFiles)
+  in
+  let bin = FilePath.concat temp_dir "bin" in
+  prepare_pkg
+  >> prepare_dist
+  >> prepare_opam_reg
+  >> PrepareBin.prepare_bin ~opam_response bin log_file
+  >>| read_env ~opam_reg ~dist_library_dir:empty_dist
+
+let () =
+  let verbose = false in
+  let main _env ~dest_dir:_ ~temp_dir ~outf:_ =
+    let _name = Some "example-doc" in
+    (* let dest_dir = FilePath.concat dest_dir "dest" in *)
+    Satyrographos_command.Lockdown.save_lockdown
+      ~verbose
+      ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
+  in
+  let post_dump_dirs ~dest_dir:_ ~temp_dir =
+    let pkg_dir = FilePath.concat temp_dir "pkg" in
+    [pkg_dir]
+  in
+  eval (test_install ~post_dump_dirs env main)

--- a/test/testcases/command_lockdown_save__opam.expected
+++ b/test/testcases/command_lockdown_save__opam.expected
@@ -1,0 +1,118 @@
+Installing packages
+------------------------------------------------------------
+Gathering OPAM package information...
+------------------------------------------------------------
+@@temp_dir@@/pkg
+@@temp_dir@@/pkg/Makefile
+@@temp_dir@@/pkg/README.md
+@@temp_dir@@/pkg/Satyristes
+@@temp_dir@@/pkg/doc-example.saty
+@@temp_dir@@/pkg/doc-grcnum.saty
+@@temp_dir@@/pkg/font.ttf
+@@temp_dir@@/pkg/fonts.satysfi-hash
+@@temp_dir@@/pkg/grcnum.satyh
+@@temp_dir@@/pkg/lockdown.yaml
+@@temp_dir@@/pkg/satysfi-grcnum.opam
+------------------------------------------------------------
+diff -Nr @@empty_dir@@/Makefile @@temp_dir@@/pkg/Makefile
+0a1,9
+> 
+> PHONY: build-doc
+> build-doc:
+> 	@echo "Target: build-doc"
+> 	@echo 'Files under $$SATYSFI_RUNTIME'
+> 	@echo "=============================="
+> 	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
+> 	@echo "=============================="
+> 
+diff -Nr @@empty_dir@@/README.md @@temp_dir@@/pkg/README.md
+0a1
+> @@README.md@@
+diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
+0a1,22
+> 
+> (lang "0.0.3")
+> (library
+>   (name "grcnum")
+>   (version "0.2")
+>   (sources
+>     ((package "grcnum.satyh" "./grcnum.satyh")
+>      (font "grcnum-font.ttf" "./font.ttf" ())
+>      (hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
+>      ; (file "doc/grcnum.md" "README.md")
+>     ))
+>   (opam "satysfi-grcnum.opam")
+>   (dependencies ((fonts-theano ()))))
+> 
+> (doc
+>   (name "example-doc")
+>   (build
+>     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
+>      (make "build-doc")))
+>   (dependencies ((grcnum ())
+>                  (fonts-theano ()))))
+> 
+diff -Nr @@empty_dir@@/doc-example.saty @@temp_dir@@/pkg/doc-example.saty
+0a1
+> @@doc-example.saty@@
+diff -Nr @@empty_dir@@/doc-grcnum.saty @@temp_dir@@/pkg/doc-grcnum.saty
+0a1
+> @@doc-grcnum.saty@@
+diff -Nr @@empty_dir@@/font.ttf @@temp_dir@@/pkg/font.ttf
+0a1
+> @@font.ttf@@
+diff -Nr @@empty_dir@@/fonts.satysfi-hash @@temp_dir@@/pkg/fonts.satysfi-hash
+0a1,3
+> {
+>   "grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>
+> }
+diff -Nr @@empty_dir@@/grcnum.satyh @@temp_dir@@/pkg/grcnum.satyh
+0a1
+> @@grcnum.satyh@@
+diff -Nr @@empty_dir@@/lockdown.yaml @@temp_dir@@/pkg/lockdown.yaml
+0a1,10
+> satyrographos: 0.0.3
+> dependencies:
+> - Opam
+> - packages:
+>   - name: ocaml
+>     version: 4.09.0
+>   - name: satyrographos
+>     version: 0.0.2.7
+>   - name: satysfi
+>     version: 0.0.5+dev2020.09.05
+diff -Nr @@empty_dir@@/satysfi-grcnum.opam @@temp_dir@@/pkg/satysfi-grcnum.opam
+0a1,30
+> opam-version: "2.0"
+> synopsis: "Test Package"
+> name: "satysfi-grcnum"
+> version: "0.1"
+> description: """
+> Test package for SATySFi
+> """
+> maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> license: "LGPL-3.0-or-later"
+> homepage: "https://github.com/na4zagin3/satysfi-fss"
+> dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
+> bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
+> depends: [
+> 
+>   "satysfi" {>= "0.0.5" & < "0.0.6"}
+>   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+> 
+>   "satysfi-base" {>= "1.3.0" & < "2"}
+>   "satysfi-fonts-junicode" {>= "1" & < "2"}
+> 
+> ]
+> build: [ ]
+> install: [
+>   ["satyrographos" "opam" "install"
+>    "--name" "test-package"
+>    "--prefix" "%{prefix}%"
+>    "--script" "%{build}%/Satyristes"]
+> ]
+> 
+------------------------------------------------------------
+Command invoked:
+opam list -i --color=never --columns name,installed-version --separator=, --recursive --required-by satysfi-fonts-theano,satysfi-grcnum

--- a/test/testcases/command_lockdown_save__opam.ml
+++ b/test/testcases/command_lockdown_save__opam.ml
@@ -1,0 +1,112 @@
+module StdList = List
+
+open Satyrographos_testlib
+open TestLib
+
+open Shexp_process
+
+let satyristes =
+{|
+(lang "0.0.3")
+(library
+  (name "grcnum")
+  (version "0.2")
+  (sources
+    ((package "grcnum.satyh" "./grcnum.satyh")
+     (font "grcnum-font.ttf" "./font.ttf" ())
+     (hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
+     ; (file "doc/grcnum.md" "README.md")
+    ))
+  (opam "satysfi-grcnum.opam")
+  (dependencies ((fonts-theano ()))))
+
+(doc
+  (name "example-doc")
+  (build
+    ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
+     (make "build-doc")))
+  (dependencies ((grcnum ())
+                 (fonts-theano ()))))
+|}
+
+let satysfi_grcnum_opam =
+  "satysfi-grcnum.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-grcnum"
+    ~version:"0.1"
+    ()
+
+let fontHash =
+{|{
+  "grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>
+}|}
+
+let makefile =
+{|
+PHONY: build-doc
+build-doc:
+	@echo "Target: build-doc"
+	@echo 'Files under $$SATYSFI_RUNTIME'
+	@echo "=============================="
+	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
+	@echo "=============================="
+|}
+
+let files =
+  [
+    satysfi_grcnum_opam;
+    "Satyristes", satyristes;
+    "README.md", "@@README.md@@";
+    "fonts.satysfi-hash", fontHash;
+    "grcnum.satyh", "@@grcnum.satyh@@";
+    "font.ttf", "@@font.ttf@@";
+    "doc-grcnum.saty", "@@doc-grcnum.saty@@";
+    "doc-example.saty", "@@doc-example.saty@@";
+    "Makefile", makefile;
+  ]
+
+let opam_response = {
+  PrepareBin.list_result = {|# Packages matching: (installed | available) & (name-match(satyrographos) | name-match(satysfi) | name-match(ocaml))
+# Name       ,# Version
+ocaml        ,4.09.0
+satyrographos,0.0.2.7
+satysfi      ,0.0.5+dev2020.09.05|}
+}
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let pkg_dir = FilePath.concat temp_dir "pkg" in
+  let prepare_pkg =
+    PrepareDist.empty pkg_dir
+    >> prepare_files pkg_dir files
+  in
+  let empty_dist = FilePath.concat temp_dir "empty_dist" in
+  let prepare_dist = PrepareDist.empty empty_dist in
+  let opam_reg = FilePath.concat temp_dir "opam_reg" in
+  let log_file = exec_log_file_path temp_dir in
+  let prepare_opam_reg =
+    PrepareOpamReg.(prepare opam_reg theanoFiles)
+    >> PrepareOpamReg.(prepare opam_reg grcnumFiles)
+    >> PrepareOpamReg.(prepare opam_reg classGreekFiles)
+    >> PrepareOpamReg.(prepare opam_reg baseFiles)
+  in
+  let bin = FilePath.concat temp_dir "bin" in
+  prepare_pkg
+  >> prepare_dist
+  >> prepare_opam_reg
+  >> PrepareBin.prepare_bin ~opam_response bin log_file
+  >>| read_env ~opam_reg ~dist_library_dir:empty_dist
+
+let () =
+  let verbose = false in
+  let main _env ~dest_dir:_ ~temp_dir ~outf:_ =
+    let _name = Some "example-doc" in
+    (* let dest_dir = FilePath.concat dest_dir "dest" in *)
+    Satyrographos_command.Lockdown.save_lockdown
+      ~verbose
+      ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
+  in
+  let post_dump_dirs ~dest_dir:_ ~temp_dir =
+    let pkg_dir = FilePath.concat temp_dir "pkg" in
+    [pkg_dir]
+  in
+  eval (test_install ~post_dump_dirs env main)

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -35,6 +35,9 @@
    command_lint__valid_in_specified_location
    command_lint__valid_versions
    command_lint__warning_expr
+   command_lockdown_restore__opam
+   command_lockdown_save__invalid_opam_response
+   command_lockdown_save__opam
    command_opam_build__doc_satysfi
    command_opam_install__doc
    command_opam_install__duplicated_font_hash

--- a/test/testlib/testLib.mli
+++ b/test/testlib/testLib.mli
@@ -33,6 +33,7 @@ val run_function : (outf:Format.formatter -> unit) -> unit t
 
 val test_install :
   ?replacements:(string * string) list ->
+  ?post_dump_dirs:(dest_dir:string -> temp_dir:string -> string list) ->
   (dest_dir:string -> temp_dir:string -> 'a t) ->
   ('a -> dest_dir:string -> temp_dir:string -> outf:Format.formatter -> unit) ->
   unit t


### PR DESCRIPTION
This PR adds lockdown subcommand which save all the transiently dependent
OPAM packages into lockdown.yaml and also restore them from the lockdown file.

This is the first step of https://github.com/na4zagin3/satyrographos/issues/98