### PR TITLE
Add (omake ...) build rule

### DIFF
--- a/src/buildScript_0_0_2.ml
+++ b/src/buildScript_0_0_2.ml
@@ -84,7 +84,7 @@ let load_sections f =
 
 let parse_build_command = function
   | "make" :: args ->
-    Make args
+    MakeWithEnvVar args
   | "satysfi" :: args ->
     Satysfi args
   | cmd -> failwithf "command %s is not yet supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()

--- a/src/buildScript_0_0_3.ml
+++ b/src/buildScript_0_0_3.ml
@@ -107,6 +107,8 @@ let parse_build_command = function
     Run (cmd, args)
   | "run" :: _ ->
     failwithf "run command requires a executable name like (run <cmd> <args>...)" ()
+  | "make" :: args ->
+    Make args
   | "make-with-env-var" :: args ->
     MakeWithEnvVar args
   | "satysfi" :: args ->

--- a/src/buildScript_0_0_3.ml
+++ b/src/buildScript_0_0_3.ml
@@ -107,8 +107,8 @@ let parse_build_command = function
     Run (cmd, args)
   | "run" :: _ ->
     failwithf "run command requires a executable name like (run <cmd> <args>...)" ()
-  | "make" :: args ->
-    Make args
+  | "make-with-env-var" :: args ->
+    MakeWithEnvVar args
   | "satysfi" :: args ->
     Satysfi args
   | cmd -> failwithf "command %s is not supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()

--- a/src/buildScript_0_0_3.ml
+++ b/src/buildScript_0_0_3.ml
@@ -113,6 +113,8 @@ let parse_build_command = function
     MakeWithEnvVar args
   | "satysfi" :: args ->
     Satysfi args
+  | "omake" :: args ->
+    OMake args
   | cmd -> failwithf "command %s is not supported" ([%sexp_of: string list] cmd |> Sexp.to_string) ()
 
 let section_to_modules ~base_dir (range, (m : Section.t)) =

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -70,6 +70,7 @@ type build_command =
   | Satysfi of string list
   | Make of string list
   | MakeWithEnvVar of string list
+  | OMake of string list
   | Run of string * string list
 [@@deriving sexp]
 

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -68,6 +68,7 @@ type documentSource = [
 
 type build_command =
   | Satysfi of string list
+  | Make of string list
   | MakeWithEnvVar of string list
   | Run of string * string list
 [@@deriving sexp]

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -68,7 +68,7 @@ type documentSource = [
 
 type build_command =
   | Satysfi of string list
-  | Make of string list
+  | MakeWithEnvVar of string list
   | Run of string * string list
 [@@deriving sexp]
 

--- a/src/command/build.ml
+++ b/src/command/build.ml
@@ -16,6 +16,8 @@ let read_module ~outf ~verbose ~build_module ~buildscript_path =
 let parse_build_command ~satysfi_runtime = function
   | BuildScript.Run (cmd, args) ->
     P.run cmd args
+  | BuildScript.Make args ->
+    P.run "make" args
   | BuildScript.MakeWithEnvVar args ->
     P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args)
   | BuildScript.Satysfi args ->

--- a/src/command/build.ml
+++ b/src/command/build.ml
@@ -16,7 +16,7 @@ let read_module ~outf ~verbose ~build_module ~buildscript_path =
 let parse_build_command ~satysfi_runtime = function
   | BuildScript.Run (cmd, args) ->
     P.run cmd args
-  | BuildScript.Make args ->
+  | BuildScript.MakeWithEnvVar args ->
     P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args)
   | BuildScript.Satysfi args ->
     RunSatysfi.run_satysfi_command ~satysfi_runtime args

--- a/src/command/build.ml
+++ b/src/command/build.ml
@@ -22,6 +22,8 @@ let parse_build_command ~satysfi_runtime = function
     P.run "make" (["SATYSFI_RUNTIME=" ^ satysfi_runtime] @ args)
   | BuildScript.Satysfi args ->
     RunSatysfi.run_satysfi_command ~satysfi_runtime args
+  | BuildScript.OMake args ->
+    P.run "omake" args
 
 let run_build_commands ~workingDir ~project_env buildCommands =
   let commands satysfi_runtime = P.List.iter buildCommands ~f:(parse_build_command ~satysfi_runtime) in

--- a/src/command/lint.ml
+++ b/src/command/lint.ml
@@ -28,7 +28,7 @@ let lint_build ~locs ~(buildscript_version : BuildScript.version) (m : BuildScri
     BuildScript.get_build_opt m
     |> Option.value ~default:[]
     |> List.exists ~f:(function
-        | BuildScript.Make _
+        | BuildScript.MakeWithEnvVar _
           when
             [%equal: BuildScript.version] buildscript_version BuildScript.Lang_0_0_2
             |> not -> true

--- a/src/command/lint_problem.ml
+++ b/src/command/lint_problem.ml
@@ -78,7 +78,7 @@ let show_problem ~outf = function
       "@;%s" stacktrace
   | LibraryBuildDeprecatedMakeCommand ->
     Format.fprintf outf
-      "(make <args>...) build command has been deprecated.@ Please use (run make <args>...) instead and then `satyrographos satysfi ...` command instead of `satysfi -C $SATYSFI_RUNTIME ...`."
+      "(make <args>...) build command has been deprecated.@ Please use (make <args>...) instead and then `satyrographos satysfi ...` command instead of `satysfi -C $SATYSFI_RUNTIME ...`."
   | LibraryMissingFile ->
     Format.fprintf outf
       "Missing file"

--- a/src/template/template_docMake_en.ml
+++ b/src/template/template_docMake_en.ml
@@ -163,7 +163,7 @@ let satyristes_template =
 
 (doc
   (name  "main")
-  (build ((run make)))
+  (build ((make)))
   (dependencies
    (;; Standard library
     (dist ())

--- a/src/template/template_docMake_ja.ml
+++ b/src/template/template_docMake_ja.ml
@@ -165,7 +165,7 @@ let satyristes_template =
 
 (doc
   (name  "main")
-  (build ((run make)))
+  (build ((make)))
   (dependencies
    (;; Standard library
     (dist ())

--- a/src/template/template_docOmake_en.ml
+++ b/src/template/template_docOmake_en.ml
@@ -4,7 +4,7 @@ let satyristes_template =
 
 (doc
   (name  "main")
-  (build ((run omake)))
+  (build ((omake)))
   (dependencies
    (;; Standard library
     (dist ())

--- a/src/template/template_docOmake_ja.ml
+++ b/src/template/template_docOmake_ja.ml
@@ -4,7 +4,7 @@ let satyristes_template =
 
 (doc
   (name  "main")
-  (build ((run omake)))
+  (build ((omake)))
   (dependencies
    (;; Standard library
     (dist ())

--- a/test/testcases/command_build__doc_make.expected
+++ b/test/testcases/command_build__doc_make.expected
@@ -1,22 +1,6 @@
 Installing packages
 ------------------------------------------------------------
 Target: build-doc
-Files under $SATYSFI_RUNTIME
-==============================
-.
-./dist
-./dist/.satyrographos
-./dist/fonts
-./dist/fonts/fonts-theano
-./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
-./dist/fonts/fonts-theano/TheanoModern-Regular.otf
-./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
-./dist/hash
-./dist/hash/fonts.satysfi-hash
-./dist/metadata
-./dist/packages
-./dist/packages/grcnum
-./dist/packages/grcnum/grcnum.satyh
 ==============================
 0
 

--- a/test/testcases/command_build__doc_make.ml
+++ b/test/testcases/command_build__doc_make.ml
@@ -21,9 +21,6 @@ let makefile =
 PHONY: build-doc
 build-doc:
 	@echo "Target: build-doc"
-	@echo 'Files under $$SATYSFI_RUNTIME'
-	@echo "=============================="
-	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
 	@echo "=============================="
 	@echo "$(SATYROGRAPHOS_PROJECT)" | grep -e 'pkg/Satyristes' >/dev/null ; echo "$$?"
 |}

--- a/test/testcases/command_build__doc_satysfi.expected
+++ b/test/testcases/command_build__doc_satysfi.expected
@@ -1,23 +1,6 @@
 Installing packages
 ------------------------------------------------------------
 Target: build-doc
-Files under $SATYSFI_RUNTIME
-==============================
-.
-./dist
-./dist/.satyrographos
-./dist/fonts
-./dist/fonts/fonts-theano
-./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
-./dist/fonts/fonts-theano/TheanoModern-Regular.otf
-./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
-./dist/hash
-./dist/hash/fonts.satysfi-hash
-./dist/metadata
-./dist/packages
-./dist/packages/grcnum
-./dist/packages/grcnum/grcnum.satyh
-==============================
 
 ================
 Reading runtime dist: @@temp_dir@@/empty_dist

--- a/test/testcases/command_build__doc_satysfi.ml
+++ b/test/testcases/command_build__doc_satysfi.ml
@@ -22,10 +22,6 @@ let makefile =
 PHONY: build-doc
 build-doc:
 	@echo "Target: build-doc"
-	@echo 'Files under $$SATYSFI_RUNTIME'
-	@echo "=============================="
-	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
-	@echo "=============================="
 |}
 
 let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =

--- a/test/testcases/command_build__doc_with_libraries.expected
+++ b/test/testcases/command_build__doc_with_libraries.expected
@@ -1,23 +1,6 @@
 Installing packages
 ------------------------------------------------------------
 Target: build-doc
-Files under $SATYSFI_RUNTIME
-==============================
-.
-./dist
-./dist/.satyrographos
-./dist/fonts
-./dist/fonts/fonts-theano
-./dist/fonts/fonts-theano/TheanoDidot-Regular.otf
-./dist/fonts/fonts-theano/TheanoModern-Regular.otf
-./dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
-./dist/hash
-./dist/hash/fonts.satysfi-hash
-./dist/metadata
-./dist/packages
-./dist/packages/grcnum
-./dist/packages/grcnum/grcnum.satyh
-==============================
 
 ================
 Reading runtime dist: @@temp_dir@@/empty_dist

--- a/test/testcases/command_build__doc_with_libraries.ml
+++ b/test/testcases/command_build__doc_with_libraries.ml
@@ -45,10 +45,6 @@ let makefile =
 PHONY: build-doc
 build-doc:
 	@echo "Target: build-doc"
-	@echo 'Files under $$SATYSFI_RUNTIME'
-	@echo "=============================="
-	@cd "$(SATYSFI_RUNTIME)" ; find . | LC_ALL=C sort
-	@echo "=============================="
 |}
 
 let files =


### PR DESCRIPTION
This PR changes build rules in script lang 0.0.3.

- adds `(omake ...)` build rule
- adds `(make-with-env-var ...)` build rule which behaves as same as `(make ...)` in script lang 0.0.2
- keeps `(make ...)` from setting `$SATYSFI_RUNTIME`