### PR TITLE
Add (autogen ...) clause to library, libraryDoc and doc module 

### DIFF
--- a/src/buildScript_0_0_2.ml
+++ b/src/buildScript_0_0_2.ml
@@ -109,7 +109,8 @@ let section_to_modules ~base_dir (range, (m : Section.t)) =
         |> CompatibilitySet.of_list
       in
       let position = Some (position_of_range range) in
-      [name, Library {name; version; opam; sources; dependencies; compatibility; position; }]
+      let autogen = Library.Dependency.empty in
+      [name, Library {name; version; opam; sources; dependencies; compatibility; position; autogen; }]
     | LibraryDoc {name; version; opam; workingDirectory: string; build; sources; dependencies;} ->
       if String.suffix name 4 |> String.equal "-doc" |> not
       then failwithf "libraryDoc must have suffix -doc but got %s" name ();
@@ -121,7 +122,8 @@ let section_to_modules ~base_dir (range, (m : Section.t)) =
       let build =
         List.map ~f:parse_build_command build
       in
-      [name, LibraryDoc {name; version; opam; workingDirectory: string; build; sources; dependencies; position; }]
+      let autogen = Library.Dependency.empty in
+      [name, LibraryDoc {name; version; opam; workingDirectory: string; build; sources; dependencies; position; autogen; }]
 
 let sections_to_modules ~base_dir sections =
   let modules = sections |> List.concat_map ~f:(section_to_modules ~base_dir) in

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -305,6 +305,10 @@ let read_module (m: m) ~src_dir =
     get_dependencies_opt m
     |> Option.value ~default:(Library.Dependency.empty)
   in
+  let autogen =
+    get_autogen_opt m
+    |> Option.value ~default:(Library.Dependency.empty)
+  in
   let sources =
     get_sources_opt m
     |> Option.value ~default:[]
@@ -325,6 +329,7 @@ let read_module (m: m) ~src_dir =
               name = Some name;
               version;
               dependencies;
+              autogen;
             }
   in
   let libraries =

--- a/src/buildScript_prim.ml
+++ b/src/buildScript_prim.ml
@@ -57,6 +57,7 @@ type library = {
   opam: string;
   sources: sources [@sexp.omit_nil];
   dependencies: Library.Dependency.t [@sexp.omit_nil];
+  autogen: Library.Dependency.t [@sexp.omit_nil];
   compatibility: CompatibilitySet.t [@sexp.omit_nil];
   position: position option;
 } [@@deriving sexp]
@@ -86,6 +87,7 @@ type libraryDoc = {
   build: build [@sexp.omit_nil];
   sources: documentSource list [@sexp.omit_nil];
   dependencies: Library.Dependency.t [@sexp.omit_nil];
+  autogen: Library.Dependency.t [@sexp.omit_nil];
   position: position option;
 } [@@deriving sexp]
 
@@ -94,6 +96,7 @@ type doc = {
   workingDirectory: string;
   build: build [@sexp.omit_nil];
   dependencies: Library.Dependency.t [@sexp.omit_nil];
+  autogen: Library.Dependency.t [@sexp.omit_nil];
   position: position option;
 } [@@deriving sexp]
 
@@ -149,6 +152,11 @@ let export_opam_package = function
 
 let export_opam bs =
   StringMap.iter bs ~f:export_opam_package
+
+let get_autogen_opt = function
+  | Library l -> Some l.autogen
+  | LibraryDoc l -> Some l.autogen
+  | Doc l -> Some l.autogen
 
 let get_build_opt = function
   | Library _ -> None

--- a/src/command/build.ml
+++ b/src/command/build.ml
@@ -50,9 +50,10 @@ let setup_project_env ~buildscript_path ~satysfi_runtime_dir ~outf ~verbose ~lib
   Install.install satysfi_dist ~outf ~system_font_prefix ~persistent_autogen ~autogen_libraries ~libraries ~verbose ~safe:true ~copy:false ~env ();
   project_env
 
-let build ~outf ~build_dir ~verbose ~build_module ~buildscript_path ~system_font_prefix ~autogen_libraries ~env =
+let build ~outf ~build_dir ~verbose ~build_module ~buildscript_path ~system_font_prefix ~env =
   let src_dir, p = read_module ~outf ~verbose ~build_module ~buildscript_path in
   let libraries = Library.Dependency.to_list p.dependencies |> Some in
+  let autogen_libraries = Library.Dependency.to_list p.autogen in
   let with_build_dir build_dir c =
     let satysfi_runtime_dir = FilePath.concat build_dir "satysfi" in
     let project_env =
@@ -124,12 +125,10 @@ let opam_pin_project ~(buildscript: BuildScript.t) ~buildscript_path =
 let build_command ~outf ~buildscript_path ~name ~verbose ~env =
   let f ~buildscript ~build_module ~build_dir =
     let system_font_prefix = None in
-    (* TODO Read autogen section from the build module *)
-    let autogen_libraries = [] in
     opam_pin_project ~buildscript ~buildscript_path
     |> P.eval ;
     Format.fprintf outf "@.================@.";
-    build ~outf ~verbose ~build_module ~buildscript_path ~system_font_prefix ~autogen_libraries ~env ~build_dir;
+    build ~outf ~verbose ~build_module ~buildscript_path ~system_font_prefix ~env ~build_dir;
     Format.fprintf outf "@.================@."
   in
   let buildscript = BuildScript.load buildscript_path in

--- a/src/command/install.ml
+++ b/src/command/install.ml
@@ -148,7 +148,7 @@ let add_autogen_libraries ~outf ~libraries ~env:(_ : Environment.t) ~(persistent
   (* %libraries need to come last *)
   |> add_library Autogen.Libraries.name Autogen.Libraries.generate
 
-let get_library_map ~outf ~system_font_prefix ?(autogen_libraries=[]) ~libraries ~(env: Environment.t) ~persistent_autogen () =
+let get_library_map ~outf ~system_font_prefix ~autogen_libraries ~libraries ~(env: Environment.t) ~persistent_autogen () =
   let maybe_depot = env.depot in
   let maybe_reg = Option.map maybe_depot ~f:(fun p -> p.reg) in
   let library_map = get_libraries ~outf ~maybe_reg ~env ~libraries in
@@ -160,8 +160,10 @@ let get_library_map ~outf ~system_font_prefix ?(autogen_libraries=[]) ~libraries
       Map.add_exn ~key:"%fonts-system" ~data:systemFontLibrary library_map
   in
   let autogen_libraries =
-    autogen_libraries
-    |> Set.of_list (module String)
+    Map.data library_map
+    |> List.map ~f:(fun l -> l.Library.autogen)
+    |> List.cons (Library.Dependency.of_list autogen_libraries)
+    |> Library.Dependency.union_list
   in
   if Set.is_empty autogen_libraries
   then library_map

--- a/src/command/lint_module_dependency.ml
+++ b/src/command/lint_module_dependency.ml
@@ -32,9 +32,21 @@ let get_libraries ~locs ~env ~library_override m =
     |> Option.map ~f:(fun d -> Library.Dependency.elements d)
     |> Option.value ~default:[]
   in
+  let autogen_libraries =
+    BuildScript.get_autogen_opt m
+    |> Option.map ~f:Library.Dependency.elements
+    |> Option.value ~default:[]
+  in
   let combine ~key:_ _v1 v2 = v2 in
   Result.try_with (fun () ->
-      Install.get_library_map ~outf:dummy_formatter ~system_font_prefix:None ~libraries:(Some libraries) ~persistent_autogen:[] ~env ()
+      Install.get_library_map
+        ~outf:dummy_formatter
+        ~system_font_prefix:None
+        ~libraries:(Some libraries)
+        ~autogen_libraries
+        ~persistent_autogen:[] 
+        ~env
+        ()
       |> (fun m -> Map.merge_skewed ~combine m library_override)
       |> Map.data
     )

--- a/src/command/opam.ml
+++ b/src/command/opam.ml
@@ -9,7 +9,6 @@ let library_dir prefix (buildscript: BuildScript.m) =
 
 let build_opam ~outf ~verbose ~prefix:_ ~build_module ~buildscript_path ~env =
   let system_font_prefix = None in
-  let autogen_libraries = [] in
   Build.build
     ~outf
     ~verbose
@@ -17,7 +16,6 @@ let build_opam ~outf ~verbose ~prefix:_ ~build_module ~buildscript_path ~env =
     ~buildscript_path
     ~build_dir:None
     ~system_font_prefix
-    ~autogen_libraries
     ~env
 
 let install_opam ~outf ~verbose ~prefix ~build_module ~buildscript_path ~env:_ =

--- a/src/library.ml
+++ b/src/library.ml
@@ -66,6 +66,7 @@ type t = {
   files: file LibraryFiles.t [@sexp.omit_nil];
   compatibility: Compatibility.t [@sexp.omit_nil];
   dependencies: Dependency.t [@sexp.omit_nil];
+  autogen: Dependency.t [@sexp.omit_nil];
 }
 [@@deriving sexp, compare]
 
@@ -76,6 +77,7 @@ let empty = {
   files = LibraryFiles.empty;
   compatibility = Compatibility.empty;
   dependencies = Dependency.empty;
+  autogen = Dependency.empty;
 }
 
 
@@ -137,6 +139,7 @@ let normalize ~outf p = {
   files = p.files;
   compatibility = p.compatibility;
   dependencies = p.dependencies;
+  autogen = p.autogen;
   name = p.name;
   version = p.version;
 }
@@ -185,6 +188,7 @@ let union p1 p2 =
     files = LibraryFiles.union handle_file_conflict p1.files p2.files;
     compatibility = Compatibility.union p1.compatibility p2.compatibility;
     dependencies = Dependency.union p1.dependencies p2.dependencies;
+    autogen = Dependency.union p1.autogen p2.autogen;
     name = Core.Option.first_some p1.name p2.name;
     version = Core.Option.first_some p1.version p2.version;
   }

--- a/src/library.mli
+++ b/src/library.mli
@@ -100,6 +100,7 @@ type metadata = {
   libraryVersion: string [@default ""];
   compatibility: Compatibility.t;
   dependencies: (string * unit (* for future extension *)) list;
+  autogen: (string * unit (* for future extension *)) list [@sexp.omit_nil];
 }
 [@@deriving sexp, compare]
 

--- a/src/library.mli
+++ b/src/library.mli
@@ -66,6 +66,7 @@ type t = {
   files: file LibraryFiles.t [@sexp.omit_nil];
   compatibility: Compatibility.t [@sexp.omit_nil];
   dependencies: Dependency.t [@sexp.omit_nil];
+  autogen: Dependency.t [@sexp.omit_nil];
 }
 [@@deriving sexp, compare]
 

--- a/src/template/template_docMake_en.ml
+++ b/src/template/template_docMake_en.ml
@@ -166,9 +166,9 @@ let satyristes_template =
   (build ((make)))
   (dependencies
    (;; Standard library
-    (dist ())
+    dist
     ;; Third-party library
-    (fss ())
+    fss
     )))
 |}
 

--- a/src/template/template_docMake_ja.ml
+++ b/src/template/template_docMake_ja.ml
@@ -168,9 +168,9 @@ let satyristes_template =
   (build ((make)))
   (dependencies
    (;; Standard library
-    (dist ())
+    dist
     ;; Third-party library
-    (fss ())
+    fss
     )))
 |}
 

--- a/src/template/template_docOmake_en.ml
+++ b/src/template/template_docOmake_en.ml
@@ -7,9 +7,9 @@ let satyristes_template =
   (build ((omake)))
   (dependencies
    (;; Standard library
-    (dist ())
+    dist
     ;; Third-party library
-    (fss ())
+    fss
     )))
 |}
 

--- a/src/template/template_docOmake_ja.ml
+++ b/src/template/template_docOmake_ja.ml
@@ -7,9 +7,9 @@ let satyristes_template =
   (build ((omake)))
   (dependencies
    (;; Standard library
-    (dist ())
+    dist
     ;; Third-party library
-    (fss ())
+    fss
     )))
 |}
 

--- a/test/testcases/command_build__doc_make.ml
+++ b/test/testcases/command_build__doc_make.ml
@@ -12,8 +12,7 @@ let satyristes =
   (name "example-doc")
   (build
     ((make "build-doc")))
-  (dependencies ((grcnum ())
-                 (fonts-theano ()))))
+  (dependencies (grcnum fonts-theano)))
 |}
 
 let makefile =

--- a/test/testcases/command_build__doc_satysfi.ml
+++ b/test/testcases/command_build__doc_satysfi.ml
@@ -13,8 +13,7 @@ let satyristes =
   (build
     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
      (make "build-doc")))
-  (dependencies ((grcnum ())
-                 (fonts-theano ()))))
+  (dependencies (grcnum fonts-theano)))
 |}
 
 let makefile =

--- a/test/testcases/command_build__doc_with_autogen.expected
+++ b/test/testcases/command_build__doc_with_autogen.expected
@@ -1,0 +1,175 @@
+Installing packages
+------------------------------------------------------------
+Target: build-doc
+
+================
+Reading runtime dist: @@temp_dir@@/empty_dist
+Read user libraries: ()
+Reading opam libraries: (base class-greek fonts-theano grcnum)
+Not gathering system fonts
+Generating autogen libraries
+Generating autogen library %libraries
+Installing libraries: (%libraries dist fonts-theano grcnum)
+Removing destination @@temp_dir@@/pkg/_build/satysfi/dist
+Installation completed!
+
+[1;33mCompatibility notice[0m for library fonts-theano:
+
+  Fonts have been renamed.
+  
+    TheanoDidot -> fonts-theano:TheanoDidot
+    TheanoModern -> fonts-theano:TheanoModern
+    TheanoOldStyle -> fonts-theano:TheanoOldStyle
+
+[1;33mCompatibility notice[0m for library grcnum:
+
+  Packages have been renamed.
+  
+    grcnum.satyh -> grcnum/grcnum.satyh
+
+================
+------------------------------------------------------------
+@@temp_dir@@/pkg
+@@temp_dir@@/pkg/Makefile
+@@temp_dir@@/pkg/README.md
+@@temp_dir@@/pkg/Satyristes
+@@temp_dir@@/pkg/_build
+@@temp_dir@@/pkg/_build/satysfi
+@@temp_dir@@/pkg/_build/satysfi/dist
+@@temp_dir@@/pkg/_build/satysfi/dist/.satyrographos
+@@temp_dir@@/pkg/_build/satysfi/dist/fonts
+@@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano
+@@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoDidot-Regular.otf
+@@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoModern-Regular.otf
+@@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+@@temp_dir@@/pkg/_build/satysfi/dist/hash
+@@temp_dir@@/pkg/_build/satysfi/dist/hash/fonts.satysfi-hash
+@@temp_dir@@/pkg/_build/satysfi/dist/metadata
+@@temp_dir@@/pkg/_build/satysfi/dist/packages
+@@temp_dir@@/pkg/_build/satysfi/dist/packages/grcnum
+@@temp_dir@@/pkg/_build/satysfi/dist/packages/grcnum/grcnum.satyh
+@@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos
+@@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental
+@@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental/libraries.satyg
+@@temp_dir@@/pkg/doc-example-ja.pdf
+@@temp_dir@@/pkg/doc-example.saty
+@@temp_dir@@/pkg/doc-grcnum.saty
+@@temp_dir@@/pkg/satysfi-grcnum.opam
+------------------------------------------------------------
+diff -Nr @@empty_dir@@/Makefile @@temp_dir@@/pkg/Makefile
+0a1,5
+> 
+> PHONY: build-doc
+> build-doc:
+> 	@echo "Target: build-doc"
+> 
+diff -Nr @@empty_dir@@/README.md @@temp_dir@@/pkg/README.md
+0a1
+> @@README.md@@
+diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
+0a1,11
+> 
+> (lang "0.0.3")
+> 
+> (doc
+>   (name "example-doc")
+>   (build
+>     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
+>      (make "build-doc")))
+>   (dependencies (grcnum fonts-theano))
+>   (autogen (%libraries)))
+> 
+diff -Nr @@empty_dir@@/_build/satysfi/dist/fonts/fonts-theano/TheanoDidot-Regular.otf @@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoDidot-Regular.otf
+0a1
+> @@TheanoDidot-Regular.otf@@
+diff -Nr @@empty_dir@@/_build/satysfi/dist/fonts/fonts-theano/TheanoModern-Regular.otf @@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoModern-Regular.otf
+0a1
+> @@TheanoModern-Regular.otf@@
+diff -Nr @@empty_dir@@/_build/satysfi/dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
+0a1
+> @@TheanoOldStyle-Regular.otf@@
+diff -Nr @@empty_dir@@/_build/satysfi/dist/hash/fonts.satysfi-hash @@temp_dir@@/pkg/_build/satysfi/dist/hash/fonts.satysfi-hash
+0a1
+> {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
+\ No newline at end of file
+diff -Nr @@empty_dir@@/_build/satysfi/dist/metadata @@temp_dir@@/pkg/_build/satysfi/dist/metadata
+0a1,9
+> ((version 1) (libraryName %libraries) (libraryVersion 0.1)
+>  (compatibility
+>   ((rename_packages
+>     (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))
+>    (rename_fonts
+>     (((new_name fonts-theano:TheanoDidot) (old_name TheanoDidot))
+>      ((new_name fonts-theano:TheanoModern) (old_name TheanoModern))
+>      ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle))))))
+>  (dependencies ((fonts-theano ()))))
+diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/grcnum/grcnum.satyh @@temp_dir@@/pkg/_build/satysfi/dist/packages/grcnum/grcnum.satyh
+0a1
+> @@grcnum.satyh@@
+diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/satyrographos/experimental/libraries.satyg @@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental/libraries.satyg
+0a1,18
+> let _ =
+> (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)
+> let _ =
+> (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
+> let _ =
+> (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
+> type library =
+> (| name : string; version : string; |)
+> module Libraries : sig
+> val list :
+> library list
+> end = struct
+> let list =
+> [ (| name = `dist`; version = ` `; |);
+>   (| name = `fonts-theano`; version = `2.0`; |);
+>   (| name = `grcnum`; version = `0.2`; |); ]
+> 
+> end
+diff -Nr @@empty_dir@@/doc-example-ja.pdf @@temp_dir@@/pkg/doc-example-ja.pdf
+0a1
+> @@doc-example.saty@@
+diff -Nr @@empty_dir@@/doc-example.saty @@temp_dir@@/pkg/doc-example.saty
+0a1
+> @@doc-example.saty@@
+diff -Nr @@empty_dir@@/doc-grcnum.saty @@temp_dir@@/pkg/doc-grcnum.saty
+0a1
+> @@doc-grcnum.saty@@
+diff -Nr @@empty_dir@@/satysfi-grcnum.opam @@temp_dir@@/pkg/satysfi-grcnum.opam
+0a1,30
+> opam-version: "2.0"
+> synopsis: "Test Package"
+> name: "satysfi-grcnum"
+> version: "0.1"
+> description: """
+> Test package for SATySFi
+> """
+> maintainer: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> authors: "SAKAMOTO Noriaki <mrty.ityt.pt@gmail.com>"
+> license: "LGPL-3.0-or-later"
+> homepage: "https://github.com/na4zagin3/satysfi-fss"
+> dev-repo: "git+https://github.com/na4zagin3/satysfi-fss.git"
+> bug-reports: "https://github.com/na4zagin3/satysfi-fss/issues"
+> depends: [
+> 
+>   "satysfi" {>= "0.0.5" & < "0.0.6"}
+>   "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+> 
+>   "satysfi-base" {>= "1.3.0" & < "2"}
+>   "satysfi-fonts-junicode" {>= "1" & < "2"}
+> 
+> ]
+> build: [ ]
+> install: [
+>   ["satyrographos" "opam" "install"
+>    "--name" "test-package"
+>    "--prefix" "%{prefix}%"
+>    "--script" "%{build}%/Satyristes"]
+> ]
+> 
+------------------------------------------------------------
+Command invoked:
+satysfi -C @@temp_dir@@/pkg/_build/satysfi --version
+Command invoked:
+satysfi -C @@temp_dir@@/pkg/_build/satysfi doc-example.saty -o doc-example-ja.pdf
+doc-example.saty -> doc-example-ja.pdf

--- a/test/testcases/command_build__doc_with_autogen.expected
+++ b/test/testcases/command_build__doc_with_autogen.expected
@@ -5,27 +5,15 @@ Target: build-doc
 ================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
-Reading opam libraries: (base class-greek fonts-theano grcnum)
+Reading opam libraries: (base localized-today)
 Not gathering system fonts
 Generating autogen libraries
+Generating autogen library %today
+autogen:%today: Using lockdowned values
 Generating autogen library %libraries
-Installing libraries: (%libraries dist fonts-theano grcnum)
+Installing libraries: (%libraries %today dist localized-today)
 Removing destination @@temp_dir@@/pkg/_build/satysfi/dist
 Installation completed!
-
-[1;33mCompatibility notice[0m for library fonts-theano:
-
-  Fonts have been renamed.
-  
-    TheanoDidot -> fonts-theano:TheanoDidot
-    TheanoModern -> fonts-theano:TheanoModern
-    TheanoOldStyle -> fonts-theano:TheanoOldStyle
-
-[1;33mCompatibility notice[0m for library grcnum:
-
-  Packages have been renamed.
-  
-    grcnum.satyh -> grcnum/grcnum.satyh
 
 ================
 ------------------------------------------------------------
@@ -37,23 +25,18 @@ Installation completed!
 @@temp_dir@@/pkg/_build/satysfi
 @@temp_dir@@/pkg/_build/satysfi/dist
 @@temp_dir@@/pkg/_build/satysfi/dist/.satyrographos
-@@temp_dir@@/pkg/_build/satysfi/dist/fonts
-@@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano
-@@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoDidot-Regular.otf
-@@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoModern-Regular.otf
-@@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
-@@temp_dir@@/pkg/_build/satysfi/dist/hash
-@@temp_dir@@/pkg/_build/satysfi/dist/hash/fonts.satysfi-hash
 @@temp_dir@@/pkg/_build/satysfi/dist/metadata
 @@temp_dir@@/pkg/_build/satysfi/dist/packages
-@@temp_dir@@/pkg/_build/satysfi/dist/packages/grcnum
-@@temp_dir@@/pkg/_build/satysfi/dist/packages/grcnum/grcnum.satyh
+@@temp_dir@@/pkg/_build/satysfi/dist/packages/localized-today
+@@temp_dir@@/pkg/_build/satysfi/dist/packages/localized-today/localized-today.satyh
 @@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos
 @@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental
 @@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental/libraries.satyg
+@@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental/today.satyg
 @@temp_dir@@/pkg/doc-example-ja.pdf
 @@temp_dir@@/pkg/doc-example.saty
 @@temp_dir@@/pkg/doc-grcnum.saty
+@@temp_dir@@/pkg/lockdown.yaml
 @@temp_dir@@/pkg/satysfi-grcnum.opam
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/Makefile @@temp_dir@@/pkg/Makefile
@@ -76,36 +59,16 @@ diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
 >   (build
 >     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
 >      (make "build-doc")))
->   (dependencies (grcnum fonts-theano))
+>   (dependencies (localized-today))
 >   (autogen (%libraries)))
 > 
-diff -Nr @@empty_dir@@/_build/satysfi/dist/fonts/fonts-theano/TheanoDidot-Regular.otf @@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoDidot-Regular.otf
-0a1
-> @@TheanoDidot-Regular.otf@@
-diff -Nr @@empty_dir@@/_build/satysfi/dist/fonts/fonts-theano/TheanoModern-Regular.otf @@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoModern-Regular.otf
-0a1
-> @@TheanoModern-Regular.otf@@
-diff -Nr @@empty_dir@@/_build/satysfi/dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf @@temp_dir@@/pkg/_build/satysfi/dist/fonts/fonts-theano/TheanoOldStyle-Regular.otf
-0a1
-> @@TheanoOldStyle-Regular.otf@@
-diff -Nr @@empty_dir@@/_build/satysfi/dist/hash/fonts.satysfi-hash @@temp_dir@@/pkg/_build/satysfi/dist/hash/fonts.satysfi-hash
-0a1
-> {"fonts-theano:TheanoDidot":<"Single":{"src-dist":"fonts-theano/TheanoDidot-Regular.otf"}>,"fonts-theano:TheanoModern":<"Single":{"src-dist":"fonts-theano/TheanoModern-Regular.otf"}>,"fonts-theano:TheanoOldStyle":<"Single":{"src-dist":"fonts-theano/TheanoOldStyle-Regular.otf"}>}
-\ No newline at end of file
 diff -Nr @@empty_dir@@/_build/satysfi/dist/metadata @@temp_dir@@/pkg/_build/satysfi/dist/metadata
-0a1,9
-> ((version 1) (libraryName %libraries) (libraryVersion 0.1)
->  (compatibility
->   ((rename_packages
->     (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))
->    (rename_fonts
->     (((new_name fonts-theano:TheanoDidot) (old_name TheanoDidot))
->      ((new_name fonts-theano:TheanoModern) (old_name TheanoModern))
->      ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle))))))
->  (dependencies ((fonts-theano ()))))
-diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/grcnum/grcnum.satyh @@temp_dir@@/pkg/_build/satysfi/dist/packages/grcnum/grcnum.satyh
+0a1,2
+> ((version 1) (libraryName %libraries) (libraryVersion 0.1) (compatibility ())
+>  (dependencies ()) (autogen ((%today ()))))
+diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/localized-today/localized-today.satyh @@temp_dir@@/pkg/_build/satysfi/dist/packages/localized-today/localized-today.satyh
 0a1
-> @@grcnum.satyh@@
+> @require: satyrographos/experimental/today
 diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/satyrographos/experimental/libraries.satyg @@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental/libraries.satyg
 0a1,18
 > let _ =
@@ -121,9 +84,29 @@ diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/satyrographos/experimental/l
 > library list
 > end = struct
 > let list =
-> [ (| name = `dist`; version = ` `; |);
->   (| name = `fonts-theano`; version = `2.0`; |);
->   (| name = `grcnum`; version = `0.2`; |); ]
+> [ (| name = `%today`; version = `0.1`; |);
+>   (| name = `dist`; version = ` `; |);
+>   (| name = `localized-today`; version = `0.1`; |); ]
+> 
+> end
+diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/satyrographos/experimental/today.satyg @@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental/today.satyg
+0a1,18
+> let _ =
+> (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/today is an experimental autogen package.`)
+> let _ =
+> (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
+> let _ =
+> (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
+> module Fonts : sig
+> val datetime :
+> string
+> val tzname :
+> string
+> end = struct
+> let datetime =
+> `2020-11-06T00:46:35.000000+09:00`
+> let tzname =
+> `Asia/Tokyo`
 > 
 > end
 diff -Nr @@empty_dir@@/doc-example-ja.pdf @@temp_dir@@/pkg/doc-example-ja.pdf
@@ -135,6 +118,23 @@ diff -Nr @@empty_dir@@/doc-example.saty @@temp_dir@@/pkg/doc-example.saty
 diff -Nr @@empty_dir@@/doc-grcnum.saty @@temp_dir@@/pkg/doc-grcnum.saty
 0a1
 > @@doc-grcnum.saty@@
+diff -Nr @@empty_dir@@/lockdown.yaml @@temp_dir@@/pkg/lockdown.yaml
+0a1,15
+> satyrographos: 0.0.3
+> dependencies:
+> - Opam
+> - packages:
+>   - name: ocaml
+>     version: 4.09.0
+>   - name: satyrographos
+>     version: 0.0.2.7
+>   - name: satysfi
+>     version: 0.0.5+dev2020.09.05
+> autogen:
+>   '%today':
+>     time: 2020-11-06T00:46:35.000000+09:00
+>     zone: Asia/Tokyo
+> 
 diff -Nr @@empty_dir@@/satysfi-grcnum.opam @@temp_dir@@/pkg/satysfi-grcnum.opam
 0a1,30
 > opam-version: "2.0"

--- a/test/testcases/command_build__doc_with_autogen.ml
+++ b/test/testcases/command_build__doc_with_autogen.ml
@@ -14,7 +14,7 @@ let satyristes =
   (build
     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
      (make "build-doc")))
-  (dependencies (grcnum fonts-theano))
+  (dependencies (localized-today))
   (autogen (%libraries)))
 |}
 
@@ -31,6 +31,23 @@ build-doc:
 	@echo "Target: build-doc"
 |}
 
+let lockdown_yaml =
+  "lockdown.yaml", {|satyrographos: 0.0.3
+dependencies:
+- Opam
+- packages:
+  - name: ocaml
+    version: 4.09.0
+  - name: satyrographos
+    version: 0.0.2.7
+  - name: satysfi
+    version: 0.0.5+dev2020.09.05
+autogen:
+  '%today':
+    time: 2020-11-06T00:46:35.000000+09:00
+    zone: Asia/Tokyo
+|}
+
 let files =
   [
     satysfi_grcnum_opam;
@@ -39,6 +56,7 @@ let files =
     "doc-grcnum.saty", "@@doc-grcnum.saty@@";
     "doc-example.saty", "@@doc-example.saty@@";
     "Makefile", makefile;
+    lockdown_yaml;
   ]
 
 let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
@@ -53,9 +71,7 @@ let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
   let opam_reg = FilePath.concat temp_dir "opam_reg" in
   let log_file = exec_log_file_path temp_dir in
   let prepare_opam_reg =
-    PrepareOpamReg.(prepare opam_reg theanoFiles)
-    >> PrepareOpamReg.(prepare opam_reg grcnumFiles)
-    >> PrepareOpamReg.(prepare opam_reg classGreekFiles)
+    PrepareOpamReg.(prepare opam_reg localizedTodayFiles)
     >> PrepareOpamReg.(prepare opam_reg baseFiles)
   in
   let bin = FilePath.concat temp_dir "bin" in

--- a/test/testcases/command_build__doc_with_autogen.ml
+++ b/test/testcases/command_build__doc_with_autogen.ml
@@ -1,0 +1,85 @@
+module StdList = List
+
+open Satyrographos_testlib
+open TestLib
+
+open Shexp_process
+
+let satyristes =
+{|
+(lang "0.0.3")
+
+(doc
+  (name "example-doc")
+  (build
+    ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
+     (make "build-doc")))
+  (dependencies (grcnum fonts-theano))
+  (autogen (%libraries)))
+|}
+
+let satysfi_grcnum_opam =
+  "satysfi-grcnum.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-grcnum"
+    ~version:"0.1"
+    ()
+
+let makefile =
+{|
+PHONY: build-doc
+build-doc:
+	@echo "Target: build-doc"
+|}
+
+let files =
+  [
+    satysfi_grcnum_opam;
+    "Satyristes", satyristes;
+    "README.md", "@@README.md@@";
+    "doc-grcnum.saty", "@@doc-grcnum.saty@@";
+    "doc-example.saty", "@@doc-example.saty@@";
+    "Makefile", makefile;
+  ]
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let pkg_dir = FilePath.concat temp_dir "pkg" in
+  let prepare_pkg =
+    PrepareDist.empty pkg_dir
+    >> prepare_files pkg_dir files
+  in
+  let empty_dist = FilePath.concat temp_dir "empty_dist" in
+  let prepare_dist = PrepareDist.empty empty_dist in
+  let opam_reg = FilePath.concat temp_dir "opam_reg" in
+  let log_file = exec_log_file_path temp_dir in
+  let prepare_opam_reg =
+    PrepareOpamReg.(prepare opam_reg theanoFiles)
+    >> PrepareOpamReg.(prepare opam_reg grcnumFiles)
+    >> PrepareOpamReg.(prepare opam_reg classGreekFiles)
+    >> PrepareOpamReg.(prepare opam_reg baseFiles)
+  in
+  let bin = FilePath.concat temp_dir "bin" in
+  prepare_pkg
+  >> prepare_dist
+  >> prepare_opam_reg
+  >> PrepareBin.prepare_bin bin log_file
+  >>| read_env ~opam_reg ~dist_library_dir:empty_dist
+
+let () =
+  let verbose = false in
+  let main env ~dest_dir:_ ~temp_dir ~outf =
+    let name = Some "example-doc" in
+    (* let dest_dir = FilePath.concat dest_dir "dest" in *)
+    Satyrographos_command.Build.build_command
+      ~outf
+      ~verbose
+      ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
+      ~build_dir:(FilePath.concat temp_dir "pkg/_build" |> Option.some)
+      ~env
+      ~name
+  in
+  let post_dump_dirs ~dest_dir:_ ~temp_dir =
+    let pkg_dir = FilePath.concat temp_dir "pkg" in
+    [pkg_dir]
+  in
+  eval (test_install ~post_dump_dirs env main)

--- a/test/testcases/command_build__doc_with_libraries.ml
+++ b/test/testcases/command_build__doc_with_libraries.ml
@@ -18,15 +18,14 @@ let satyristes =
      ; (file "doc/grcnum.md" "README.md")
     ))
   (opam "satysfi-grcnum.opam")
-  (dependencies ((fonts-theano ()))))
+  (dependencies (fonts-theano)))
 
 (doc
   (name "example-doc")
   (build
     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
      (make "build-doc")))
-  (dependencies ((grcnum ())
-                 (fonts-theano ()))))
+  (dependencies (grcnum fonts-theano)))
 |}
 
 let satysfi_grcnum_opam =

--- a/test/testcases/command_lint__autogen.expected
+++ b/test/testcases/command_lint__autogen.expected
@@ -1,0 +1,1 @@
+0 problem(s) found.

--- a/test/testcases/command_lint__autogen.ml
+++ b/test/testcases/command_lint__autogen.ml
@@ -1,0 +1,63 @@
+open Core
+open Satyrographos_testlib
+
+let satysfi_package_opam =
+  "satysfi-package.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package"
+    ~version:"0.1"
+    ()
+
+let satysfi_package_doc_opam =
+  "satysfi-package-doc.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package-doc"
+    ~version:"0.1"
+    ~depends:{|
+  "satysfi" {>= "0.0.5" & < "0.0.6"}
+  "satyrographos" {>= "0.0.2.6" & < "0.0.3"}
+
+  "satysfi-package" {= "0.1"}
+|}
+    ()
+
+let satyristes =
+  "Satyristes", sprintf
+    {|(lang "0.0.3")
+
+(library
+  (name "package")
+  (version "0.1")
+  (sources ((package "test.satyh" "test.satyh")))
+  (opam "satysfi-package.opam")
+  (dependencies ())
+  (autogen (%%libraries)))
+
+(libraryDoc
+  (name "package-doc")
+  (version "0.1")
+  (build ())
+  (sources ())
+  (opam "satysfi-package-doc.opam")
+  (dependencies (package)))
+|}
+
+let test_satyh =
+  "test.satyh", {|@require: satyrographos/experimental/libraries|}
+
+let opam_libs = Satyrographos.Library.[
+    {empty with
+     name = Some "package";
+     files = LibraryFiles.of_alist_exn [
+         "packages/package/test.satyh", `Content ""
+       ]
+    };
+]
+
+let files =
+  [ satysfi_package_opam;
+    satysfi_package_doc_opam;
+    satyristes;
+    test_satyh;
+  ]
+
+let () =
+  TestCommand.test_lint_command ~opam_libs files

--- a/test/testcases/command_lockdown_restore__opam.expected
+++ b/test/testcases/command_lockdown_restore__opam.expected
@@ -29,7 +29,7 @@ diff -Nr @@empty_dir@@/README.md @@temp_dir@@/pkg/README.md
 0a1
 > @@README.md@@
 diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
-0a1,22
+0a1,21
 > 
 > (lang "0.0.3")
 > (library
@@ -42,15 +42,14 @@ diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
 >      ; (file "doc/grcnum.md" "README.md")
 >     ))
 >   (opam "satysfi-grcnum.opam")
->   (dependencies ((fonts-theano ()))))
+>   (dependencies (fonts-theano)))
 > 
 > (doc
 >   (name "example-doc")
 >   (build
 >     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
 >      (make "build-doc")))
->   (dependencies ((grcnum ())
->                  (fonts-theano ()))))
+>   (dependencies (grcnum fonts-theano)))
 > 
 diff -Nr @@empty_dir@@/doc-example.saty @@temp_dir@@/pkg/doc-example.saty
 0a1

--- a/test/testcases/command_lockdown_save__invalid_opam_response.expected
+++ b/test/testcases/command_lockdown_save__invalid_opam_response.expected
@@ -29,7 +29,7 @@ diff -Nr @@empty_dir@@/README.md @@temp_dir@@/pkg/README.md
 0a1
 > @@README.md@@
 diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
-0a1,22
+0a1,21
 > 
 > (lang "0.0.3")
 > (library
@@ -42,15 +42,14 @@ diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
 >      ; (file "doc/grcnum.md" "README.md")
 >     ))
 >   (opam "satysfi-grcnum.opam")
->   (dependencies ((fonts-theano ()))))
+>   (dependencies (fonts-theano)))
 > 
 > (doc
 >   (name "example-doc")
 >   (build
 >     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
 >      (make "build-doc")))
->   (dependencies ((grcnum ())
->                  (fonts-theano ()))))
+>   (dependencies (grcnum fonts-theano)))
 > 
 diff -Nr @@empty_dir@@/doc-example.saty @@temp_dir@@/pkg/doc-example.saty
 0a1
@@ -150,7 +149,7 @@ diff -Nr @@empty_dir@@/README.md @@temp_dir@@/pkg/README.md
 0a1
 > @@README.md@@
 diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
-0a1,22
+0a1,21
 > 
 > (lang "0.0.3")
 > (library
@@ -163,15 +162,14 @@ diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
 >      ; (file "doc/grcnum.md" "README.md")
 >     ))
 >   (opam "satysfi-grcnum.opam")
->   (dependencies ((fonts-theano ()))))
+>   (dependencies (fonts-theano)))
 > 
 > (doc
 >   (name "example-doc")
 >   (build
 >     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
 >      (make "build-doc")))
->   (dependencies ((grcnum ())
->                  (fonts-theano ()))))
+>   (dependencies (grcnum fonts-theano)))
 > 
 diff -Nr @@empty_dir@@/doc-example.saty @@temp_dir@@/pkg/doc-example.saty
 0a1

--- a/test/testcases/command_lockdown_save__opam.expected
+++ b/test/testcases/command_lockdown_save__opam.expected
@@ -29,7 +29,7 @@ diff -Nr @@empty_dir@@/README.md @@temp_dir@@/pkg/README.md
 0a1
 > @@README.md@@
 diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
-0a1,22
+0a1,21
 > 
 > (lang "0.0.3")
 > (library
@@ -42,15 +42,14 @@ diff -Nr @@empty_dir@@/Satyristes @@temp_dir@@/pkg/Satyristes
 >      ; (file "doc/grcnum.md" "README.md")
 >     ))
 >   (opam "satysfi-grcnum.opam")
->   (dependencies ((fonts-theano ()))))
+>   (dependencies (fonts-theano)))
 > 
 > (doc
 >   (name "example-doc")
 >   (build
 >     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
 >      (make "build-doc")))
->   (dependencies ((grcnum ())
->                  (fonts-theano ()))))
+>   (dependencies (grcnum fonts-theano)))
 > 
 diff -Nr @@empty_dir@@/doc-example.saty @@temp_dir@@/pkg/doc-example.saty
 0a1

--- a/test/testcases/command_lockdown_save__opam.ml
+++ b/test/testcases/command_lockdown_save__opam.ml
@@ -18,15 +18,14 @@ let satyristes =
      ; (file "doc/grcnum.md" "README.md")
     ))
   (opam "satysfi-grcnum.opam")
-  (dependencies ((fonts-theano ()))))
+  (dependencies (fonts-theano)))
 
 (doc
   (name "example-doc")
   (build
     ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
      (make "build-doc")))
-  (dependencies ((grcnum ())
-                 (fonts-theano ()))))
+  (dependencies (grcnum fonts-theano)))
 |}
 
 let satysfi_grcnum_opam =

--- a/test/testcases/command_migrate__build_0_0_2.t
+++ b/test/testcases/command_migrate__build_0_0_2.t
@@ -60,10 +60,10 @@ Dump generated files
   >    (Hash fonts.satysfi-hash fonts.satysfi-hash)
   >    (Font TheanoDidot-Regular.otf theano/TheanoDidot-Regular.otf ())
   >    (File md/mdja2.satysfi-md mdja2.satysfi-md)))
-  >  (dependencies ((fss ())))
+  >  (dependencies (fss))
   >  (compatibility ((RenameFont fonts-theano:TheanoDidot TheanoDidot))))
   > (LibraryDoc (name package-doc) (version 0.1) (opam satysfi-package-doc.opam)
-  >  (workingDirectory .) (dependencies ((package ()))))
+  >  (workingDirectory .) (dependencies (package)))
   [1]
 
 Migration is idempotent

--- a/test/testcases/command_opam_install__duplicated_font_hash.ml
+++ b/test/testcases/command_opam_install__duplicated_font_hash.ml
@@ -19,7 +19,7 @@ let satyristes =
      (file "doc/grcnum.md" "README.md")
     ))
   (opam "satysfi-grcnum.opam")
-  (dependencies ((fonts-theano ()))))
+  (dependencies (fonts-theano)))
 |}
 
 let fontHash =

--- a/test/testcases/command_opam_install__font_hash.ml
+++ b/test/testcases/command_opam_install__font_hash.ml
@@ -19,7 +19,7 @@ let satyristes =
      (file "doc/grcnum.md" "README.md")
     ))
   (opam "satysfi-grcnum.opam")
-  (dependencies ((fonts-theano ()))))
+  (dependencies (fonts-theano)))
 |}
 
 let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =

--- a/test/testcases/command_opam_install__library_depending_autogen.expected
+++ b/test/testcases/command_opam_install__library_depending_autogen.expected
@@ -43,7 +43,7 @@ diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash @@dest_
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/metadata @@dest_dir@@/dest/share/satysfi/grcnum/metadata
 0a1,2
 > ((version 1) (libraryName grcnum) (libraryVersion 0.2) (compatibility ())
->  (dependencies ((fonts-theano ()))))
+>  (dependencies ((fonts-theano ()))) (autogen ((%libraries ()))))
 diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/packages/grcnum/grcnum.satyh @@dest_dir@@/dest/share/satysfi/grcnum/packages/grcnum/grcnum.satyh
 0a1
 > @@grcnum.satyh@@

--- a/test/testcases/command_opam_install__library_depending_autogen.expected
+++ b/test/testcases/command_opam_install__library_depending_autogen.expected
@@ -1,0 +1,49 @@
+Installing packages
+------------------------------------------------------------
+Read library:
+((name (grcnum)) (version (0.2))
+ (hashes ((hash/fonts.satysfi-hash (("(module grcnum)") (Assoc ())))))
+ (files
+  ((doc/grcnum.md (Filename @@temp_dir@@/pkg/README.md))
+   (fonts/grcnum/grcnum-font.ttf (Filename @@temp_dir@@/pkg/font.ttf))
+   (packages/grcnum/grcnum.satyh (Filename @@temp_dir@@/pkg/grcnum.satyh))))
+ (dependencies (fonts-theano)) (autogen (%libraries)))
+Copying @@temp_dir@@/pkg/README.md to @@dest_dir@@/dest/share/satysfi/grcnum/doc/grcnum.md
+Copying @@temp_dir@@/pkg/font.ttf to @@dest_dir@@/dest/share/satysfi/grcnum/fonts/grcnum/grcnum-font.ttf
+Copying @@temp_dir@@/pkg/grcnum.satyh to @@dest_dir@@/dest/share/satysfi/grcnum/packages/grcnum/grcnum.satyh
+Generating @@dest_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash
+------------------------------------------------------------
+@@dest_dir@@
+@@dest_dir@@/dest
+@@dest_dir@@/dest/share
+@@dest_dir@@/dest/share/satysfi
+@@dest_dir@@/dest/share/satysfi/grcnum
+@@dest_dir@@/dest/share/satysfi/grcnum/doc
+@@dest_dir@@/dest/share/satysfi/grcnum/doc/grcnum.md
+@@dest_dir@@/dest/share/satysfi/grcnum/fonts
+@@dest_dir@@/dest/share/satysfi/grcnum/fonts/grcnum
+@@dest_dir@@/dest/share/satysfi/grcnum/fonts/grcnum/grcnum-font.ttf
+@@dest_dir@@/dest/share/satysfi/grcnum/hash
+@@dest_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash
+@@dest_dir@@/dest/share/satysfi/grcnum/metadata
+@@dest_dir@@/dest/share/satysfi/grcnum/packages
+@@dest_dir@@/dest/share/satysfi/grcnum/packages/grcnum
+@@dest_dir@@/dest/share/satysfi/grcnum/packages/grcnum/grcnum.satyh
+------------------------------------------------------------
+diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/doc/grcnum.md @@dest_dir@@/dest/share/satysfi/grcnum/doc/grcnum.md
+0a1
+> @@README.md@@
+diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/fonts/grcnum/grcnum-font.ttf @@dest_dir@@/dest/share/satysfi/grcnum/fonts/grcnum/grcnum-font.ttf
+0a1
+> @@font.ttf@@
+diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash @@dest_dir@@/dest/share/satysfi/grcnum/hash/fonts.satysfi-hash
+0a1
+> {}
+\ No newline at end of file
+diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/metadata @@dest_dir@@/dest/share/satysfi/grcnum/metadata
+0a1,2
+> ((version 1) (libraryName grcnum) (libraryVersion 0.2) (compatibility ())
+>  (dependencies ((fonts-theano ()))))
+diff -Nr @@empty_dir@@/dest/share/satysfi/grcnum/packages/grcnum/grcnum.satyh @@dest_dir@@/dest/share/satysfi/grcnum/packages/grcnum/grcnum.satyh
+0a1
+> @@grcnum.satyh@@

--- a/test/testcases/command_opam_install__library_depending_autogen.ml
+++ b/test/testcases/command_opam_install__library_depending_autogen.ml
@@ -1,0 +1,63 @@
+module StdList = List
+
+open Satyrographos_testlib
+open TestLib
+
+open Shexp_process
+
+let satyristes =
+{|
+(lang "0.0.3")
+(library
+  (name "grcnum")
+  (version "0.2")
+  (sources
+    ((package "grcnum.satyh" "./grcnum.satyh")
+     (font "grcnum-font.ttf" "./font.ttf" ())
+     ;; gh-229
+     ;; (hash "fonts.satysfi-hash" "./fonts.satysfi-hash")
+     (file "doc/grcnum.md" "README.md")
+    ))
+  (opam "satysfi-grcnum.opam")
+  (dependencies (fonts-theano))
+  (compatibility ((satyrographos 0.0.1)))
+  (autogen (%libraries)))
+|}
+
+let fontHash =
+{|{
+  "grcnum:grcnum-font":<"Single":{"src-dist":"grcnum/grcnum-font.ttf"}>
+}|}
+
+let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+  let open Shexp_process.Infix in
+  let pkg_dir = FilePath.concat temp_dir "pkg" in
+  let prepare_pkg =
+    PrepareDist.empty pkg_dir
+    >> stdout_to (FilePath.concat pkg_dir "Satyristes") (echo satyristes)
+    >> stdout_to (FilePath.concat pkg_dir "README.md") (echo "@@README.md@@")
+    >> stdout_to (FilePath.concat pkg_dir "fonts.satysfi-hash") (echo fontHash)
+    >> stdout_to (FilePath.concat pkg_dir "grcnum.satyh") (echo "@@grcnum.satyh@@")
+    >> stdout_to (FilePath.concat pkg_dir "font.ttf") (echo "@@font.ttf@@")
+  in
+  let empty_dist = FilePath.concat temp_dir "empty_dist" in
+  let prepare_dist = PrepareDist.empty empty_dist in
+  let opam_reg = FilePath.concat temp_dir "opam_reg" in
+  let prepare_opam_reg =
+    PrepareOpamReg.(prepare opam_reg theanoFiles)
+    >> PrepareOpamReg.(prepare opam_reg grcnumFiles)
+    >> PrepareOpamReg.(prepare opam_reg classGreekFiles)
+    >> PrepareOpamReg.(prepare opam_reg baseFiles)
+  in
+  prepare_pkg
+  >> prepare_dist
+  >> prepare_opam_reg
+  >>| read_env ~opam_reg ~dist_library_dir:empty_dist
+
+let () =
+  let verbose = true in
+  let main env ~dest_dir ~temp_dir =
+    let name = Some "grcnum" in
+    let dest_dir = FilePath.concat dest_dir "dest" in
+    Satyrographos_command.Opam.(with_build_script install_opam ~verbose ~prefix:dest_dir ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes") ~env ~name) () in
+  eval (test_install env main)

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -2,6 +2,7 @@
  (names
    command_build__doc_make
    command_build__doc_satysfi
+   command_build__doc_with_autogen
    command_build__doc_with_libraries
    command_install__distWithBrokenHash
    command_install__distWithNonHashUnderHashDir
@@ -19,6 +20,7 @@
    command_install_l__thirdParties_brokenDependency
    command_install_l__transitive
    command_lint__acyclic_for_each_mode
+   command_lint__autogen
    command_lint__compatibility_satyrographos_0_0_1
    command_lint__cyclic_dependencies
    command_lint__insufficient_dependencies
@@ -43,6 +45,7 @@
    command_opam_install__duplicated_font_hash
    command_opam_install__font_hash
    command_opam_install__library
+   command_opam_install__library_depending_autogen
    command_opam_install__library_missingHash
    command_opam_install__library_missingPackage
    command_opam_install__library_recursive

--- a/test/testlib/prepareOpamReg.ml
+++ b/test/testlib/prepareOpamReg.ml
@@ -48,6 +48,12 @@ let baseFiles = [
 (dependencies ()))|};
   "base/packages/base/void.satyh", "@@void.satyh@@"; ]
 
+let localizedTodayFiles = [
+  "localized-today/metadata",
+  {|((version 1) (libraryName localized-today) (libraryVersion 0.1) (compatibility ())
+(dependencies ()) (autogen ((%today ()))))|};
+  "localized-today/packages/localized-today/localized-today.satyh", "@require: satyrographos/experimental/today"; ]
+
 (* TODO Remove this function *)
 let prepare =
   TestLib.prepare_files


### PR DESCRIPTION
This PR adds `(autogen ...)` clause to library, libraryDoc and doc module.

Example:

```lisp
(lang "0.0.3")

(doc
  (name "example-doc")
  (build
    ((satysfi "doc-example.saty" "-o" "doc-example-ja.pdf")
     (make "build-doc")))
  (dependencies (localized-today))
  (autogen (%today)))

```