### PR TITLE
Stabilize new subcommand

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -97,16 +97,36 @@ document (|
 ```
 
 ## ライブラリ作者向け
-### 仕組み
-Satyrographos は `~/.opam/<ocaml-version>/share/satysfi/<package>` と  `~/.satyrographos/packages/<package>` にある全てのファイルを `~/.satysfi/dist` にリンクします。
+### 新規作成
+`new` サブコマンドを使うとテンプレートから新規ライブラリを作ることができます。
 
-また、ファイルの重複検知やハッシュファイルのマージ等も同時に行います。それを除けば、 `satyrographos install` は以下のコマンドを実行しているのと似たようなものです。
 ```sh
-$ cp -r "$(opam var share)"/share/satysfi/*/* ~/.satysfi/dist
-$ cp -r ~/.satyrographos/packages/*/* ~/.satysfi/dist
+$ satyrographos new lib your-new-library
+Name: your-new-library
+Choose licenses:
+0) MIT
+1) LGPL-3.0-or-later
+> 0
+License: MIT
+Created a new library/document.
 ```
 
-加えて、 `--system-font-prefix <system-font-name-prefix>` が用いられると、 Satyrograph はシステムフォントの情報を `fc-list` コマンドを用いて得、インストールします。
+Satyrographos は `lib` 以外のテンプレートも提供しています。テンプレートの一覧を得るには `--help` を追加してください。
+
+```sh
+$ satyrographos new --help
+
+...
+
+Available templates:
+  doc-make@en : Document with Makefile (en)
+  doc-make@ja : Document with Makefile (ja)
+  doc-omake@en : Document with OMakefile (en)
+  doc-omake@ja : Document with OMakefile (ja)
+  lib : Package library
+
+...
+```
 
 ### 名前
 ライブラリ名は以下の形式に従って下さい。

--- a/README.md
+++ b/README.md
@@ -115,16 +115,40 @@ document (|
 ```
 
 ## For Library Authors
-### How Does It Work?
-Satyrographos links all files under `~/.opam/<ocaml-version>/share/satysfi/<package>` and  `~/.satyrographos/packages/<package>` into `~/.satysfi/dist`.
+### Create a new library
 
-Satyrographos also does duplication detection, hash file merging, show compatibility warning, &c. Basically `satyrographos install` behaves as
+Satyrographos provides `new` subcommand to create a new library from a template.
+
 ```sh
-$ cp -r "$(opam var share)"/share/satysfi/*/* ~/.satysfi/dist
-$ cp -r ~/.satyrographos/packages/*/* ~/.satysfi/dist
+$ satyrographos new lib your-new-library
+Name: your-new-library
+Choose licenses:
+0) MIT
+1) LGPL-3.0-or-later
+> 0
+License: MIT
+Created a new library/document.
+
+$ ls
+your-new-library/
 ```
 
-With `--system-font-prefix <system-font-name-prefix>`, Satyrograph query system fonts with `fc-list` and installs those fonts too.
+Satyrographos also has templates other than `lib`.  To get the list of the templates, add `--help` option.
+
+```sh
+$ satyrographos new --help
+
+...
+
+Available templates:
+  doc-make@en : Document with Makefile (en)
+  doc-make@ja : Document with Makefile (ja)
+  doc-omake@en : Document with OMakefile (en)
+  doc-omake@ja : Document with OMakefile (ja)
+  lib : Package library
+
+...
+```
 
 ### Library Names
 Please follow the following formats.

--- a/bin/commandNew.ml
+++ b/bin/commandNew.ml
@@ -30,7 +30,6 @@ Available templates:
       and license = flag "--license" (optional string) ~doc:"LICENSE License"
       in
       fun () ->
-        Compatibility.optin ();
         Satyrographos_command.New.create_project
           name
           license

--- a/doc/internals.ja.md
+++ b/doc/internals.ja.md
@@ -1,0 +1,12 @@
+# 内部仕様
+
+Satyrographos は `~/.opam/<ocaml-version>/share/satysfi/<package>` と  `~/.satyrographos/packages/<package>` にある全てのファイルを `~/.satysfi/dist` にリンクする。
+
+また、ファイルの重複検知やハッシュファイルのマージ等も同時に行う。それを除けば、 `satyrographos install` は以下のコマンドを実行しているのと似たようなものである。
+
+```sh
+$ cp -r "$(opam var share)"/share/satysfi/*/* ~/.satysfi/dist
+$ cp -r ~/.satyrographos/packages/*/* ~/.satysfi/dist
+```
+
+加えて、 `--system-font-prefix <system-font-name-prefix>` が用いられると、 Satyrograph はシステムフォントの情報を `fc-list` コマンドを用いて得、インストールする。

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -1,0 +1,11 @@
+# Internals
+
+Satyrographos links all files under `~/.opam/<ocaml-version>/share/satysfi/<package>` and  `~/.satyrographos/packages/<package>` into `~/.satysfi/dist`.
+
+Satyrographos also does duplication detection, hash file merging, show compatibility warning, &c. Basically `satyrographos install` behaves as
+```sh
+$ cp -r "$(opam var share)"/share/satysfi/*/* ~/.satysfi/dist
+$ cp -r ~/.satyrographos/packages/*/* ~/.satysfi/dist
+```
+
+With `--system-font-prefix <system-font-name-prefix>`, Satyrograph query system fonts with `fc-list` and installs those fonts too.

--- a/src/template/template_docMake_en.ml
+++ b/src/template/template_docMake_en.ml
@@ -1,4 +1,4 @@
-let name = "doc-make@en"
+let name = "[experimental]doc-make@en"
 
 let local_satyh_template =
 "local.satyh",

--- a/src/template/template_docMake_ja.ml
+++ b/src/template/template_docMake_ja.ml
@@ -1,4 +1,4 @@
-let name = "doc-make@ja"
+let name = "[experimental]doc-make@ja"
 
 let local_satyh_template =
 "local.satyh",

--- a/src/template/template_docOmake_en.ml
+++ b/src/template/template_docOmake_en.ml
@@ -61,4 +61,4 @@ let files = [
 ]
 
 let template =
-  "doc-omake@en", ("Document with OMakefile (en)", files)
+  "[experimental]doc-omake@en", ("Document with OMakefile (en)", files)

--- a/src/template/template_docOmake_ja.ml
+++ b/src/template/template_docOmake_ja.ml
@@ -39,4 +39,4 @@ let files = [
 ]
 
 let template =
-  "doc-omake@ja", ("Document with OMakefile (ja)", files)
+  "[experimental]doc-omake@ja", ("Document with OMakefile (ja)", files)

--- a/test/testcases/command_new__doc_make.t
+++ b/test/testcases/command_new__doc_make.t
@@ -1,6 +1,5 @@
 Create a new document with doc-make@en template
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new doc-make@en --license CC-BY-4.0 test-doc-en
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos new doc-make@en --license CC-BY-4.0 test-doc-en
   Name: test-doc-en
   License: CC-BY-4.0
   Created a new library/document.
@@ -14,8 +13,7 @@ Try to build when there is satysfi command
   > fi
 
 Create a new document with doc-make@ja template
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new doc-make@ja --license CC-BY-4.0 test-doc-ja
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos new doc-make@ja --license CC-BY-4.0 test-doc-ja
   Name: test-doc-ja
   License: CC-BY-4.0
   Created a new library/document.

--- a/test/testcases/command_new__doc_make.t
+++ b/test/testcases/command_new__doc_make.t
@@ -1,5 +1,5 @@
 Create a new document with doc-make@en template
-  $ satyrographos new doc-make@en --license CC-BY-4.0 test-doc-en
+  $ satyrographos new [experimental]doc-make@en --license CC-BY-4.0 test-doc-en
   Name: test-doc-en
   License: CC-BY-4.0
   Created a new library/document.
@@ -13,7 +13,7 @@ Try to build when there is satysfi command
   > fi
 
 Create a new document with doc-make@ja template
-  $ satyrographos new doc-make@ja --license CC-BY-4.0 test-doc-ja
+  $ satyrographos new [experimental]doc-make@ja --license CC-BY-4.0 test-doc-ja
   Name: test-doc-ja
   License: CC-BY-4.0
   Created a new library/document.

--- a/test/testcases/command_new__doc_omake.t
+++ b/test/testcases/command_new__doc_omake.t
@@ -1,6 +1,5 @@
 Create a new document with doc-omake@en template
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new doc-omake@en --license CC-BY-4.0 test-doc-en
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos new doc-omake@en --license CC-BY-4.0 test-doc-en
   Name: test-doc-en
   License: CC-BY-4.0
   Created a new library/document.
@@ -14,8 +13,7 @@ Try to build when there is satysfi command
   > fi
 
 Create a new document with doc-omake@ja template
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new doc-omake@ja --license CC-BY-4.0 test-doc-ja
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos new doc-omake@ja --license CC-BY-4.0 test-doc-ja
   Name: test-doc-ja
   License: CC-BY-4.0
   Created a new library/document.

--- a/test/testcases/command_new__doc_omake.t
+++ b/test/testcases/command_new__doc_omake.t
@@ -1,5 +1,5 @@
 Create a new document with doc-omake@en template
-  $ satyrographos new doc-omake@en --license CC-BY-4.0 test-doc-en
+  $ satyrographos new [experimental]doc-omake@en --license CC-BY-4.0 test-doc-en
   Name: test-doc-en
   License: CC-BY-4.0
   Created a new library/document.
@@ -13,7 +13,7 @@ Try to build when there is satysfi command
   > fi
 
 Create a new document with doc-omake@ja template
-  $ satyrographos new doc-omake@ja --license CC-BY-4.0 test-doc-ja
+  $ satyrographos new [experimental]doc-omake@ja --license CC-BY-4.0 test-doc-ja
   Name: test-doc-ja
   License: CC-BY-4.0
   Created a new library/document.

--- a/test/testcases/command_new__existing_directory.t
+++ b/test/testcases/command_new__existing_directory.t
@@ -1,7 +1,6 @@
 Attempt to create a new library with the conflicting name
   $ mkdir test-lib
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new --license MIT lib test-lib
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos new --license MIT lib test-lib
   test-lib already exists.
   [1]
   $ find test-lib | LC_ALL=C sort

--- a/test/testcases/command_new__invalid_license_option.t
+++ b/test/testcases/command_new__invalid_license_option.t
@@ -1,6 +1,5 @@
 Interactively create a new library with giving wrong answers.
-  $ printf "\na\n999\n1\n" | SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new lib test-lib
-  Compatibility warning: You have opted in to use experimental features.
+  $ printf "\na\n999\n1\n" | satyrographos new lib test-lib
   Name: test-lib
   Choose licenses:
   0) MIT

--- a/test/testcases/command_new__invalid_names.t
+++ b/test/testcases/command_new__invalid_names.t
@@ -1,13 +1,10 @@
 Attempt to create libraries with invalid names
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new --license MIT lib test/lib
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos new --license MIT lib test/lib
   Project name should consist of ASCII alphabets, numbers, underscores, or hyphens.
   [1]
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new --license MIT lib test.lib
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos new --license MIT lib test.lib
   Project name should consist of ASCII alphabets, numbers, underscores, or hyphens.
   [1]
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new --license MIT lib test-lib.
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos new --license MIT lib test-lib.
   Project name should consist of ASCII alphabets, numbers, underscores, or hyphens.
   [1]

--- a/test/testcases/command_new__lib.t
+++ b/test/testcases/command_new__lib.t
@@ -1,6 +1,5 @@
 Create a new library with --license option
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new --license MIT lib test-lib
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos new --license MIT lib test-lib
   Name: test-lib
   License: MIT
   Created a new library/document.
@@ -204,8 +203,7 @@ Dump generated files
 
 Interactively create a new library
   $ mv test-lib test-lib-non-interactive
-  $ printf "0\n" | SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos new lib test-lib
-  Compatibility warning: You have opted in to use experimental features.
+  $ printf "0\n" | satyrographos new lib test-lib
   Name: test-lib
   Choose licenses:
   0) MIT


### PR DESCRIPTION
This PR removes the opt-in gate for `new` subcommand.
At the same time, templates with experimental features are marked with `[experimental]` prefix in their template names.

Resolves https://github.com/na4zagin3/satyrographos/issues/153