### PR TITLE
Stabilize `lint` subcommand

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -289,15 +289,24 @@ $ opam add -vy "file://$PWD"
 
 OPAMに頼らずテストを実行する方法については開発中（[#4](https://github.com/na4zagin3/satyrographos/issues/4)）です。
 
+また、`lint` コマンドは依存関係等の問題を検出することができます。適宜実行して下さい。詳しいオプションは[lint](./doc/lint.md)を見て下さい。
+
+```sh
+$ satyrographos lint
+```
+
 #### Satyrograpohsレポへの登録
 https://opam.ocaml.org/doc/Packaging.html に従えば上手に行くはずです。
 但し、`opam publish`には`--repo`オプションを加えて下さい。
 
-```
+```sh
+# 問題検出
+$ satyrographos lint
+
 # レポジトリにタグを打つ
-git tag -a <tag>
+$ git tag -a <tag>
 # タグをプッシュ
-git push origin <tag>
+$ git push origin <tag>
 
 opam publish --repo=na4zagin3/satyrographos-repo
 ```

--- a/README.md
+++ b/README.md
@@ -312,11 +312,20 @@ $ opam add -vy "file://$PWD"
 There’s ongoing ticket [#4](https://github.com/na4zagin3/satyrographos/issues/4) to run
 test cases without OPAM installation. Stay tuned!
 
+You can use `lint` subcommand to detect several problems.  See [satyrographos-lint](./doc/lint.md) for more details.
+
+```sh
+$ satyrographos lint
+```
+
 #### Register Satyrograpohs Repo
 `opam-publish` must work.
 Follow https://opam.ocaml.org/doc/Packaging.html except you need to specify `--repo` option.
 
-```
+```sh
+# Check validity
+$ satyrographos lint
+
 # Tag you repository
 git tag -a <tag>
 # Push the tag

--- a/bin/commandLint.ml
+++ b/bin/commandLint.ml
@@ -22,7 +22,6 @@ let lint_command =
       and warning_expr = flag "W" (optional warning_expr_flag_type) ~doc:"WARNING_EXPR Enable/disable warnings. (e.g., “-lib/dep,-opam-file/version” disables warnings related to library dependencies and OPAM package versions; “opam-file/lint/{-*,+3..5}” disables all the OPAM lint warnings except warnings 3 through 5)"
       in
       fun () ->
-        Compatibility.optin ();
         let exit_code =
           Satyrographos_command.Lint.lint
             ~env

--- a/doc/lint.md
+++ b/doc/lint.md
@@ -1,0 +1,87 @@
+# Lint subcommand
+
+Lint subcommand detects problems in Satyristes, OPAM files, and SATySFi files.
+
+## Command line interface
+
+```sh
+satyrographos [--verbose] [--script <satyristes-path>] [-W <warning-expr>]
+```
+
+- `--verbose` makes the output verbose
+- `--script` points to `Satyristes` file.  Its default value is `./Satyristes`.
+- `-W` can enable/disable warnigs.
+
+## Problem class
+
+Each problem is classified one problem class.  For example, the following problems belong to `lib/version` problem class.
+
+- A Satyrographos library has an empty version id.
+- A Satyrographos library has an invalid version id.
+
+Each OPAM Lint error/warning is considered as problem class `opam-file/lint/<opam-warning-no>`. For example, an empty `synopsis` field causes `opam-file/lint/47`.
+
+### `-W` option
+
+`-W` option is added to disable warnings/errors being reported by `lint` subcommand.
+
+For now, `-W` option can disable not only warning but also errors. This behavior should be revised when lint subcommand is stable enough since errors should not be turned off.
+
+`-W` option takes a warning expression.  The grammar is following.
+
+```bnf
+main ::=
+  | exprs
+
+exprs ::=
+  | expr ( "," expr )*
+    -- List of exprs
+  | ( atom "/" )* "{" exprs "}"
+    -- Common prefix for the exprs
+
+expr ::=
+  | ( "+" | "-" ) glob
+    -- Enable or disable warnings matching the glob
+
+glob ::=
+  | "*"
+  | atom
+  | atom "/" glob
+  | "{" globList "}"
+    -- Alternative choose
+
+globList ::=
+  | glob
+  | glob "," globList
+
+atom ::=
+  | id
+  | range
+
+id ::=
+  | idCharFirst idChar
+
+idCharFirst ::=
+  | alphaNum
+
+idChar ::=
+  | idCharFirst
+  | "_" | "-" | "."
+
+range ::=
+  | digit ".." digit
+```
+
+Examples:
+
+- `+a/b` enables warnings prefixed with `a/b`, e.g., `a/b`, `a/b/c`, but not `a/bc` or `a`.
+- `+a/*` enables warnings prefixed with `a/`, e.g., `a/b`, `a/b/c`, but not `a/bc` or `a`.
+- `-*,+a` disables all the warnings but ones prefixed with `a`.
+- `a/{+b,-c}` is equivalent to `+a/b,-a/c`
+- `+a/{b,c}` is equivalent to `a/{+b,+c}` so as to `+a/b,+a/c`.
+- `+{1..3,a}` is equivalent to `+1,+2,+3,+a`
+
+## Exit codes
+
+- `0` if no errors are detected.
+- `1` if errors are detected.

--- a/test/testcases/command_new__doc_make.t
+++ b/test/testcases/command_new__doc_make.t
@@ -29,11 +29,9 @@ Try to build when there is satysfi command
   > fi
 
 Ensure there are no warnings
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos lint -W '-lib/dep/exception-during-setup' --script test-doc-en/Satyristes --satysfi-version 0.0.5
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos lint -W '-lib/dep/exception-during-setup' --script test-doc-en/Satyristes --satysfi-version 0.0.5
   WARNING: Script lang 0.0.3 is under development.
   0 problem(s) found.
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos lint -W '-lib/dep/exception-during-setup' --script test-doc-ja/Satyristes --satysfi-version 0.0.5
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos lint -W '-lib/dep/exception-during-setup' --script test-doc-ja/Satyristes --satysfi-version 0.0.5
   WARNING: Script lang 0.0.3 is under development.
   0 problem(s) found.

--- a/test/testcases/command_new__doc_omake.t
+++ b/test/testcases/command_new__doc_omake.t
@@ -29,11 +29,9 @@ Try to build when there is satysfi command
   > fi
 
 Ensure there are no warnings
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos lint -W '-lib/dep/exception-during-setup' --script test-doc-en/Satyristes --satysfi-version 0.0.5
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos lint -W '-lib/dep/exception-during-setup' --script test-doc-en/Satyristes --satysfi-version 0.0.5
   WARNING: Script lang 0.0.3 is under development.
   0 problem(s) found.
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos lint -W '-lib/dep/exception-during-setup' --script test-doc-ja/Satyristes --satysfi-version 0.0.5
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos lint -W '-lib/dep/exception-during-setup' --script test-doc-ja/Satyristes --satysfi-version 0.0.5
   WARNING: Script lang 0.0.3 is under development.
   0 problem(s) found.

--- a/test/testcases/command_new__lib.t
+++ b/test/testcases/command_new__lib.t
@@ -219,6 +219,5 @@ Compare them
 
 Ensure there are no warnings
   $ cd test-lib-interactive
-  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos lint -W '-lib/dep/exception-during-setup' --satysfi-version 0.0.5
-  Compatibility warning: You have opted in to use experimental features.
+  $ satyrographos lint -W '-lib/dep/exception-during-setup' --satysfi-version 0.0.5
   0 problem(s) found.


### PR DESCRIPTION
This PR removes the opt-in gate for lint subcommand.