### PR TITLE
Add a template with autogen libraries

### DIFF
--- a/src/autogen/fonts.ml
+++ b/src/autogen/fonts.ml
@@ -130,7 +130,7 @@ let get_font_info ~outf font_list =
   FontInfo.font_list_task ~outf (FontInfo.font_info_list_task font_files)
   >>| join_with_font_info
 
-let package_name = "satyrographos/experimental/fonts"
+let package_name = "$fonts"
 let package_path = "packages/" ^ package_name ^ ".satyg"
 
 let font_type_name = "font"

--- a/src/autogen/libraries.ml
+++ b/src/autogen/libraries.ml
@@ -32,7 +32,7 @@ let library_list_entry (name, (lib: Library.t)) =
       "version", `LiteralString (Option.value ~default:"" lib.version);
     ]
 
-let package_name = "satyrographos/experimental/libraries"
+let package_name = "$libraries"
 let package_path = "packages/" ^ package_name ^ ".satyg"
 
 let generate ~outf:_ ~persistent_yojson:_ library_map =

--- a/src/autogen/today.ml
+++ b/src/autogen/today.ml
@@ -21,32 +21,32 @@ let module_sig =
   ]
 
 type persistent = {
-  time: string;
-  zone: string;
+  datetime: string;
+  tzname: string;
 }
 [@@deriving equal, yojson]
 
 let module_struct data =
   [`Let (datetime_field_name,
-         data.time
+         data.datetime
          |> Satysfi.value_of_string);
    `Let (tzname_field_name,
-         data.zone
+         data.tzname
          |> Satysfi.value_of_string);
   ]
 
 let generate_persistent () =
   (* TODO (gh-98) get the values from the lockfile *)
-  let time = Time.now () in
-  let zone =
+  let datetime = Time.now () in
+  let tzname =
     Time.Zone.local
     |> Lazy.force
   in
-  { time =
-      time
-      |> Time.to_string_iso8601_basic ~zone;
-    zone =
-      zone
+  { datetime =
+      datetime
+      |> Time.to_string_iso8601_basic ~zone:tzname;
+    tzname =
+      tzname
       |> Time.Zone.name;
   }
 

--- a/src/autogen/today.ml
+++ b/src/autogen/today.ml
@@ -72,7 +72,7 @@ let generate ~outf ~persistent_yojson =
       generate_persistent ()
   in
 
-  let f = `Module ("Fonts", module_sig, module_struct data) in
+  let f = `Module ("Today", module_sig, module_struct data) in
   let decls =
     Satysfi.expr_experimental_message package_name
     @ [f] in

--- a/src/template/template.ml
+++ b/src/template/template.ml
@@ -47,5 +47,6 @@ let templates = [
   Template_docMake_ja.template;
   Template_docOmake_en.template;
   Template_docOmake_ja.template;
+  Template_exampleAutogen.template;
   Template_lib.template;
 ]

--- a/src/template/template_exampleAutogen.ml
+++ b/src/template/template_exampleAutogen.ml
@@ -1,0 +1,176 @@
+let main_saty_template =
+  "main.saty", {|
+@require: stdjabook
+@require: math
+@require: itemize
+@require: $fonts
+@require: $libraries
+@require: $today
+
+let abc = {ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz,.\;.!?}
+let lorem = {Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.}
+let math-example = {${\abs{\mathrm{Orb}_G\(x\)} \cdot \abs{\mathrm{Stab}_G\(x\)} = \abs{G}}}
+
+
+let-inline \show-string s = embed-string s
+let-inline \show-float s = embed-string (show-float s)
+let-inline \show-int i = embed-string (arabic i)
+let-inline ctx \with-math-font font it =
+  let ctx = ctx
+    |> set-math-font font#name in
+  read-inline ctx it
+let-inline ctx \with-text-font font it =
+  let ctx = ctx
+    |> set-font Latin (font#name, 1., 0.)
+    |> set-font OtherScript (font#name, 1., 0.) in
+  read-inline ctx it
+let-inline \identity x = x
+let-inline \optionally-show pre x post = match x with
+  | None -> {}
+  | Some x -> {\identity(pre);\show-string(x);\identity(post);}
+let-inline \font-location font =
+  match font#font-location with
+  | Single src ->
+    {Single \{src = \show-string(src#src);\;
+	 \optionally-show({orig-location = })(src#orig-location)({\; });\}}
+  | Collection src ->
+    {Collection \{src = \show-string(src#src);\;
+		index = \show-int(src#index);\;
+    	\optionally-show({orig-location =\ })(src#orig-location)({\; });\}}
+
+let show-math-font-block-text ctx font =
+  '<
+    +subsection{\show-string(font#name);} <
+      +pn {
+        Name: \show-string(font#name);
+      }
+      +pn {
+        Library: \show-string(font#library-name);
+      }
+      +pn {
+        Location: \font-location(font);
+      }
+      +p {
+        \with-math-font(font)(math-example);
+      }
+    >
+  >
+
+let show-text-font-block-text ctx font =
+  '<
+    +subsection{\show-string(font#name);} <
+      +pn {
+        Name: \show-string(font#name);
+      }
+      +pn {
+        Library: \show-string(font#library-name);
+      }
+      +pn {
+        Location: \font-location(font);
+      }
+      +pn {
+        \with-text-font(font)(abc);
+      }
+      +p {
+        \with-text-font(font)(lorem);
+      }
+    >
+  >
+
+let is-text-font font = match font#font-type with
+  | TextFont -> true
+  | _ -> false
+
+let is-math-font font = match font#font-type with
+  | MathFont -> true
+  | _ -> false
+
+let-block ctx +show-text-fonts fonts =
+  List.filter is-text-font fonts
+  |> List.map (show-text-font-block-text ctx)
+  |> List.map (read-block ctx)
+  |> List.fold-left (+++) block-nil
+
+let-block ctx +show-math-fonts fonts =
+  List.filter is-math-font fonts
+  |> List.map (show-math-font-block-text ctx)
+  |> List.map (read-block ctx)
+  |> List.fold-left (+++) block-nil
+
+let show-library-block-text ctx library =
+  '<
+    +subsection{\show-string(library#name);} <
+      +pn {
+        Name: \show-string(library#name);
+      }
+      +pn {
+        Version: \show-string(library#version);
+      }
+    >
+  >
+
+let-block ctx +show-libraries libraries =
+  libraries
+  |> List.map (show-library-block-text ctx)
+  |> List.map (read-block ctx)
+  |> List.fold-left (+++) block-nil
+
+in
+
+document (|
+  title = {};
+  author = {};
+  show-title = false;
+  show-toc = false;
+|) '<
+  +p {
+    Built at \code(Today.datetime); (\code(Today.tzname);).
+  }
+  +section{Packages}<
+    +show-libraries(Libraries.list);
+  >
+  +section{Math Fonts}<
+    +show-math-fonts(Fonts.list);
+  >
+  +section{Text Fonts}<
+    +show-text-fonts(Fonts.list);
+  >
+>
+|}
+
+let satyristes_template =
+"Satyristes",
+{|(lang "0.0.3")
+
+(doc
+  (name  "main")
+  (build ((satysfi main.saty -o main.pdf)))
+  (autogen ($fonts $libraries $today))
+  (dependencies
+   (;; Standard library
+    dist
+    ;; Third-party library
+    fss
+    )))
+|}
+
+let readme_template =
+"README.md",
+{|# @@library@@
+
+An example with autogen libraries
+
+## How to compile?
+
+Run `satyrographos build`.
+|}
+
+let files = [
+  main_saty_template;
+  satyristes_template;
+  Template_docMake_en.gitignore_template;
+  readme_template;
+]
+
+let template =
+  "[experimental]example-autogen", ("Example with autogen libraries", files)

--- a/test/testcases/command_build__doc_with_autogen.expected
+++ b/test/testcases/command_build__doc_with_autogen.expected
@@ -122,8 +122,8 @@ diff -Nr @@empty_dir@@/lockdown.yaml @@temp_dir@@/pkg/lockdown.yaml
 >     version: 0.0.5+dev2020.09.05
 > autogen:
 >   '$today':
->     time: 2020-11-06T00:46:35.000000+09:00
->     zone: Asia/Tokyo
+>     datetime: 2020-11-06T00:46:35.000000+09:00
+>     tzname: Asia/Tokyo
 > 
 diff -Nr @@empty_dir@@/satysfi-grcnum.opam @@temp_dir@@/pkg/satysfi-grcnum.opam
 0a1,30

--- a/test/testcases/command_build__doc_with_autogen.expected
+++ b/test/testcases/command_build__doc_with_autogen.expected
@@ -27,12 +27,10 @@ Installation completed!
 @@temp_dir@@/pkg/_build/satysfi/dist/.satyrographos
 @@temp_dir@@/pkg/_build/satysfi/dist/metadata
 @@temp_dir@@/pkg/_build/satysfi/dist/packages
+@@temp_dir@@/pkg/_build/satysfi/dist/packages/$libraries.satyg
 @@temp_dir@@/pkg/_build/satysfi/dist/packages/$today.satyg
 @@temp_dir@@/pkg/_build/satysfi/dist/packages/localized-today
 @@temp_dir@@/pkg/_build/satysfi/dist/packages/localized-today/localized-today.satyh
-@@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos
-@@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental
-@@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental/libraries.satyg
 @@temp_dir@@/pkg/doc-example-ja.pdf
 @@temp_dir@@/pkg/doc-example.saty
 @@temp_dir@@/pkg/doc-grcnum.saty
@@ -66,28 +64,10 @@ diff -Nr @@empty_dir@@/_build/satysfi/dist/metadata @@temp_dir@@/pkg/_build/saty
 0a1,2
 > ((version 1) (libraryName $libraries) (libraryVersion 0.1) (compatibility ())
 >  (dependencies ()) (autogen (($today ()))))
-diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/$today.satyg @@temp_dir@@/pkg/_build/satysfi/dist/packages/$today.satyg
-0a1,13
-> let _ =
->   (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)
-> let _ =
->   (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
-> let _ =
->   (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
-> module Fonts : sig
->   val datetime : string
->   val tzname : string
-> end = struct
->   let datetime = `2020-11-06T00:46:35.000000+09:00`
->   let tzname = `Asia/Tokyo`
-> end
-diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/localized-today/localized-today.satyh @@temp_dir@@/pkg/_build/satysfi/dist/packages/localized-today/localized-today.satyh
-0a1
-> @require: satyrographos/experimental/today
-diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/satyrographos/experimental/libraries.satyg @@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental/libraries.satyg
+diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/$libraries.satyg @@temp_dir@@/pkg/_build/satysfi/dist/packages/$libraries.satyg
 0a1,15
 > let _ =
->   (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)
+>   (display-message) (#` [Warning] Satyrographos: Package $libraries is an experimental autogen package.`)
 > let _ =
 >   (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
 > let _ =
@@ -101,6 +81,24 @@ diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/satyrographos/experimental/l
 >       (| name = `dist`; version = ` `; |);
 >       (| name = `localized-today`; version = `0.1`; |); ]
 > end
+diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/$today.satyg @@temp_dir@@/pkg/_build/satysfi/dist/packages/$today.satyg
+0a1,13
+> let _ =
+>   (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)
+> let _ =
+>   (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
+> let _ =
+>   (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
+> module Today : sig
+>   val datetime : string
+>   val tzname : string
+> end = struct
+>   let datetime = `2020-11-06T00:46:35.000000+09:00`
+>   let tzname = `Asia/Tokyo`
+> end
+diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/localized-today/localized-today.satyh @@temp_dir@@/pkg/_build/satysfi/dist/packages/localized-today/localized-today.satyh
+0a1
+> @require: $today
 diff -Nr @@empty_dir@@/doc-example-ja.pdf @@temp_dir@@/pkg/doc-example-ja.pdf
 0a1
 > @@doc-example.saty@@

--- a/test/testcases/command_build__doc_with_autogen.expected
+++ b/test/testcases/command_build__doc_with_autogen.expected
@@ -67,47 +67,39 @@ diff -Nr @@empty_dir@@/_build/satysfi/dist/metadata @@temp_dir@@/pkg/_build/saty
 > ((version 1) (libraryName $libraries) (libraryVersion 0.1) (compatibility ())
 >  (dependencies ()) (autogen (($today ()))))
 diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/$today.satyg @@temp_dir@@/pkg/_build/satysfi/dist/packages/$today.satyg
-0a1,18
+0a1,13
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)
+>   (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
+>   (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
+>   (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
 > module Fonts : sig
-> val datetime :
-> string
-> val tzname :
-> string
+>   val datetime : string
+>   val tzname : string
 > end = struct
-> let datetime =
-> `2020-11-06T00:46:35.000000+09:00`
-> let tzname =
-> `Asia/Tokyo`
-> 
+>   let datetime = `2020-11-06T00:46:35.000000+09:00`
+>   let tzname = `Asia/Tokyo`
 > end
 diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/localized-today/localized-today.satyh @@temp_dir@@/pkg/_build/satysfi/dist/packages/localized-today/localized-today.satyh
 0a1
 > @require: satyrographos/experimental/today
 diff -Nr @@empty_dir@@/_build/satysfi/dist/packages/satyrographos/experimental/libraries.satyg @@temp_dir@@/pkg/_build/satysfi/dist/packages/satyrographos/experimental/libraries.satyg
-0a1,18
+0a1,15
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)
+>   (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
+>   (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
-> type library =
-> (| name : string; version : string; |)
+>   (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
+> type library = (| name : string; version : string; |)
 > module Libraries : sig
-> val list :
-> library list
+>   val list : library list
 > end = struct
-> let list =
-> [ (| name = `$today`; version = `0.1`; |);
->   (| name = `dist`; version = ` `; |);
->   (| name = `localized-today`; version = `0.1`; |); ]
-> 
+>   let list =
+>     [ (| name = `$today`; version = `0.1`; |);
+>       (| name = `dist`; version = ` `; |);
+>       (| name = `localized-today`; version = `0.1`; |); ]
 > end
 diff -Nr @@empty_dir@@/doc-example-ja.pdf @@temp_dir@@/pkg/doc-example-ja.pdf
 0a1

--- a/test/testcases/command_build__doc_with_autogen.ml
+++ b/test/testcases/command_build__doc_with_autogen.ml
@@ -44,8 +44,8 @@ dependencies:
     version: 0.0.5+dev2020.09.05
 autogen:
   '$today':
-    time: 2020-11-06T00:46:35.000000+09:00
-    zone: Asia/Tokyo
+    datetime: 2020-11-06T00:46:35.000000+09:00
+    tzname: Asia/Tokyo
 |}
 
 let files =

--- a/test/testcases/command_install_l__autogen.expected
+++ b/test/testcases/command_install_l__autogen.expected
@@ -16,24 +16,21 @@ Loaded libraries
    ((packages/satyrographos/experimental/libraries.satyg
      (Content
        "let _ =\
-      \n(display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)\
+      \n  (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)\
       \nlet _ =\
-      \n(display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
+      \n  (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
       \nlet _ =\
-      \n(display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
-      \ntype library =\
-      \n(| name : string; version : string; |)\
+      \n  (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
+      \ntype library = (| name : string; version : string; |)\
       \nmodule Libraries : sig\
-      \nval list :\
-      \nlibrary list\
+      \n  val list : library list\
       \nend = struct\
-      \nlet list =\
-      \n[ (| name = `$today`; version = `0.1`; |);\
-      \n  (| name = `base`; version = `1.1.1`; |);\
-      \n  (| name = `dist`; version = ` `; |);\
-      \n  (| name = `fonts-theano`; version = `2.0`; |);\
-      \n  (| name = `grcnum`; version = `0.2`; |); ]\
-      \n\
+      \n  let list =\
+      \n    [ (| name = `$today`; version = `0.1`; |);\
+      \n      (| name = `base`; version = `1.1.1`; |);\
+      \n      (| name = `dist`; version = ` `; |);\
+      \n      (| name = `fonts-theano`; version = `2.0`; |);\
+      \n      (| name = `grcnum`; version = `0.2`; |); ]\
       \nend\
       \n")))))
  ((name ($today)) (version (0.1))
@@ -41,22 +38,17 @@ Loaded libraries
    ((packages/$today.satyg
      (Content
        "let _ =\
-      \n(display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)\
+      \n  (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)\
       \nlet _ =\
-      \n(display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
+      \n  (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
       \nlet _ =\
-      \n(display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
+      \n  (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
       \nmodule Fonts : sig\
-      \nval datetime :\
-      \nstring\
-      \nval tzname :\
-      \nstring\
+      \n  val datetime : string\
+      \n  val tzname : string\
       \nend = struct\
-      \nlet datetime =\
-      \n`2020-11-05T23:52:11.000000Z`\
-      \nlet tzname =\
-      \n`Asia/Tokyo`\
-      \n\
+      \n  let datetime = `2020-11-05T23:52:11.000000Z`\
+      \n  let tzname = `Asia/Tokyo`\
       \nend\
       \n")))))
  ((name (base)) (version (1.1.1))
@@ -139,22 +131,17 @@ Installing ((name ($libraries)) (version (0.1))
    (packages/$today.satyg
     (Content
       "let _ =\
-     \n(display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)\
+     \n  (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)\
      \nlet _ =\
-     \n(display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
+     \n  (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
      \nlet _ =\
-     \n(display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
+     \n  (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
      \nmodule Fonts : sig\
-     \nval datetime :\
-     \nstring\
-     \nval tzname :\
-     \nstring\
+     \n  val datetime : string\
+     \n  val tzname : string\
      \nend = struct\
-     \nlet datetime =\
-     \n`2020-11-05T23:52:11.000000Z`\
-     \nlet tzname =\
-     \n`Asia/Tokyo`\
-     \n\
+     \n  let datetime = `2020-11-05T23:52:11.000000Z`\
+     \n  let tzname = `Asia/Tokyo`\
      \nend\
      \n"))
    (packages/base/void.satyh
@@ -166,24 +153,21 @@ Installing ((name ($libraries)) (version (0.1))
    (packages/satyrographos/experimental/libraries.satyg
     (Content
       "let _ =\
-     \n(display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)\
+     \n  (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)\
      \nlet _ =\
-     \n(display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
+     \n  (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
      \nlet _ =\
-     \n(display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
-     \ntype library =\
-     \n(| name : string; version : string; |)\
+     \n  (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
+     \ntype library = (| name : string; version : string; |)\
      \nmodule Libraries : sig\
-     \nval list :\
-     \nlibrary list\
+     \n  val list : library list\
      \nend = struct\
-     \nlet list =\
-     \n[ (| name = `$today`; version = `0.1`; |);\
-     \n  (| name = `base`; version = `1.1.1`; |);\
-     \n  (| name = `dist`; version = ` `; |);\
-     \n  (| name = `fonts-theano`; version = `2.0`; |);\
-     \n  (| name = `grcnum`; version = `0.2`; |); ]\
-     \n\
+     \n  let list =\
+     \n    [ (| name = `$today`; version = `0.1`; |);\
+     \n      (| name = `base`; version = `1.1.1`; |);\
+     \n      (| name = `dist`; version = ` `; |);\
+     \n      (| name = `fonts-theano`; version = `2.0`; |);\
+     \n      (| name = `grcnum`; version = `0.2`; |); ]\
      \nend\
      \n"))))
  (compatibility
@@ -256,24 +240,19 @@ diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 >      ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle))))))
 >  (dependencies ((fonts-theano ()))))
 diff -Nr @@empty_dir@@/dest/packages/$today.satyg @@dest_dir@@/dest/packages/$today.satyg
-0a1,18
+0a1,13
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)
+>   (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
+>   (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
+>   (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
 > module Fonts : sig
-> val datetime :
-> string
-> val tzname :
-> string
+>   val datetime : string
+>   val tzname : string
 > end = struct
-> let datetime =
-> `2020-11-05T23:52:11.000000Z`
-> let tzname =
-> `Asia/Tokyo`
-> 
+>   let datetime = `2020-11-05T23:52:11.000000Z`
+>   let tzname = `Asia/Tokyo`
 > end
 diff -Nr @@empty_dir@@/dest/packages/base/void.satyh @@dest_dir@@/dest/packages/base/void.satyh
 0a1
@@ -282,24 +261,21 @@ diff -Nr @@empty_dir@@/dest/packages/grcnum/grcnum.satyh @@dest_dir@@/dest/packa
 0a1
 > @@grcnum.satyh@@
 diff -Nr @@empty_dir@@/dest/packages/satyrographos/experimental/libraries.satyg @@dest_dir@@/dest/packages/satyrographos/experimental/libraries.satyg
-0a1,20
+0a1,17
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)
+>   (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
+>   (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
 > let _ =
-> (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
-> type library =
-> (| name : string; version : string; |)
+>   (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
+> type library = (| name : string; version : string; |)
 > module Libraries : sig
-> val list :
-> library list
+>   val list : library list
 > end = struct
-> let list =
-> [ (| name = `$today`; version = `0.1`; |);
->   (| name = `base`; version = `1.1.1`; |);
->   (| name = `dist`; version = ` `; |);
->   (| name = `fonts-theano`; version = `2.0`; |);
->   (| name = `grcnum`; version = `0.2`; |); ]
-> 
+>   let list =
+>     [ (| name = `$today`; version = `0.1`; |);
+>       (| name = `base`; version = `1.1.1`; |);
+>       (| name = `dist`; version = ` `; |);
+>       (| name = `fonts-theano`; version = `2.0`; |);
+>       (| name = `grcnum`; version = `0.2`; |); ]
 > end

--- a/test/testcases/command_install_l__autogen.expected
+++ b/test/testcases/command_install_l__autogen.expected
@@ -13,10 +13,10 @@ Removing destination @@dest_dir@@/dest
 Loaded libraries
 (((name ($libraries)) (version (0.1))
   (files
-   ((packages/satyrographos/experimental/libraries.satyg
+   ((packages/$libraries.satyg
      (Content
        "let _ =\
-      \n  (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)\
+      \n  (display-message) (#` [Warning] Satyrographos: Package $libraries is an experimental autogen package.`)\
       \nlet _ =\
       \n  (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
       \nlet _ =\
@@ -43,7 +43,7 @@ Loaded libraries
       \n  (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
       \nlet _ =\
       \n  (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
-      \nmodule Fonts : sig\
+      \nmodule Today : sig\
       \n  val datetime : string\
       \n  val tzname : string\
       \nend = struct\
@@ -128,32 +128,10 @@ Installing ((name ($libraries)) (version (0.1))
    (fonts/fonts-theano/TheanoOldStyle-Regular.otf
     (Filename
      @@temp_dir@@/opam_reg/fonts-theano/fonts/fonts-theano/TheanoOldStyle-Regular.otf))
-   (packages/$today.satyg
+   (packages/$libraries.satyg
     (Content
       "let _ =\
-     \n  (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)\
-     \nlet _ =\
-     \n  (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
-     \nlet _ =\
-     \n  (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
-     \nmodule Fonts : sig\
-     \n  val datetime : string\
-     \n  val tzname : string\
-     \nend = struct\
-     \n  let datetime = `2020-11-05T23:52:11.000000Z`\
-     \n  let tzname = `Asia/Tokyo`\
-     \nend\
-     \n"))
-   (packages/base/void.satyh
-    (Filename
-     @@temp_dir@@/opam_reg/base/packages/base/void.satyh))
-   (packages/grcnum/grcnum.satyh
-    (Filename
-     @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))
-   (packages/satyrographos/experimental/libraries.satyg
-    (Content
-      "let _ =\
-     \n  (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)\
+     \n  (display-message) (#` [Warning] Satyrographos: Package $libraries is an experimental autogen package.`)\
      \nlet _ =\
      \n  (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
      \nlet _ =\
@@ -169,7 +147,29 @@ Installing ((name ($libraries)) (version (0.1))
      \n      (| name = `fonts-theano`; version = `2.0`; |);\
      \n      (| name = `grcnum`; version = `0.2`; |); ]\
      \nend\
-     \n"))))
+     \n"))
+   (packages/$today.satyg
+    (Content
+      "let _ =\
+     \n  (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)\
+     \nlet _ =\
+     \n  (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)\
+     \nlet _ =\
+     \n  (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)\
+     \nmodule Today : sig\
+     \n  val datetime : string\
+     \n  val tzname : string\
+     \nend = struct\
+     \n  let datetime = `2020-11-05T23:52:11.000000Z`\
+     \n  let tzname = `Asia/Tokyo`\
+     \nend\
+     \n"))
+   (packages/base/void.satyh
+    (Filename
+     @@temp_dir@@/opam_reg/base/packages/base/void.satyh))
+   (packages/grcnum/grcnum.satyh
+    (Filename
+     @@temp_dir@@/opam_reg/grcnum/packages/grcnum/grcnum.satyh))))
  (compatibility
   ((rename_packages
     (((new_name grcnum/grcnum.satyh) (old_name grcnum.satyh))))
@@ -206,14 +206,12 @@ Installation completed!
 @@dest_dir@@/dest/hash/fonts.satysfi-hash
 @@dest_dir@@/dest/metadata
 @@dest_dir@@/dest/packages
+@@dest_dir@@/dest/packages/$libraries.satyg
 @@dest_dir@@/dest/packages/$today.satyg
 @@dest_dir@@/dest/packages/base
 @@dest_dir@@/dest/packages/base/void.satyh
 @@dest_dir@@/dest/packages/grcnum
 @@dest_dir@@/dest/packages/grcnum/grcnum.satyh
-@@dest_dir@@/dest/packages/satyrographos
-@@dest_dir@@/dest/packages/satyrographos/experimental
-@@dest_dir@@/dest/packages/satyrographos/experimental/libraries.satyg
 ------------------------------------------------------------
 diff -Nr @@empty_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf @@dest_dir@@/dest/fonts/fonts-theano/TheanoDidot-Regular.otf
 0a1
@@ -239,31 +237,10 @@ diff -Nr @@empty_dir@@/dest/metadata @@dest_dir@@/dest/metadata
 >      ((new_name fonts-theano:TheanoModern) (old_name TheanoModern))
 >      ((new_name fonts-theano:TheanoOldStyle) (old_name TheanoOldStyle))))))
 >  (dependencies ((fonts-theano ()))))
-diff -Nr @@empty_dir@@/dest/packages/$today.satyg @@dest_dir@@/dest/packages/$today.satyg
-0a1,13
-> let _ =
->   (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)
-> let _ =
->   (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
-> let _ =
->   (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
-> module Fonts : sig
->   val datetime : string
->   val tzname : string
-> end = struct
->   let datetime = `2020-11-05T23:52:11.000000Z`
->   let tzname = `Asia/Tokyo`
-> end
-diff -Nr @@empty_dir@@/dest/packages/base/void.satyh @@dest_dir@@/dest/packages/base/void.satyh
-0a1
-> @@void.satyh@@
-diff -Nr @@empty_dir@@/dest/packages/grcnum/grcnum.satyh @@dest_dir@@/dest/packages/grcnum/grcnum.satyh
-0a1
-> @@grcnum.satyh@@
-diff -Nr @@empty_dir@@/dest/packages/satyrographos/experimental/libraries.satyg @@dest_dir@@/dest/packages/satyrographos/experimental/libraries.satyg
+diff -Nr @@empty_dir@@/dest/packages/$libraries.satyg @@dest_dir@@/dest/packages/$libraries.satyg
 0a1,17
 > let _ =
->   (display-message) (#` [Warning] Satyrographos: Package satyrographos/experimental/libraries is an experimental autogen package.`)
+>   (display-message) (#` [Warning] Satyrographos: Package $libraries is an experimental autogen package.`)
 > let _ =
 >   (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
 > let _ =
@@ -279,3 +256,24 @@ diff -Nr @@empty_dir@@/dest/packages/satyrographos/experimental/libraries.satyg 
 >       (| name = `fonts-theano`; version = `2.0`; |);
 >       (| name = `grcnum`; version = `0.2`; |); ]
 > end
+diff -Nr @@empty_dir@@/dest/packages/$today.satyg @@dest_dir@@/dest/packages/$today.satyg
+0a1,13
+> let _ =
+>   (display-message) (#` [Warning] Satyrographos: Package $today is an experimental autogen package.`)
+> let _ =
+>   (display-message) (#` [Warning] Satyrographos: Its API is unstable; will thus be backward-incompatibly changed.`)
+> let _ =
+>   (display-message) (#` [Warning] Satyrographos: Furthermore, the package itself may be renamed or removed.`)
+> module Today : sig
+>   val datetime : string
+>   val tzname : string
+> end = struct
+>   let datetime = `2020-11-05T23:52:11.000000Z`
+>   let tzname = `Asia/Tokyo`
+> end
+diff -Nr @@empty_dir@@/dest/packages/base/void.satyh @@dest_dir@@/dest/packages/base/void.satyh
+0a1
+> @@void.satyh@@
+diff -Nr @@empty_dir@@/dest/packages/grcnum/grcnum.satyh @@dest_dir@@/dest/packages/grcnum/grcnum.satyh
+0a1
+> @@grcnum.satyh@@

--- a/test/testcases/command_install_l__autogen.ml
+++ b/test/testcases/command_install_l__autogen.ml
@@ -20,8 +20,8 @@ let () =
   let system_font_prefix = None in
   let persistent_autogen = [
     "$today", `Assoc [
-      "time", `String "2020-11-05T23:52:11.000000Z";
-      "zone", `String "Asia/Tokyo";
+      "datetime", `String "2020-11-05T23:52:11.000000Z";
+      "tzname", `String "Asia/Tokyo";
     ]
   ]
   in

--- a/test/testcases/command_lint__autogen.ml
+++ b/test/testcases/command_lint__autogen.ml
@@ -41,7 +41,7 @@ let satyristes =
 |}
 
 let test_satyh =
-  "test.satyh", {|@require: satyrographos/experimental/libraries|}
+  "test.satyh", {|@require: $libraries|}
 
 let opam_libs = Satyrographos.Library.[
     {empty with

--- a/test/testcases/command_new__example_autogen.t
+++ b/test/testcases/command_new__example_autogen.t
@@ -1,0 +1,18 @@
+Create a new document with example-autogen template
+  $ satyrographos new [experimental]example-autogen --license CC-BY-4.0 test-example-autogen
+  Name: test-example-autogen
+  License: CC-BY-4.0
+  Created a new library/document.
+
+Try to build when there is satysfi command
+  $ if command satysfi --version >/dev/null 2>&1 && opam list -i --silent satysfi-dist ; then
+  >   cd test-example-autogen
+  >   SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos build >build.log 2>&1
+  >   [ -f main.pdf ] || cat build.log
+  >   cd ..
+  > fi
+
+Ensure there are no warnings
+  $ satyrographos lint -W '-lib/dep/exception-during-setup' --script test-example-autogen/Satyristes --satysfi-version 0.0.5
+  WARNING: Script lang 0.0.3 is under development.
+  0 problem(s) found.

--- a/test/testlib/prepareOpamReg.ml
+++ b/test/testlib/prepareOpamReg.ml
@@ -52,7 +52,7 @@ let localizedTodayFiles = [
   "localized-today/metadata",
   {|((version 1) (libraryName localized-today) (libraryVersion 0.1) (compatibility ())
 (dependencies ()) (autogen (($today ()))))|};
-  "localized-today/packages/localized-today/localized-today.satyh", "@require: satyrographos/experimental/today"; ]
+  "localized-today/packages/localized-today/localized-today.satyh", "@require: $today"; ]
 
 (* TODO Remove this function *)
 let prepare =


### PR DESCRIPTION
Example:
```
$ satyrographos new [experimental]example-autogen --license CC-BY-4.0 test-example-autogen
```

This PR also fixes the module name and the field names of `$today` autogen library.  Also changed import paths of other autogen libraries.