### PR TITLE
Make subgraph_with_mode remove vertices as well as edges

### DIFF
--- a/src/satysfi/mode.ml
+++ b/src/satysfi/mode.ml
@@ -45,8 +45,12 @@ let of_extension_opt = function
     |> Option.map ~f:(fun m -> Text m)
 
 let of_basename_opt basename =
-  "." ^ FilePath.get_extension basename
-  |> of_extension_opt
+  try
+    "." ^ FilePath.get_extension basename
+    |> of_extension_opt
+  with
+  | _ ->
+    None
 
 let to_extension = function
   | Pdf ->

--- a/test/testcases/command_debug_depgraph__subgraph_with_mode.t
+++ b/test/testcases/command_debug_depgraph__subgraph_with_mode.t
@@ -14,7 +14,6 @@ Generate dependency graphs for satyh
   $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph -S 0.0.5 --mode pdf first.saty
   Compatibility warning: You have opted in to use experimental features.
   digraph G {
-    "second.satyh-md" [shape=box, ];
     "second" [shape=doubleoctagon, ];
     "second.satyh" [shape=box, ];
     "second.satyg" [shape=box, ];
@@ -34,7 +33,6 @@ Generate dependency graphs for satyh-md
   digraph G {
     "second.satyh-md" [shape=box, ];
     "second" [shape=doubleoctagon, ];
-    "second.satyh" [shape=box, ];
     "second.satyg" [shape=box, ];
     "first.saty" [shape=box, ];
     

--- a/test/testcases/command_lint__insufficient_dependencies_for_some_modes.ml
+++ b/test/testcases/command_lint__insufficient_dependencies_for_some_modes.ml
@@ -17,6 +17,7 @@ let satyristes =
   (sources ((package "first.satyh" "first.satyh")
             (package "second.satyg" "second.satyg")
             (package "third.satyh" "third.satyh")
+            (package "safe.satyg" "safe.satyg")
            ))
   (opam "satysfi-package.opam")
   (dependencies ()))
@@ -28,6 +29,8 @@ let packages = [
   "second.satyg", {|@import: third
 |};
   "third.satyh", {|
+|};
+  "safe.satyg", {|@import: second
 |};
 ]
 


### PR DESCRIPTION
This fixes a bug where `lint` reports non-problematic imports as in https://github.com/na4zagin3/satyrographos-repo/pull/216#issuecomment-723535012