### PR TITLE
Support .satysfi-md as a source type of dependency graphs

### DIFF
--- a/src/satysfi/dependency.ml
+++ b/src/satysfi/dependency.ml
@@ -5,6 +5,7 @@ module Location = Satyrographos.Location
 type directive =
   | Import of string
   | Require of string
+  | MdDepends of string
 [@@deriving sexp, compare, hash, equal]
 
 type t = {
@@ -16,6 +17,7 @@ type t = {
 let render_directive = function
   | Import f -> sprintf "@import: %s" f
   | Require p -> sprintf "@require: %s" p
+  | MdDepends p -> sprintf "md depends %s" p
 
 let parse_directives =
   (* TODO Rewrite when multi-line comment is added to SATySFi *)
@@ -274,12 +276,67 @@ let%expect_test "parse_string_saty: directives followed by declarations" =
             ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 8))))))))
         (Import file))))) |}]
 
+let parse_satysfi_md_yojson ~path (json: Yojson.Safe.t) =
+  begin match json with
+    | `Assoc lvs ->
+      List.find_map lvs ~f:(function
+          | "depends", `List ds ->
+            List.filter_map ds ~f:(function
+                | `String s -> Some s
+                | _ ->
+                  failwithf
+                    "%s:\nDependency must be a list of strings but got %s@."
+                    path
+                    (Yojson.Safe.to_string (`List ds))
+                    ()
+              )
+            |> Option.some
+          | _ -> None
+        )
+      |> Option.map ~f:(fun ps ->
+          {
+            path = path;
+            directives =
+              let loc = {
+                Location.path;
+                range = None;
+              }
+              in
+              List.map ~f:(fun p -> loc, MdDepends p) ps
+          })
+    | _ ->
+      None
+  end
+  |> Option.value_exn ~message:(sprintf "File %s does not have depends field" path)
+
+let parse_satysfi_md_str ~path str =
+  Yojson.Safe.from_string str
+  |> parse_satysfi_md_yojson ~path
+
+let parse_satysfi_md_file ~path =
+  Yojson.Safe.from_file path
+  |> parse_satysfi_md_yojson ~path
+
+let%expect_test "parse_satysfi_md_str: valid" =
+  let path = "test.saty" in
+  parse_satysfi_md_str ~path {|{"depends":["mdja"]}|}
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty)
+     (directives ((((path test.saty) (range ())) (MdDepends mdja))))) |}]
+
 let parse_file_result path =
-  Result.try_with (fun () ->
-      In_channel.read_all path
-    )
-  |> Result.map ~f:(match FilePath.get_extension path with
-      | _ -> parse_string_saty ~path)
+  match FilePath.get_extension path with
+  | "satysfi-md" ->
+    Result.try_with (fun () ->
+        parse_satysfi_md_file ~path)
+  | _ ->
+    Result.try_with (fun () ->
+        In_channel.read_all path
+      )
+    |> Result.map ~f:(match FilePath.get_extension path with
+        | _ -> parse_string_saty ~path)
 
 let referred_file_basenames ~package_root_dirs { path; directives; }=
   let basedir = FilePath.dirname path in
@@ -287,6 +344,7 @@ let referred_file_basenames ~package_root_dirs { path; directives; }=
       match d with
       | Import f ->
         loc, d, [FilePath.concat basedir f]
-      | Require p ->
+      | Require p
+      | MdDepends p ->
         loc, d, List.map package_root_dirs ~f:(fun rd -> FilePath.concat rd p)
     )

--- a/src/satysfi/dependency.ml
+++ b/src/satysfi/dependency.ml
@@ -9,8 +9,7 @@ type directive =
 
 type t = {
   path: string;
-  imports: (Location.t * string) list;
-  requires: (Location.t * string) list;
+  directives: (Location.t * directive) list;
 }
 [@@deriving sexp]
 
@@ -80,225 +79,214 @@ let of_directives ~path ds =
       range = Some (ColumnRange cr);
     }
   in
-  let accum acc = function
-    | cr, Import c ->
-      { acc with imports = (loc cr, c) :: acc.imports; }
-    | cr, Require c ->
-      { acc with requires = (loc cr, c) :: acc.requires; }
-  in
-  let empty = {
+  {
     path = path;
-    imports = [];
-    requires = [];
-  } in
-  List.fold_left ~f:accum ~init:empty ds
+    directives = List.map ds ~f:(fun (cr, d) -> loc cr, d);
+  }
 
-let parse_string ~path str =
+let parse_string_saty ~path str =
   parse_directives str
   |> of_directives ~path
+
+let%expect_test "parse_string_saty: empty" =
+  let path = "test.saty" in
+  parse_string_saty ~path ""
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (directives ())) |}]
+
+let%expect_test "parse_string_saty: single import with crlf" =
+  let path = "test.saty" in
+  parse_string_saty ~path "@import: imported/file1\r\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty)
+     (directives
+      ((((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 8))))))))
+        (Import imported/file1))))) |}]
+
+let%expect_test "parse_string_saty: single import with eol" =
+  let path = "test.saty" in
+  parse_string_saty ~path "@import: imported/file1\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty)
+     (directives
+      ((((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 8))))))))
+        (Import imported/file1))))) |}]
+
+let%expect_test "parse_string_saty: single import with eos" =
+  let path = "test.saty" in
+  parse_string_saty ~path "@import: imported/file1"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty)
+     (directives
+      ((((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 8))))))))
+        (Import imported/file1))))) |}]
+
+let%expect_test "parse_string_saty: single require" =
+  let path = "test.saty" in
+  parse_string_saty ~path "@require: required/file1"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty)
+     (directives
+      ((((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 9))))))))
+        (Require required/file1))))) |}]
+
+let%expect_test "parse_string_saty: imports and requires" =
+  let path = "test.saty" in
+  parse_string_saty ~path "@require: required/file1\n@import: imported/file1\n@require: required/file2\n@import: imported/file2\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty)
+     (directives
+      ((((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 9))))))))
+        (Require required/file1))
+       (((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 1) (cnum 1))) (rend ((lnum 1) (cnum 9))))))))
+        (Import imported/file1))
+       (((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 2) (cnum 1))) (rend ((lnum 2) (cnum 10))))))))
+        (Require required/file2))
+       (((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 3) (cnum 1))) (rend ((lnum 3) (cnum 9))))))))
+        (Import imported/file2))))) |}]
+
+let%expect_test "parse_string_saty: conflicting names" =
+  let path = "test.saty" in
+  parse_string_saty ~path "@require: file1\n@import: file1\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty)
+     (directives
+      ((((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 9))))))))
+        (Require file1))
+       (((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 1) (cnum 1))) (rend ((lnum 1) (cnum 9))))))))
+        (Import file1))))) |}]
+
+let%expect_test "parse_string_saty: % in package name" =
+  let path = "test.saty" in
+  parse_string_saty ~path "@require: file1 % not a comment\n@import: file1 % not a comment\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty)
+     (directives
+      ((((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 9))))))))
+        (Require "file1 % not a comment"))
+       (((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 1) (cnum 1))) (rend ((lnum 1) (cnum 9))))))))
+        (Import "file1 % not a comment"))))) |}]
+
+let%expect_test "parse_string_saty: comment lines" =
+  let path = "test.saty" in
+  parse_string_saty ~path "% comment\n%\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty) (directives ())) |}]
+
+let%expect_test "parse_string_saty: comment lines followed by directives" =
+  let path = "test.saty" in
+  parse_string_saty ~path "% comment\n%\n@import: file\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty)
+     (directives
+      ((((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 2) (cnum 1))) (rend ((lnum 2) (cnum 9))))))))
+        (Import file))))) |}]
+
+let%expect_test "parse_string_saty: comment lines interleaved between directives" =
+  let path = "test.saty" in
+  parse_string_saty ~path "% comment\n@require: lib\n%\n@import: file\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty)
+     (directives
+      ((((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 1) (cnum 1))) (rend ((lnum 1) (cnum 10))))))))
+        (Require lib))
+       (((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 3) (cnum 1))) (rend ((lnum 3) (cnum 9))))))))
+        (Import file))))) |}]
+
+let%expect_test "parse_string_saty: directives followed by declarations" =
+  let path = "test.saty" in
+  parse_string_saty ~path "@import: file\nlet x = 1\n"
+  |> [%sexp_of: t]
+  |> Sexp.output_hum Out_channel.stdout;
+  [%expect{|
+    ((path test.saty)
+     (directives
+      ((((path test.saty)
+         (range
+          ((ColumnRange
+            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 8))))))))
+        (Import file))))) |}]
 
 let parse_file_result path =
   Result.try_with (fun () ->
       In_channel.read_all path
     )
-  |> Result.map ~f:(parse_string ~path)
+  |> Result.map ~f:(match FilePath.get_extension path with
+      | _ -> parse_string_saty ~path)
 
-let%expect_test "parse_string: empty" =
-  let path = "test.saty" in
-  parse_string ~path ""
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty) (imports ()) (requires ())) |}]
-
-let%expect_test "parse_string: single import with crlf" =
-  let path = "test.saty" in
-  parse_string ~path "@import: imported/file1\r\n"
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty)
-     (imports
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 8))))))))
-        imported/file1)))
-     (requires ())) |}]
-
-let%expect_test "parse_string: single import with eol" =
-  let path = "test.saty" in
-  parse_string ~path "@import: imported/file1\n"
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty)
-     (imports
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 8))))))))
-        imported/file1)))
-     (requires ())) |}]
-
-let%expect_test "parse_string: single import with eos" =
-  let path = "test.saty" in
-  parse_string ~path "@import: imported/file1"
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty)
-     (imports
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 8))))))))
-        imported/file1)))
-     (requires ())) |}]
-
-let%expect_test "parse_string: single require" =
-  let path = "test.saty" in
-  parse_string ~path "@require: required/file1"
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty) (imports ())
-     (requires
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 9))))))))
-        required/file1)))) |}]
-
-let%expect_test "parse_string: imports and requires" =
-  let path = "test.saty" in
-  parse_string ~path "@require: required/file1\n@import: imported/file1\n@require: required/file2\n@import: imported/file2\n"
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty)
-     (imports
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 3) (cnum 1))) (rend ((lnum 3) (cnum 9))))))))
-        imported/file2)
-       (((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 1) (cnum 1))) (rend ((lnum 1) (cnum 9))))))))
-        imported/file1)))
-     (requires
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 2) (cnum 1))) (rend ((lnum 2) (cnum 10))))))))
-        required/file2)
-       (((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 9))))))))
-        required/file1)))) |}]
-
-let%expect_test "parse_string: conflicting names" =
-  let path = "test.saty" in
-  parse_string ~path "@require: file1\n@import: file1\n"
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty)
-     (imports
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 1) (cnum 1))) (rend ((lnum 1) (cnum 9))))))))
-        file1)))
-     (requires
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 9))))))))
-        file1)))) |}]
-
-let%expect_test "parse_string: % in package name" =
-  let path = "test.saty" in
-  parse_string ~path "@require: file1 % not a comment\n@import: file1 % not a comment\n"
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty)
-     (imports
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 1) (cnum 1))) (rend ((lnum 1) (cnum 9))))))))
-        "file1 % not a comment")))
-     (requires
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 9))))))))
-        "file1 % not a comment")))) |}]
-
-let%expect_test "parse_string: comment lines" =
-  let path = "test.saty" in
-  parse_string ~path "% comment\n%\n"
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty) (imports ()) (requires ())) |}]
-
-let%expect_test "parse_string: comment lines followed by directives" =
-  let path = "test.saty" in
-  parse_string ~path "% comment\n%\n@import: file\n"
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty)
-     (imports
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 2) (cnum 1))) (rend ((lnum 2) (cnum 9))))))))
-        file)))
-     (requires ())) |}]
-
-let%expect_test "parse_string: comment lines interleaved between directives" =
-  let path = "test.saty" in
-  parse_string ~path "% comment\n@require: lib\n%\n@import: file\n"
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty)
-     (imports
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 3) (cnum 1))) (rend ((lnum 3) (cnum 9))))))))
-        file)))
-     (requires
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 1) (cnum 1))) (rend ((lnum 1) (cnum 10))))))))
-        lib)))) |}]
-
-let%expect_test "parse_string: directives followed by declarations" =
-  let path = "test.saty" in
-  parse_string ~path "@import: file\nlet x = 1\n"
-  |> [%sexp_of: t]
-  |> Sexp.output_hum Out_channel.stdout;
-  [%expect{|
-    ((path test.saty)
-     (imports
-      ((((path test.saty)
-         (range
-          ((ColumnRange
-            ((rstart ((lnum 0) (cnum 0))) (rend ((lnum 0) (cnum 8))))))))
-        file)))
-     (requires ())) |}]
-
-let referred_file_basenames ~package_root_dirs { path; imports; requires; }=
+let referred_file_basenames ~package_root_dirs { path; directives; }=
   let basedir = FilePath.dirname path in
-  List.map imports ~f:(fun (loc, p) -> loc, Import p, [FilePath.concat basedir p])
-  @ List.map requires ~f:(fun (loc, p) -> loc, Require p, List.map package_root_dirs ~f:(fun rd -> FilePath.concat rd p))
+  List.map directives ~f:(fun (loc, d) ->
+      match d with
+      | Import f ->
+        loc, d, [FilePath.concat basedir f]
+      | Require p ->
+        loc, d, List.map package_root_dirs ~f:(fun rd -> FilePath.concat rd p)
+    )

--- a/test/testcases/command_debug_depgraph__satysfi_md.t
+++ b/test/testcases/command_debug_depgraph__satysfi_md.t
@@ -1,0 +1,21 @@
+Prepare SATySFi source
+  $ cat >mdja.satysfi-md <<EOF
+  > {
+  >   "depends":["mdja"],
+  >   "document":["Test.document"],
+  >   "header-default":["(| title = {}; author = {}; |)"]
+  > }
+  > EOF
+
+Generate dependency graphs
+  $ SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos debug depgraph -S 0.0.5 mdja.satysfi-md
+  Compatibility warning: You have opted in to use experimental features.
+  digraph G {
+    "mdja" [shape=ellipse, ];
+    "mdja.satysfi-md" [shape=box, ];
+    
+    
+    "mdja.satysfi-md" -> "mdja" [color="#117722", fontcolor="#117722",
+                                 label="md depends mdja", ];
+    
+    }


### PR DESCRIPTION
This PR adds .satysfi-md file as one source of dependency graphs.
Meanwhile, lint subcommand still does not check dependencies of .satysfi-md files.

Resolves #205