### PR TITLE
Migrate: Add build section to OPAM files with an empty build section

### DIFF
--- a/src/command/migrate.ml
+++ b/src/command/migrate.ml
@@ -2,7 +2,8 @@ open Core
 
 open Satyrographos
 
-let migrate_0_0_2 ~outf:_ ~buildscript_path  =
+let migrate_0_0_2 ~outf ~buildscript_path  =
+  Format.fprintf outf "Reading %s.@." buildscript_path;
   let sections2 =
     Sexp.load_sexps_conv_exn
       buildscript_path
@@ -13,9 +14,60 @@ let migrate_0_0_2 ~outf:_ ~buildscript_path  =
       sections2
       ~f:BuildScript_0_0_3.migrate_from_0_0_2
   in
+  Format.fprintf outf "Writing %s.@." buildscript_path;
   BuildScript_0_0_3.save_sections
     buildscript_path
-    sections3
+    sections3;
+  let basedir =
+    FilePath.dirname buildscript_path
+  in
+  let bs = BuildScript.load buildscript_path in
+  let migrate_opam name opam_path =
+    Format.fprintf outf "Reading %s@." opam_path;
+    let file =
+      OpamFilename.create (OpamFilename.Dir.of_string basedir) (OpamFilename.Base.of_string opam_path)
+    in
+    let opam = OpamFile.OPAM.read (OpamFile.make file) in
+    let build =
+      match OpamFile.OPAM.build opam with
+      | [[], None]
+      | [] ->
+        Format.fprintf outf "Fixing build section in %s.@." opam_path;
+        let cmd =
+          ["satyrographos"; "opam"; "install";
+           "--name"; "satysfi-" ^ name;
+           "--prefix"; "%{prefix}%";
+           "--script"; "%{build}%/Satyristes"]
+        in
+        Some [
+          (cmd |> List.map ~f:(fun s -> OpamTypes.CString s, None)), None
+        ]
+      | _ ->
+        Format.fprintf outf {|Please be sure %s has the following build section.@.
+build:
+  ["satyrographos" "opam" "install"
+   "--name" "satysfi-%s"
+   "--prefix" "%%{prefix}%%"
+   "--script" "%%{build}%%/Satyristes"]
+|} opam_path name;
+        None
+    in
+    match build with
+    | None -> ()
+    | Some build ->
+      let opam =
+        OpamFile.OPAM.with_build build opam
+      in
+      Format.fprintf outf "Writing %s@." opam_path;
+      OpamFile.OPAM.write (OpamFile.make file) opam
+  in
+  BuildScript.get_module_map bs
+  |> BuildScript.StringMap.iter ~f:(fun m ->
+      let name = BuildScript.get_name m in
+      BuildScript.get_opam_opt m
+      |> Option.iter ~f:(migrate_opam name)
+    )
+
 
 let migrate ~outf ~buildscript_path =
   let buildscript_path = Option.value ~default:"Satyristes" buildscript_path in

--- a/test/testcases/command_migrate__build_0_0_2.t
+++ b/test/testcases/command_migrate__build_0_0_2.t
@@ -25,6 +25,29 @@ Prepare a Satyrographos 0.0.2 library
   >   (opam "satysfi-package-doc.opam")
   >   (dependencies ((package ()))))
   > EOF
+  $ cat > test-lib/satysfi-package.opam <<EOF
+  > opam-version: "2.0"
+  > build: []
+  > install: [
+  >   ["satyrographos" "opam" "install"
+  >    "--name" "satysfi-package"
+  >    "--prefix" "%{prefix}%"
+  >    "--script" "%{build}%/Satyristes"]
+  > ]
+  $ cat > test-lib/satysfi-package-doc.opam <<EOF
+  > opam-version: "2.0"
+  > build: [
+  >   ["satyrographos" "opam" "build"
+  >    "--name" "satysfi-package-doc"
+  >    "--prefix" "%{prefix}%"
+  >    "--script" "%{build}%/Satyristes"]
+  > ]
+  > install: [
+  >   ["satyrographos" "opam" "install"
+  >    "--name" "satysfi-package-doc"
+  >    "--prefix" "%{prefix}%"
+  >    "--script" "%{build}%/Satyristes"]
+  > ]
 
   $ cd test-lib
 
@@ -46,7 +69,21 @@ Migrate the library
   Otherwise, address them.
   Additionally, please take a backup (e.g., committing changes to the git repo) beforehand.
   Type “yes” if you are ready to proceed.
-  [yes/NO] Done.
+  [yes/NO] Reading $TESTCASE_ROOT/test-lib/Satyristes.
+  Writing $TESTCASE_ROOT/test-lib/Satyristes.
+  WARNING: Script lang 0.0.3 is under development.
+  Reading satysfi-package.opam
+  Fixing build section in satysfi-package.opam.
+  Writing satysfi-package.opam
+  Reading satysfi-package-doc.opam
+  Please be sure satysfi-package-doc.opam has the following build section.
+  
+  build:
+    ["satyrographos" "opam" "install"
+     "--name" "satysfi-package-doc"
+     "--prefix" "%{prefix}%"
+     "--script" "%{build}%/Satyristes"]
+  Done.
 
 Dump generated files
   $ mkdir ../empty-dir
@@ -64,6 +101,46 @@ Dump generated files
   >  (compatibility ((RenameFont fonts-theano:TheanoDidot TheanoDidot))))
   > (LibraryDoc (name package-doc) (version 0.1) (opam satysfi-package-doc.opam)
   >  (workingDirectory .) (dependencies (package)))
+  diff -Nr ../empty-dir/satysfi-package-doc.opam ./satysfi-package-doc.opam
+  0a1,13
+  > opam-version: "2.0"
+  > build: [
+  >   ["satyrographos" "opam" "build"
+  >    "--name" "satysfi-package-doc"
+  >    "--prefix" "%{prefix}%"
+  >    "--script" "%{build}%/Satyristes"]
+  > ]
+  > install: [
+  >   ["satyrographos" "opam" "install"
+  >    "--name" "satysfi-package-doc"
+  >    "--prefix" "%{prefix}%"
+  >    "--script" "%{build}%/Satyristes"]
+  > ]
+  diff -Nr ../empty-dir/satysfi-package.opam ./satysfi-package.opam
+  0a1,23
+  > opam-version: "2.0"
+  > build: [
+  >   "satyrographos"
+  >   "opam"
+  >   "install"
+  >   "--name"
+  >   "satysfi-package"
+  >   "--prefix"
+  >   "%{prefix}%"
+  >   "--script"
+  >   "%{build}%/Satyristes"
+  > ]
+  > install: [
+  >   "satyrographos"
+  >   "opam"
+  >   "install"
+  >   "--name"
+  >   "satysfi-package"
+  >   "--prefix"
+  >   "%{prefix}%"
+  >   "--script"
+  >   "%{build}%/Satyristes"
+  > ]
   [1]
 
 Migration is idempotent


### PR DESCRIPTION
This PR has `migrate` command update OPAM files with an empty build section.