### PR TITLE
Fix the version constraint for 'core'

### DIFF
--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -37,7 +37,7 @@ depends: [
   "yojson"
 
   # Janestreet Libs
-  "core" {>= "v0.13" & < "v0.15"}
+  "core" {>= "v0.14" & < "v0.15"}
   "ppx_jane"
   "shexp"
 ]


### PR DESCRIPTION
I have found that the current description  `>= "0.13" && < "0.15"` of the dependency upon `core` seems probably incorrect, by getting the following error when trying to upgrade `satyrographos` to `0.0.2.8` (i.e. the latest version):

```console
#=== ERROR while compiling satyrographos.0.0.2.8 =====================#
# context     2.0.0 | macos/x86_64 | ocaml-base-compiler.4.10.0 | https://opam.ocaml.org/#ff4e51fd
# path        ~/.opam/4.10.0/.opam-switch/build/satyrographos.0.0.2.8
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p satyrographos -j 4
# exit-code   1
# env-file    ~/.opam/log/satyrographos-94678-e7966f.env
# output-file ~/.opam/log/satyrographos-94678-e7966f.out
### output ###
#       ocamlc src/satysfi/.satyrographos_satysfi.objs/byte/satyrographos_satysfi__Version.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /Users/gfnmac/.opam/4.10.0/bin/ocamlc.opt -w -40 -g -ppx '.ppx/b4175a47579235f9b841d5d1f64bf609/ppx.exe --as-ppx --cookie '\''library-name="satyrographos_satysfi"'\''' -bin-annot -I src/satysfi/.satyrographos_satysfi.objs/byte -I /Users/gfnmac/.opam/4.10.0/lib/base -I /Users/gfnmac/.opam/4.10.0/lib/base/base_internalhash_types -I /Users/gfnmac/.opam/4.10.0/lib/base/caml [...]
# File "src/satysfi/version.ml", line 114, characters 2-22:
# 114 |   Option.try_with_join (fun () ->
#         ^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Option.try_with_join
```

This PR attempts to fix the constraint. According to the official documentation, `Core.Option.try_with_join` is available strictly since `0.14`, not since `0.13`:

* [0.13](https://ocaml.janestreet.com/ocaml-core/v0.13/doc/core_kernel/Core_kernel/Option/index.html)
* [0.14](https://ocaml.janestreet.com/ocaml-core/v0.14/doc/core_kernel/Core_kernel/Option/index.html)

Indeed, this modification seems to remedy the problem, as indicated by the success in `opam pin add satyrographos 〈path/to/repository〉`  on my local machine.

I will appreciate any comments or suggestions.