### PR TITLE
Add lint case hash/font/location/src-dist

### DIFF
--- a/src/command/lint.ml
+++ b/src/command/lint.ml
@@ -55,8 +55,12 @@ let lint_module ~outf ~verbose:_ ~satysfi_version ~basedir
   let dependency_problems =
     Lint_module_dependency.lint_module_dependency ~outf ~locs ~satysfi_version ~basedir ~env m
   in
+  let hash_problems =
+    Lint_module_hashes.lint_module_hashes ~outf ~locs ~satysfi_version ~basedir ~env m
+  in
   opam_problems
   @ dependency_problems
+  @ hash_problems
   @ lint_compatibility ~locs m
   @ lint_build ~locs ~buildscript_version m
 

--- a/src/command/lint_module_hashes.ml
+++ b/src/command/lint_module_hashes.ml
@@ -1,0 +1,42 @@
+open Core
+open Satyrographos
+open Lint_prim
+
+
+let lint_module_hashes ~outf:_ ~locs ~satysfi_version ~basedir ~env:_ (m : BuildScript.m) =
+  let target_library =
+    BuildScript.read_module ~src_dir:basedir m
+  in
+  target_library.hashes
+  |> Library.LibraryFiles.to_alist
+  |> List.concat_map ~f:(fun (file, (_, json)) ->
+      match file with
+      | "hash/fonts.satysfi-hash"
+      | "hash/mathfonts.satysfi-hash" ->
+        let problematic_fonts =
+          match json with
+          | `Assoc xs ->
+            List.concat_map xs ~f:(function
+                | (font_name, `Variant (_, Some (`Assoc loc)))->
+                  let has_src_dist =
+                    List.exists loc ~f:(function
+                        | "src-dist", _ ->
+                          Satyrographos_satysfi.Version.is_hash_font_src_dist_deprecated satysfi_version
+                        | _ -> false
+                      )
+                  in
+                  if has_src_dist
+                  then [font_name]
+                  else []
+                | _ -> []
+              )
+          | _ -> []
+        in
+        [{
+          locs;
+          level = `Warning;
+          problem = HashFontLocationSrcDist problematic_fonts;
+        }]
+      | _ ->
+        []
+    )

--- a/src/command/lint_problem.ml
+++ b/src/command/lint_problem.ml
@@ -4,6 +4,7 @@ type problem =
   | ExceptionDuringSettingUpEnv of Exn.t
   | InternalBug of string
   | InternalException of Exn.t * string
+  | HashFontLocationSrcDist of string list
   | LibraryBuildDeprecatedMakeCommand
   | LibraryMissingFile
   | LibraryVersionShouldNotBeEmpty
@@ -36,6 +37,8 @@ let problem_class = function
     "internal/bug"
   | InternalException _ ->
     "internal/exception"
+  | HashFontLocationSrcDist _ ->
+    "hash/font/location/src-dist"
   | LibraryBuildDeprecatedMakeCommand ->
     "lib/build/deprecated/make"
   | LibraryMissingFile ->
@@ -76,6 +79,10 @@ let show_problem ~outf = function
       exn;
     Format.fprintf outf
       "@;%s" stacktrace
+  | HashFontLocationSrcDist font_names ->
+    Format.fprintf outf
+      !"src-dist field in font hashes %{sexp:string list} has been deprecated.  See https://github.com/gfngfn/SATySFi/commit/868fd678aaa19aeb59d4fb77c928e833af4c2359"
+      font_names
   | LibraryBuildDeprecatedMakeCommand ->
     Format.fprintf outf
       "(make <args>...) build command has been deprecated.@ Please use (make <args>...) instead and then `satyrographos satysfi ...` command instead of `satysfi -C $SATYSFI_RUNTIME ...`."

--- a/src/satysfi/version.ml
+++ b/src/satysfi/version.ml
@@ -128,3 +128,7 @@ let flag =
       get_current_version ()
       |> Option.value_exn ~message:"Cannot detect SATySFi Version.  Please specify with --satysfi-version"
   ]
+
+let is_hash_font_src_dist_deprecated = function
+  | Satysfi_0_0_3 -> false
+  | _ -> true

--- a/test/testcases/command_lint__hash_font_src_dist.expected
+++ b/test/testcases/command_lint__hash_font_src_dist.expected
@@ -1,0 +1,9 @@
+@@test_library@@/Satyristes:3:1: (module package):
+Warning: hash/font/location/src-dist
+  src-dist field in font hashes (font1) has been deprecated.  See https://github.com/gfngfn/SATySFi/commit/868fd678aaa19aeb59d4fb77c928e833af4c2359
+
+@@test_library@@/Satyristes:3:1: (module package):
+Warning: hash/font/location/src-dist
+  src-dist field in font hashes (mathfont1) has been deprecated.  See https://github.com/gfngfn/SATySFi/commit/868fd678aaa19aeb59d4fb77c928e833af4c2359
+
+2 problem(s) found.

--- a/test/testcases/command_lint__hash_font_src_dist.ml
+++ b/test/testcases/command_lint__hash_font_src_dist.ml
@@ -1,0 +1,54 @@
+open Core
+open Satyrographos_testlib
+
+let satysfi_package_opam =
+  "satysfi-package.opam", TestLib.opam_file_for_test
+    ~name:"satysfi-package"
+    ~version:"0.1"
+    ()
+
+let satyristes =
+  "Satyristes", sprintf
+    {|(version "0.0.2")
+
+(library
+  (name "package")
+  (version "0.1")
+  (sources ((hash "mathfonts.satysfi-hash" "mathfonts.satysfi-hash")
+            (hash "fonts.satysfi-hash" "fonts.satysfi-hash")))
+  (opam "satysfi-package.opam")
+  (dependencies ()))
+|}
+
+let fonts_satysfi_hash =
+  "fonts.satysfi-hash", {|
+{
+  "font1": <Single:{"src-dist": "abc.ttf" }>
+}
+|}
+
+let mathfonts_satysfi_hash =
+  "mathfonts.satysfi-hash", {|
+{
+  "mathfont1": <Single:{"src-dist": "math-abc.ttf" }>
+}
+|}
+
+let opam_libs = Satyrographos.Library.[
+    {empty with
+     name = Some "package";
+     files = LibraryFiles.of_alist_exn [
+         "packages/package/test.satyh", `Content ""
+       ]
+    };
+]
+
+let files =
+  [ satysfi_package_opam;
+    satyristes;
+    fonts_satysfi_hash;
+    mathfonts_satysfi_hash;
+  ]
+
+let () =
+  TestCommand.test_lint_command ~opam_libs files

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -24,6 +24,7 @@
    command_lint__autogen
    command_lint__compatibility_satyrographos_0_0_1
    command_lint__cyclic_dependencies
+   command_lint__hash_font_src_dist
    command_lint__insufficient_dependencies
    command_lint__insufficient_dependencies_for_some_modes
    command_lint__invalid_opam_file


### PR DESCRIPTION
This adds a new lint warning `hash/font/location/src-dist` when `src-dist` field exists in a font entry in `fonts.satysfi-hash` or `mathfonts.satysfi-hash` for SATySFi 0.0.4 and later.

Related: https://github.com/na4zagin3/satyrographos/issues/10