### PR TITLE
Apply changes in opam-repository

### DIFF
--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -10,16 +10,18 @@ dev-repo: "git+https://github.com/na4zagin3/satyrographos.git"
 bug-reports: "https://github.com/na4zagin3/satyrographos/issues"
 license: "LGPL-3.0-or-later"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["sed" "-i.bak" "-e" "s/%%%%VERSION_NUM%%%%/%{version}%/" "bin/main.ml"]
   ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
-  ["dune" "runtest"]
+  ["dune" "runtest" "-p" name "-j" jobs]
 ]
 
 depends: [
   "ocaml" {>= "4.09.0"}
+
+  "conf-diffutils" {with-test}
   "dune" {>= "2.7"}
   "fileutils"
   "json-derivers"
@@ -40,9 +42,6 @@ depends: [
   "core" {>= "v0.14" & < "v0.15"}
   "ppx_jane"
   "shexp"
-]
-depexts: [
-  [ "diffutils" ] {with-test}
 ]
 synopsis: "A package manager for SATySFi"
 description: """


### PR DESCRIPTION
This backports the patch at ocaml-repository: https://github.com/ocaml/opam-repository/pull/18283/commits/742fa570e95702501982885f5c8a439b75b8ae10