### PR TITLE
Fix opam command in README

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -302,9 +302,9 @@ install: [
 以下のコマンドを実行することで、パッケージのインストールからドキュメントのビルドまでを一括で行うことができます。
 
 ```sh
-$ opam add  --verbose --yes "file://$PWD"
+$ opam pin add  --verbose --yes "file://$PWD"
 又は
-$ opam add -vy "file://$PWD"
+$ opam pin add -vy "file://$PWD"
 ```
 
 OPAMに頼らずテストを実行する方法については開発中（[#4](https://github.com/na4zagin3/satyrographos/issues/4)）です。

--- a/README.md
+++ b/README.md
@@ -326,11 +326,11 @@ I assume your document files contain many use cases.
 You can install the package and build the document with the following command.
 
 ```sh
-$ opam add  --verbose --yes "file://$PWD"
+$ opam pin add  --verbose --yes "file://$PWD"
 
 OR
 
-$ opam add -vy "file://$PWD"
+$ opam pin add -vy "file://$PWD"
 ```
 
 There’s ongoing ticket [#4](https://github.com/na4zagin3/satyrographos/issues/4) to run


### PR DESCRIPTION
- I tried the command but it didn't work fine 😢 
    ```console
    $ opam add -vy "file://$PWD"
    opam: unknown command `add'.
    Usage: opam COMMAND ...
    Try `opam --help' for more information.
     
    $ opam add  --verbose --yes "file://$PWD"
    opam: unknown command `add'.
    Usage: opam COMMAND ...
    Try `opam --help' for more information.
    ```
- As I'm not an expert of `opam` nor OCaml, I think it must be `opam pin add` 🤔 
    - https://github.com/nyuichi/satysfi-base/blob/6c700c852be6e439b0860503e5134d19d7ff1ef3/.github/workflows/ci.yml#L20