### PR TITLE
Use --no-default-config option

### DIFF
--- a/src/command/runSatysfi.ml
+++ b/src/command/runSatysfi.ml
@@ -58,8 +58,17 @@ let with_env ~outf ~(project_env : Satyrographos.Environment.project_env option)
 
 let run_satysfi_command ~satysfi_runtime args =
   let open P.Infix in
-  assert_satysfi_option_C satysfi_runtime
-  >> P.run "satysfi" (["-C"; satysfi_runtime] @ args)
+  Satyrographos_satysfi.Version.get_current_version_cmd
+  >>= function
+  | None ->
+    P.run "satysfi" (["-C"; satysfi_runtime; "--no-default-config"] @ args)
+  | Some v when Satyrographos_satysfi.Version.has_option_no_default_config v ->
+    P.run "satysfi" (["-C"; satysfi_runtime; "--no-default-config"] @ args)
+  | Some v when Satyrographos_satysfi.Version.has_option_C v ->
+    P.run "satysfi" (["-C"; satysfi_runtime] @ args)
+  | _ ->
+    assert_satysfi_option_C satysfi_runtime
+    >> P.run "satysfi" (["-C"; satysfi_runtime] @ args)
 
 let satysfi_command ~outf ~system_font_prefix ~autogen_libraries ~libraries ~verbose ~(project_env : Satyrographos.Environment.project_env option) ~env args =
   let persistent_autogen =

--- a/src/satysfi/version.ml
+++ b/src/satysfi/version.ml
@@ -140,3 +140,13 @@ let flag =
 let is_hash_font_src_dist_deprecated = function
   | Satysfi_0_0_3 -> false
   | _ -> true
+
+let has_option_C = function
+  | Satysfi_0_0_3 -> false
+  | _ -> true
+
+let has_option_no_default_config = function
+  | Satysfi_0_0_3
+  | Satysfi_0_0_4
+  | Satysfi_0_0_5 -> false
+  | _ -> true

--- a/test/testcases/command_build__doc_satysfi.expected
+++ b/test/testcases/command_build__doc_satysfi.expected
@@ -1,3 +1,6 @@
+========
+SATySFi 0.0.6
+
 Installing packages
 ------------------------------------------------------------
 Target: build-doc
@@ -30,6 +33,88 @@ Installation completed!
 @@dest_dir@@
 ------------------------------------------------------------
 ------------------------------------------------------------
+Command invoked:
+satysfi --version
+Command invoked:
+satysfi -C @@temp_dir@@/pkg/_build/satysfi --no-default-config doc-example.saty -o doc-example-ja.pdf
+doc-example.saty -> doc-example-ja.pdf
+========
+SATySFi 0.0.4
+
+Installing packages
+------------------------------------------------------------
+Target: build-doc
+
+================
+Reading runtime dist: @@temp_dir@@/empty_dist
+Read user libraries: ()
+Reading opam libraries: (base class-greek fonts-theano grcnum)
+Not gathering system fonts
+Installing libraries: (dist fonts-theano grcnum)
+Removing destination @@temp_dir@@/pkg/_build/satysfi/dist
+Installation completed!
+
+[1;33mCompatibility notice[0m for library fonts-theano:
+
+  Fonts have been renamed.
+  
+    TheanoDidot -> fonts-theano:TheanoDidot
+    TheanoModern -> fonts-theano:TheanoModern
+    TheanoOldStyle -> fonts-theano:TheanoOldStyle
+
+[1;33mCompatibility notice[0m for library grcnum:
+
+  Packages have been renamed.
+  
+    grcnum.satyh -> grcnum/grcnum.satyh
+
+================
+------------------------------------------------------------
+@@dest_dir@@
+------------------------------------------------------------
+------------------------------------------------------------
+Command invoked:
+satysfi --version
+Command invoked:
+satysfi -C @@temp_dir@@/pkg/_build/satysfi doc-example.saty -o doc-example-ja.pdf
+doc-example.saty -> doc-example-ja.pdf
+========
+SATySFi 0.0.3
+
+Installing packages
+------------------------------------------------------------
+Target: build-doc
+
+================
+Reading runtime dist: @@temp_dir@@/empty_dist
+Read user libraries: ()
+Reading opam libraries: (base class-greek fonts-theano grcnum)
+Not gathering system fonts
+Installing libraries: (dist fonts-theano grcnum)
+Removing destination @@temp_dir@@/pkg/_build/satysfi/dist
+Installation completed!
+
+[1;33mCompatibility notice[0m for library fonts-theano:
+
+  Fonts have been renamed.
+  
+    TheanoDidot -> fonts-theano:TheanoDidot
+    TheanoModern -> fonts-theano:TheanoModern
+    TheanoOldStyle -> fonts-theano:TheanoOldStyle
+
+[1;33mCompatibility notice[0m for library grcnum:
+
+  Packages have been renamed.
+  
+    grcnum.satyh -> grcnum/grcnum.satyh
+
+================
+------------------------------------------------------------
+@@dest_dir@@
+------------------------------------------------------------
+------------------------------------------------------------
+Command invoked:
+satysfi --version
 Command invoked:
 satysfi -C @@temp_dir@@/pkg/_build/satysfi --version
 Command invoked:

--- a/test/testcases/command_build__doc_satysfi.ml
+++ b/test/testcases/command_build__doc_satysfi.ml
@@ -23,7 +23,7 @@ build-doc:
 	@echo "Target: build-doc"
 |}
 
-let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
+let env ~version_string ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
   let open Shexp_process.Infix in
   let pkg_dir = FilePath.concat temp_dir "pkg" in
   let prepare_pkg =
@@ -47,7 +47,7 @@ let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
   prepare_pkg
   >> prepare_dist
   >> prepare_opam_reg
-  >> PrepareBin.prepare_bin bin log_file
+  >> PrepareBin.prepare_bin ~version_string bin log_file
   >>| read_env ~opam_reg ~dist_library_dir:empty_dist
 
 let () =
@@ -63,4 +63,9 @@ let () =
       ~env
       ~name
   in
-  eval (test_install env main)
+  Format.(fprintf std_formatter "========@.SATySFi 0.0.6@.@.");
+  eval (test_install (env ~version_string:"0.0.6")  main);
+  Format.(fprintf std_formatter "========@.SATySFi 0.0.4@.@.");
+  eval (test_install (env ~version_string:"0.0.4")  main);
+  Format.(fprintf std_formatter "========@.SATySFi 0.0.3@.@.");
+  eval (test_install (env ~version_string:"0.0.3")  main)

--- a/test/testcases/command_build__doc_with_autogen.expected
+++ b/test/testcases/command_build__doc_with_autogen.expected
@@ -159,7 +159,7 @@ diff -Nr @@empty_dir@@/satysfi-grcnum.opam @@temp_dir@@/pkg/satysfi-grcnum.opam
 > 
 ------------------------------------------------------------
 Command invoked:
-satysfi -C @@temp_dir@@/pkg/_build/satysfi --version
+satysfi --version
 Command invoked:
-satysfi -C @@temp_dir@@/pkg/_build/satysfi doc-example.saty -o doc-example-ja.pdf
+satysfi -C @@temp_dir@@/pkg/_build/satysfi --no-default-config doc-example.saty -o doc-example-ja.pdf
 doc-example.saty -> doc-example-ja.pdf

--- a/test/testcases/command_build__doc_with_libraries.expected
+++ b/test/testcases/command_build__doc_with_libraries.expected
@@ -35,7 +35,7 @@ opam pin add --no-action --yes satysfi-grcnum file://@@temp_dir@@/pkg
 Command invoked:
 opam reinstall @@temp_dir@@/pkg
 Command invoked:
-satysfi -C @@temp_dir@@/pkg/_build/satysfi --version
+satysfi --version
 Command invoked:
-satysfi -C @@temp_dir@@/pkg/_build/satysfi doc-example.saty -o doc-example-ja.pdf
+satysfi -C @@temp_dir@@/pkg/_build/satysfi --no-default-config doc-example.saty -o doc-example-ja.pdf
 doc-example.saty -> doc-example-ja.pdf

--- a/test/testcases/command_opam_build__doc_satysfi.expected
+++ b/test/testcases/command_opam_build__doc_satysfi.expected
@@ -44,7 +44,7 @@ Installation completed!
 ------------------------------------------------------------
 ------------------------------------------------------------
 Command invoked:
-satysfi -C @@build@@/satysfi --version
+satysfi --version
 Command invoked:
-satysfi -C @@build@@/satysfi doc-grcnum.saty -o doc-grcnum-ja.pdf
+satysfi -C @@build@@/satysfi --no-default-config doc-grcnum.saty -o doc-grcnum-ja.pdf
 doc-grcnum.saty -> doc-grcnum-ja.pdf

--- a/test/testlib/prepareBin.ml
+++ b/test/testlib/prepareBin.ml
@@ -1,5 +1,5 @@
 
-let satysfi log_file =
+let satysfi ~version_string log_file =
   let log_invocation =
 {|
     echo 'Command invoked:' >> $LOG_FILE
@@ -36,7 +36,7 @@ done
 payload () {
 case "$MODE" in
   version)
-    echo '  SATySFi version 0.0.3'
+    echo "  SATySFi version $VERSION_STRING"
     ;;
   process)
     echo "$INPUT -> $OUTPUT" >> $LOG_FILE
@@ -47,6 +47,7 @@ esac
   in
   String.concat "\n"
     [ "#!/bin/sh";
+      "VERSION_STRING='" ^ version_string ^ "'" ;
       "LOG_FILE='" ^ log_file ^"'";
       "MODE=help";
       "INPUT=";
@@ -83,7 +84,7 @@ esac
     ]
 
 (* TODO Refactor this so that bin_dir is implicitly shared by the main test function (e.g., test_install) *)
-let prepare_bin ?opam_response bin log_file =
+let prepare_bin ?opam_response ?(version_string="0.0.6") bin log_file =
   let path = Unix.getenv "PATH" in
   let gen_bin name content =
     let path = FilePath.concat bin name in
@@ -96,5 +97,5 @@ let prepare_bin ?opam_response bin log_file =
   let open Shexp_process in
   let open Infix in
   Unix.putenv "PATH" (bin ^ ":" ^ path);
-  gen_bin "satysfi" (satysfi log_file)
+  gen_bin "satysfi" (satysfi ~version_string log_file)
   >> gen_bin "opam" (opam ~opam_response log_file)


### PR DESCRIPTION
We can use --no-default-config option, which was introduced by
<https://github.com/gfngfn/SATySFi/pull/212>.

This fixes a problem where SATySFi may see stale `/usr/local/share/satysfi`.