### PR TITLE
Fix a wrong name used in an added section by migrate

### DIFF
--- a/src/command/migrate.ml
+++ b/src/command/migrate.ml
@@ -34,8 +34,8 @@ let migrate_0_0_2 ~outf ~buildscript_path  =
       | [] ->
         Format.fprintf outf "Fixing build section in %s.@." opam_path;
         let cmd =
-          ["satyrographos"; "opam"; "install";
-           "--name"; "satysfi-" ^ name;
+          ["satyrographos"; "opam"; "build";
+           "--name"; name;
            "--prefix"; "%{prefix}%";
            "--script"; "%{build}%/Satyristes"]
         in
@@ -45,8 +45,8 @@ let migrate_0_0_2 ~outf ~buildscript_path  =
       | _ ->
         Format.fprintf outf {|Please be sure %s has the following build section.@.
 build:
-  ["satyrographos" "opam" "install"
-   "--name" "satysfi-%s"
+  ["satyrographos" "opam" "build"
+   "--name" "%s"
    "--prefix" "%%{prefix}%%"
    "--script" "%%{build}%%/Satyristes"]
 |} opam_path name;

--- a/test/testcases/command_migrate__build_0_0_2.t
+++ b/test/testcases/command_migrate__build_0_0_2.t
@@ -81,8 +81,8 @@ Migrate the library
   Please be sure satysfi-package-doc.opam has the following build section.
   
   build:
-    ["satyrographos" "opam" "install"
-     "--name" "satysfi-package-doc"
+    ["satyrographos" "opam" "build"
+     "--name" "package-doc"
      "--prefix" "%{prefix}%"
      "--script" "%{build}%/Satyristes"]
   Done.
@@ -124,9 +124,9 @@ Dump generated files
   > build: [
   >   "satyrographos"
   >   "opam"
-  >   "install"
+  >   "build"
   >   "--name"
-  >   "satysfi-package"
+  >   "package"
   >   "--prefix"
   >   "%{prefix}%"
   >   "--script"


### PR DESCRIPTION
Satyrographos migrate subcommand added a build section with a wrong module name,
which is suffixed by "satysfi-", while it should not be.

It also set a wrong task name to `satyrographos opam` subcommand.