### PR TITLE
Install dependencies of doc module before building

### DIFF
--- a/bin/commandBuild.ml
+++ b/bin/commandBuild.ml
@@ -15,7 +15,7 @@ let build_command =
     ~summary:"Build modules (experimental)"
     [%map_open
       let script = flag "--script" (optional string) ~doc:"SCRIPT Install script"
-      and name = anon (maybe ("MODULE_NAME" %: string))
+      and names = anon (sequence ("MODULE_NAME" %: string))
       and verbose = flag  "--verbose" no_arg ~doc:"Make verbose"
       in
       Compatibility.optin ();
@@ -28,6 +28,7 @@ let build_command =
       in
       let env = Setup.read_environment () in
       (fun () ->
-         Satyrographos_command.Build.build_command ~outf ~build_dir ~buildscript_path ~name ~verbose ~env;
+         let names = if List.is_empty names then None else Some names in
+         Satyrographos_command.Build.build_command ~outf ~build_dir ~buildscript_path ~names ~verbose ~env;
          reprint_err_warn ())
     ]

--- a/test/testcases/command_build__doc_make.expected
+++ b/test/testcases/command_build__doc_make.expected
@@ -1,9 +1,14 @@
 Installing packages
 ------------------------------------------------------------
+= Pin projects
+
+= Build modules: (example-doc)
+
+== Build module example-doc
+=== Build docs
 Target: build-doc
 ==============================
 0
-
 ================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
@@ -26,8 +31,6 @@ Installation completed!
   Packages have been renamed.
   
     grcnum.satyh -> grcnum/grcnum.satyh
-
-================
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------

--- a/test/testcases/command_build__doc_make.expected
+++ b/test/testcases/command_build__doc_make.expected
@@ -5,6 +5,7 @@ Installing packages
 = Build modules: (example-doc)
 
 == Build module example-doc
+== Install dependencies: (fonts-theano grcnum)
 === Build docs
 Target: build-doc
 ==============================
@@ -34,3 +35,6 @@ Installation completed!
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------
+------------------------------------------------------------
+Command invoked:
+opam install --yes satysfi-fonts-theano satysfi-grcnum

--- a/test/testcases/command_build__doc_make.ml
+++ b/test/testcases/command_build__doc_make.ml
@@ -54,7 +54,7 @@ let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
 let () =
   let verbose = false in
   let main env ~dest_dir:_ ~temp_dir ~outf =
-    let name = Some "example-doc" in
+    let names = Some ["example-doc"] in
     (* let dest_dir = FilePath.concat dest_dir "dest" in *)
     Satyrographos_command.Build.build_command
       ~outf
@@ -62,6 +62,6 @@ let () =
       ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
       ~build_dir:(FilePath.concat temp_dir "pkg/_build" |> Option.some)
       ~env
-      ~name
+      ~names
   in
   eval (test_install env main)

--- a/test/testcases/command_build__doc_satysfi.expected
+++ b/test/testcases/command_build__doc_satysfi.expected
@@ -3,8 +3,13 @@ SATySFi 0.0.6
 
 Installing packages
 ------------------------------------------------------------
-Target: build-doc
+= Pin projects
 
+= Build modules: (example-doc)
+
+== Build module example-doc
+=== Build docs
+Target: build-doc
 ================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
@@ -27,8 +32,6 @@ Installation completed!
   Packages have been renamed.
   
     grcnum.satyh -> grcnum/grcnum.satyh
-
-================
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------
@@ -43,8 +46,13 @@ SATySFi 0.0.4
 
 Installing packages
 ------------------------------------------------------------
-Target: build-doc
+= Pin projects
 
+= Build modules: (example-doc)
+
+== Build module example-doc
+=== Build docs
+Target: build-doc
 ================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
@@ -67,8 +75,6 @@ Installation completed!
   Packages have been renamed.
   
     grcnum.satyh -> grcnum/grcnum.satyh
-
-================
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------
@@ -83,8 +89,13 @@ SATySFi 0.0.3
 
 Installing packages
 ------------------------------------------------------------
-Target: build-doc
+= Pin projects
 
+= Build modules: (example-doc)
+
+== Build module example-doc
+=== Build docs
+Target: build-doc
 ================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
@@ -107,8 +118,6 @@ Installation completed!
   Packages have been renamed.
   
     grcnum.satyh -> grcnum/grcnum.satyh
-
-================
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------

--- a/test/testcases/command_build__doc_satysfi.expected
+++ b/test/testcases/command_build__doc_satysfi.expected
@@ -8,6 +8,7 @@ Installing packages
 = Build modules: (example-doc)
 
 == Build module example-doc
+== Install dependencies: (fonts-theano grcnum)
 === Build docs
 Target: build-doc
 ================
@@ -36,6 +37,8 @@ Installation completed!
 @@dest_dir@@
 ------------------------------------------------------------
 ------------------------------------------------------------
+Command invoked:
+opam install --yes satysfi-fonts-theano satysfi-grcnum
 Command invoked:
 satysfi --version
 Command invoked:
@@ -51,6 +54,7 @@ Installing packages
 = Build modules: (example-doc)
 
 == Build module example-doc
+== Install dependencies: (fonts-theano grcnum)
 === Build docs
 Target: build-doc
 ================
@@ -79,6 +83,8 @@ Installation completed!
 @@dest_dir@@
 ------------------------------------------------------------
 ------------------------------------------------------------
+Command invoked:
+opam install --yes satysfi-fonts-theano satysfi-grcnum
 Command invoked:
 satysfi --version
 Command invoked:
@@ -94,6 +100,7 @@ Installing packages
 = Build modules: (example-doc)
 
 == Build module example-doc
+== Install dependencies: (fonts-theano grcnum)
 === Build docs
 Target: build-doc
 ================
@@ -122,6 +129,8 @@ Installation completed!
 @@dest_dir@@
 ------------------------------------------------------------
 ------------------------------------------------------------
+Command invoked:
+opam install --yes satysfi-fonts-theano satysfi-grcnum
 Command invoked:
 satysfi --version
 Command invoked:

--- a/test/testcases/command_build__doc_satysfi.ml
+++ b/test/testcases/command_build__doc_satysfi.ml
@@ -53,7 +53,7 @@ let env ~version_string ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
 let () =
   let verbose = false in
   let main env ~dest_dir:_ ~temp_dir ~outf =
-    let name = Some "example-doc" in
+    let names = Some ["example-doc"] in
     (* let dest_dir = FilePath.concat dest_dir "dest" in *)
     Satyrographos_command.Build.build_command
       ~outf
@@ -61,7 +61,7 @@ let () =
       ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
       ~build_dir:(FilePath.concat temp_dir "pkg/_build" |> Option.some)
       ~env
-      ~name
+      ~names
   in
   Format.(fprintf std_formatter "========@.SATySFi 0.0.6@.@.");
   eval (test_install (env ~version_string:"0.0.6")  main);

--- a/test/testcases/command_build__doc_with_autogen.expected
+++ b/test/testcases/command_build__doc_with_autogen.expected
@@ -1,7 +1,12 @@
 Installing packages
 ------------------------------------------------------------
-Target: build-doc
+= Pin projects
 
+= Build modules: (example-doc)
+
+== Build module example-doc
+=== Build docs
+Target: build-doc
 ================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
@@ -14,8 +19,6 @@ Generating autogen library $libraries
 Installing libraries: ($libraries $today dist localized-today)
 Removing destination @@temp_dir@@/pkg/_build/satysfi/dist
 Installation completed!
-
-================
 ------------------------------------------------------------
 @@temp_dir@@/pkg
 @@temp_dir@@/pkg/Makefile

--- a/test/testcases/command_build__doc_with_autogen.expected
+++ b/test/testcases/command_build__doc_with_autogen.expected
@@ -5,6 +5,7 @@ Installing packages
 = Build modules: (example-doc)
 
 == Build module example-doc
+== Install dependencies: (localized-today)
 === Build docs
 Target: build-doc
 ================
@@ -161,6 +162,8 @@ diff -Nr @@empty_dir@@/satysfi-grcnum.opam @@temp_dir@@/pkg/satysfi-grcnum.opam
 > ]
 > 
 ------------------------------------------------------------
+Command invoked:
+opam install --yes satysfi-localized-today
 Command invoked:
 satysfi --version
 Command invoked:

--- a/test/testcases/command_build__doc_with_autogen.ml
+++ b/test/testcases/command_build__doc_with_autogen.ml
@@ -84,7 +84,7 @@ let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
 let () =
   let verbose = false in
   let main env ~dest_dir:_ ~temp_dir ~outf =
-    let name = Some "example-doc" in
+    let names = Some ["example-doc"] in
     (* let dest_dir = FilePath.concat dest_dir "dest" in *)
     Satyrographos_command.Build.build_command
       ~outf
@@ -92,7 +92,7 @@ let () =
       ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
       ~build_dir:(FilePath.concat temp_dir "pkg/_build" |> Option.some)
       ~env
-      ~name
+      ~names
   in
   let post_dump_dirs ~dest_dir:_ ~temp_dir =
     let pkg_dir = FilePath.concat temp_dir "pkg" in

--- a/test/testcases/command_build__doc_with_libraries.expected
+++ b/test/testcases/command_build__doc_with_libraries.expected
@@ -5,6 +5,7 @@ Installing packages
 = Build modules: (example-doc)
 
 == Build module example-doc
+== Install dependencies: (fonts-theano grcnum)
 === Build docs
 Target: build-doc
 ================
@@ -37,6 +38,8 @@ Command invoked:
 opam pin add --no-action --yes satysfi-grcnum file://@@temp_dir@@/pkg
 Command invoked:
 opam reinstall --verbose --yes @@temp_dir@@/pkg
+Command invoked:
+opam install --yes satysfi-fonts-theano satysfi-grcnum
 Command invoked:
 satysfi --version
 Command invoked:

--- a/test/testcases/command_build__doc_with_libraries.expected
+++ b/test/testcases/command_build__doc_with_libraries.expected
@@ -1,7 +1,12 @@
 Installing packages
 ------------------------------------------------------------
-Target: build-doc
+= Pin projects
 
+= Build modules: (example-doc)
+
+== Build module example-doc
+=== Build docs
+Target: build-doc
 ================
 Reading runtime dist: @@temp_dir@@/empty_dist
 Read user libraries: ()
@@ -24,8 +29,6 @@ Installation completed!
   Packages have been renamed.
   
     grcnum.satyh -> grcnum/grcnum.satyh
-
-================
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------
@@ -33,7 +36,7 @@ Installation completed!
 Command invoked:
 opam pin add --no-action --yes satysfi-grcnum file://@@temp_dir@@/pkg
 Command invoked:
-opam reinstall @@temp_dir@@/pkg
+opam reinstall --verbose --yes @@temp_dir@@/pkg
 Command invoked:
 satysfi --version
 Command invoked:

--- a/test/testcases/command_build__doc_with_libraries.ml
+++ b/test/testcases/command_build__doc_with_libraries.ml
@@ -94,7 +94,7 @@ let env ~dest_dir:_ ~temp_dir : Satyrographos.Environment.t t =
 let () =
   let verbose = false in
   let main env ~dest_dir:_ ~temp_dir ~outf =
-    let name = Some "example-doc" in
+    let names = Some ["example-doc"] in
     (* let dest_dir = FilePath.concat dest_dir "dest" in *)
     Satyrographos_command.Build.build_command
       ~outf
@@ -102,6 +102,6 @@ let () =
       ~buildscript_path:(FilePath.concat temp_dir "pkg/Satyristes")
       ~build_dir:(FilePath.concat temp_dir "pkg/_build" |> Option.some)
       ~env
-      ~name
+      ~names
   in
   eval (test_install env main)


### PR DESCRIPTION
This PR introduces two features to build subcommand:

- Accepting multiple module names.  If no module names are given, Satyrographos builds all the modules described in the Satyristes.
- Installing dependencies of doc module before building