### PR TITLE
Add newer version of OCaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,9 @@ jobs:
           - 'ubuntu-latest'
 #         - 'macos-latest'
         ocaml-version:
-          - 4.09.1
-          - 4.10.1
-          - 4.11.1
+          - 4.10.2
+          - 4.11.2
+          - 4.12.1
     runs-on: ${{ matrix.os }}
     env:
       OPAMSOLVERTIMEOUT: 3600

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
           - 'ubuntu-latest'
 #         - 'macos-latest'
         ocaml-version:
+          - 4.09.1
           - 4.10.2
           - 4.11.2
           - 4.12.1


### PR DESCRIPTION
- SATySFi does not support OCaml 4.09 on CI so I drop this version
    - https://github.com/gfngfn/SATySFi/blob/8a1b1fbefae9c6958d06ee64218619e00ef0afc7/.github/workflows/ci.yml#L12-L15
