### PR TITLE
Use ocaml-0install to test with minimal version sets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,6 @@ jobs:
     name: Build
     strategy:
       matrix:
-        with-satysfi:
-          - false
         os:
           - 'ubuntu-latest'
 #         - 'macos-latest'
@@ -19,6 +17,11 @@ jobs:
           - 4.10.2
           - 4.11.2
           - 4.12.1
+        with-satysfi:
+          - false
+        oldest-dependencies:
+          - true
+          - false
     runs-on: ${{ matrix.os }}
     env:
       OPAMSOLVERTIMEOUT: 3600
@@ -32,7 +35,7 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-version }}
           dune-cache: true
 
-          cache-prefix: "satysfi-${{ matrix.with-satysfi }}"
+          cache-prefix: "oldestdeps-${{ matrix.oldest-dependencies }}-satysfi-${{ matrix.with-satysfi }}"
 
       - name: Check validity of the snapshot OPAM files
         run: |
@@ -44,11 +47,6 @@ jobs:
           opam repository add satysfi-external https://github.com/gfngfn/satysfi-external-repo.git
           opam repository add satyrographos https://github.com/na4zagin3/satyrographos-repo.git
 
-      - name: Setup OPAM repositories
-        run: |
-          opam update
-          opam upgrade --yes
-
       - name: Install SATySFi
         if: matrix.with-satysfi
         run: |
@@ -58,9 +56,22 @@ jobs:
           opam install satysfi --yes
 
       - name: Install Satyrographos
+        if: ${{ ! matrix.oldest-dependencies }}
         run: |
           opam install satyrographos --yes --with-doc
-          
+
+
+      - name: Install Satyrographos (oldest dependencies)
+        if: matrix.oldest-dependencies
+        run: |
+          OCAML_PACKAGE="ocaml.$(opam show --color=never -f version ocaml)"
+          SATYROGRAPHOS_PACKAGE=satyrographos
+          # export OPAMEXTERNALSOLVER=builtin-0install
+          # export OPAMCRITERIA=+removed,+count[version-lag,solution]
+          opam install opam-0install
+          opam install --yes $(opam exec -- opam-0install --prefer-oldest "$SATYROGRAPHOS_PACKAGE" "$OCAML_PACKAGE")
+
+
       - name: Test Satyrographos
         run: |
           opam lint

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -25,7 +25,7 @@ depends: [
   "dune" {>= "2.7"}
   "fileutils"
   "json-derivers"
-  "menhir" {>= "20180523"}
+  "menhir" {>= "20181006"}
   "ppx_deriving"
   "ppx_deriving_yojson"
   "ocamlgraph"

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -29,8 +29,8 @@ depends: [
   "ppx_deriving"
   "ppx_deriving_yojson"
   "ocamlgraph"
-  ( "opam-format" {>= "2.0.0" & < "2.2"}
-    & "opam-state" {>= "2.0.0" & < "2.2"}
+  ( "opam-format" {>= "2.0.4" & < "2.2"}
+    & "opam-state" {>= "2.0.4" & < "2.2"}
     & "ocaml" {< "4.12.0"}
   | "opam-format" {>= "2.1.0" & < "2.2"}
     & "opam-state" {>= "2.1.0" & < "2.2"}
@@ -48,6 +48,7 @@ depends: [
   "ppx_jane"
   "shexp"
 ]
+
 synopsis: "A package manager for SATySFi"
 description: """
 Satyrographos is a package manager for [SATySFi].

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -29,8 +29,13 @@ depends: [
   "ppx_deriving"
   "ppx_deriving_yojson"
   "ocamlgraph"
-  "opam-format" {>= "2.0.0" & < "2.1"}
-  "opam-state" {>= "2.0.0" & < "2.1"}
+  ( "opam-format" {>= "2.0.0" & < "2.2"}
+    & "opam-state" {>= "2.0.0" & < "2.2"}
+    & "ocaml" {< "4.12.0"}
+  | "opam-format" {>= "2.1.0" & < "2.2"}
+    & "opam-state" {>= "2.1.0" & < "2.2"}
+    & "ocaml" {>= "4.12.0"}
+  )
   "re" { >= "1.9.0" }
   "stringext" {with-test}
   "uri" {>= "3.0.0"}

--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -25,13 +25,13 @@ depends: [
   "dune" {>= "2.7"}
   "fileutils"
   "json-derivers"
-  "menhir"
+  "menhir" {>= "20180523"}
   "ppx_deriving"
   "ppx_deriving_yojson"
   "ocamlgraph"
-  "opam-format" {>= "2.0" & < "2.1"}
-  "opam-state" {>= "2.0" & < "2.1"}
-  "re"
+  "opam-format" {>= "2.0.0" & < "2.1"}
+  "opam-state" {>= "2.0.0" & < "2.1"}
+  "re" { >= "1.9.0" }
   "stringext" {with-test}
   "uri" {>= "3.0.0"}
   "uri-sexp" {>= "3.0.0"}


### PR DESCRIPTION
This is an attempt to bring a feature of OCaml CI to detect problems before submitting the MR to opam-repository (v. https://github.com/ocaml/opam-repository/pull/20220).

Closes https://github.com/na4zagin3/satyrographos/issues/294