### PR TITLE
Catch all exceptions during reading libraries

### DIFF
--- a/src/command/install.ml
+++ b/src/command/install.ml
@@ -31,9 +31,11 @@ let get_libraries ~outf ~(env: Environment.t) ~libraries =
         |> StringSet.to_map ~f:(OpamSatysfiRegistry.directory reg_opam)
   in
   Format.fprintf outf "Reading opam libraries: %s\n" (opam_libraries |> Map.keys |> [%sexp_of: string list] |> Sexp.to_string_hum);
-  let all_libraries = Map.filter_map opam_libraries ~f:(fun dir ->
+  let all_libraries = Map.filter_mapi opam_libraries ~f:(fun ~key:name ~data:dir ->
       Library.read_dir_result ~outf dir
-    |> Result.map_error ~f:(Format.fprintf outf "Warning: %s")
+      |> Result.map_error ~f:(fun err ->
+          Format.fprintf outf "Warning: Failed to read library %s at %s\nReason: %s\n" name dir err;
+          ())
     |> Result.ok) in
   let all_libraries = match Map.add all_libraries ~key:"dist" ~data:dist_library with
     | `Ok result -> result

--- a/src/library.ml
+++ b/src/library.ml
@@ -254,7 +254,7 @@ let save_metadata f (p: t) =
 
 let metadata_filename = "metadata"
 
-let read_dir_result ~outf d =
+let read_dir ~outf d =
   let add acc f =
     let rel_f = FilePath.make_relative d f in
     match rel_f with
@@ -272,14 +272,20 @@ let read_dir_result ~outf d =
       add_file rel_f f acc
   in
   if FileUtil.test FileUtil.Is_dir d
-  then
-    FileUtil.(find ~follow:Follow Is_file d add empty)
-    |> Result.return
-  else Result.failf "%s is not a library directory" d
+  then FileUtil.(find ~follow:Follow Is_file d add empty)
+  else failwithf "%s is not a library directory" d ()
 
-let read_dir ~outf d =
-  read_dir_result ~outf d
-  |> Result.ok_or_failwith
+let read_dir_result ~outf d =
+  Result.try_with (fun () -> read_dir ~outf d)
+  |> Result.map_error ~f:(fun exn ->
+      let backtrace =
+        Printexc.get_backtrace ()
+        |> String.split_lines
+        |> List.cons ""
+        |> String.concat ~sep:"\n  "
+      in
+      Exn.to_string exn
+      ^ backtrace)
 
 let write_dir ?(verbose=false) ?(symlink=false) ~outf d p =
   let p = normalize ~outf p in


### PR DESCRIPTION
This commit handles a race-condition when non-dependent packages are being
removed during reading libraries.