### PR TITLE
Refactor cram test cases with shell functions and library-opam list subcommand

### DIFF
--- a/test/testcases/command_new__doc_make.t
+++ b/test/testcases/command_new__doc_make.t
@@ -1,3 +1,6 @@
+Load utility functions
+  $ . ./test-utils.sh
+
 Create a new document with doc-make@en template
   $ satyrographos new [experimental]doc-make@en --license CC-BY-4.0 test-doc-en
   Name: test-doc-en
@@ -5,7 +8,7 @@ Create a new document with doc-make@en template
   Created a new library/document.
 
 Try to build when there is satysfi command
-  $ if command satysfi --version >/dev/null 2>&1 && opam list -i --silent satysfi-dist && opam list -i --silent satysfi-fss ; then
+  $ if test_satysfi_pkgs dist fss ; then
   >   cd test-doc-en
   >   SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos build >build.log 2>&1
   >   [ -f main.pdf ] || cat build.log
@@ -19,7 +22,7 @@ Create a new document with doc-make@ja template
   Created a new library/document.
 
 Try to build when there is satysfi command
-  $ if command satysfi --version >/dev/null 2>&1 && opam list -i --silent satysfi-dist && opam list -i --silent satysfi-fss ; then
+  $ if test_satysfi_pkgs dist fss ; then
   >   cd test-doc-ja
   >   SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos build >build.log 2>&1
   >   [ -f main.pdf ] || cat build.log

--- a/test/testcases/command_new__doc_omake.t
+++ b/test/testcases/command_new__doc_omake.t
@@ -1,3 +1,6 @@
+Load utility functions
+  $ . ./test-utils.sh
+
 Create a new document with doc-omake@en template
   $ satyrographos new [experimental]doc-omake@en --license CC-BY-4.0 test-doc-en
   Name: test-doc-en
@@ -5,7 +8,7 @@ Create a new document with doc-omake@en template
   Created a new library/document.
 
 Try to build when there is satysfi command
-  $ if command satysfi --version >/dev/null 2>&1 && command omake --version >/dev/null 2>&1 && opam list -i --silent satysfi-dist && opam list -i --silent satysfi-fss ; then
+  $ if test_omake && test_satysfi_pkgs dist fss ; then
   >   cd test-doc-en
   >   SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos build >build.log 2>&1
   >   [ -f main.pdf ] || cat build.log
@@ -19,7 +22,7 @@ Create a new document with doc-omake@ja template
   Created a new library/document.
 
 Try to build when there is satysfi command
-  $ if command satysfi --version >/dev/null 2>&1 && command omake --version >/dev/null 2>&1 && opam list -i --silent satysfi-dist && opam list -i --silent satysfi-fss ; then
+  $ if test_omake && test_satysfi_pkgs dist fss ; then
   >   cd test-doc-ja
   >   SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos build >build.log 2>&1
   >   [ -f main.pdf ] || cat build.log

--- a/test/testcases/command_new__example_autogen.t
+++ b/test/testcases/command_new__example_autogen.t
@@ -1,3 +1,6 @@
+Load utility functions
+  $ . ./test-utils.sh
+
 Create a new document with example-autogen template
   $ satyrographos new [experimental]example-autogen --license CC-BY-4.0 test-example-autogen
   Name: test-example-autogen
@@ -5,7 +8,7 @@ Create a new document with example-autogen template
   Created a new library/document.
 
 Try to build when there is satysfi command
-  $ if command satysfi --version >/dev/null 2>&1 && command fc-scan --version >/dev/null 2>&1 && opam list -i --silent satysfi-dist ; then
+  $ if test_fontconfig && test_satysfi_pkgs dist fss ; then
   >   cd test-example-autogen
   >   SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos build >build.log 2>&1
   >   [ -f main.pdf ] || cat build.log

--- a/test/testcases/dune
+++ b/test/testcases/dune
@@ -66,4 +66,4 @@
  )
 
 (cram
- (deps %{bin:satyrographos}))
+ (deps %{bin:satyrographos} ./test-utils.sh))

--- a/test/testcases/test-utils.sh
+++ b/test/testcases/test-utils.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 
 test_satysfi_pkgs () {
-    PKGS=$(SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos library-opam list 2>/dev/null )
-    command satysfi --version >/dev/null 2>&1 && [[ 0 -eq "$( sort <(printf "%s\n" "$@") <(echo "$PKGS") <(echo "$PKGS") | uniq -u | wc -l)" ]]
+    command satysfi --version >/dev/null 2>&1 || return $?
+    PKGS="$(mktemp)"
+    SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos library-opam list 2>/dev/null >"$PKGS"
+    [[ 0 -eq "$( printf "%s\n" "$@" | sort - <"$PKGS" <"$PKGS" | uniq -u | wc -l)" ]]
+
+    trap 'rm "$PKGS"' 0
 }
 
 test_omake () {

--- a/test/testcases/test-utils.sh
+++ b/test/testcases/test-utils.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+test_satysfi_pkgs () {
+    PKGS=$(SATYROGRAPHOS_EXPERIMENTAL=1 satyrographos library-opam list 2>/dev/null )
+    command satysfi --version >/dev/null 2>&1 && [[ 0 -eq "$( sort <(printf "%s\n" "$@") <(echo "$PKGS") <(echo "$PKGS") | uniq -u | wc -l)" ]]
+}
+
+test_omake () {
+    command omake --version >/dev/null 2>&1
+}
+
+test_fontconfig () {
+    command fc-scan --version >/dev/null 2>&1
+}


### PR DESCRIPTION
This MR makes the cram test cases load shared shell functions.  It also makes testing Satyrographos libraries with `library-opam` subcommand instead of directly invoking `opam list` command.