### PR TITLE
Install: show reverse dependencies of missing libraries

### DIFF
--- a/test/testcases/command_install__thirdParties_brokenDependency.expected
+++ b/test/testcases/command_install__thirdParties_brokenDependency.expected
@@ -1,7 +1,8 @@
 Installing packages
 ------------------------------------------------------------
 Exception:
-(Failure "Missing dependencies: (fonts-theano)")
+(Failure
+  "Missing dependencies: (fonts-theano). Revdeps: ((fonts-theano (grcnum)))")
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------

--- a/test/testcases/command_install_l__thirdParties_brokenDependency.expected
+++ b/test/testcases/command_install_l__thirdParties_brokenDependency.expected
@@ -1,7 +1,8 @@
 Installing packages
 ------------------------------------------------------------
 Exception:
-(Failure "Missing dependencies: (fonts-theano)")
+(Failure
+  "Missing dependencies: (fonts-theano). Revdeps: ((fonts-theano (grcnum)))")
 ------------------------------------------------------------
 @@dest_dir@@
 ------------------------------------------------------------


### PR DESCRIPTION
This commit adds more information to error messages that reports missing dependencies.

Previous:

    (Failure "Missing dependencies: (fonts-theano)")

Now:

    (Failure "Missing dependencies: (fonts-theano). Revdeps: ((fonts-theano (grcnum)))")