### PR TITLE
Use the Yojson 2.0 signatures of `to_string` and `from_file`

### DIFF
--- a/satyrographos.opam
+++ b/satyrographos.opam
@@ -42,7 +42,7 @@ depends: [
   "uri-sexp" {>= "3.0.0"}
   "yaml" {>= "3.0" & < "4.0"}
   "yaml-sexp" {>= "3.0" & < "4.0"}
-  "yojson"
+  "yojson" {>= "2.0.0"}
 
   # Janestreet Libs
   "core" {>= "v0.14" & < "v0.15"}

--- a/src/library.mli
+++ b/src/library.mli
@@ -7,9 +7,9 @@ end
 module Json : sig
   include module type of Json_derivers.Yojson
   val to_string :
-    ?buf:Bi_outbuf.t -> ?len:int -> ?std:bool -> t -> string
+    ?buf:Buffer.t -> ?len:int -> ?suf:string -> ?std:bool -> t -> string
   val from_file :
-    ?buf:Bi_outbuf.t -> ?fname:string -> ?lnum:int -> string -> t
+    ?buf:Buffer.t -> ?fname:string -> ?lnum:int -> string -> t
   val to_file :
     ?len:int -> ?std:bool -> string -> t -> unit
 end


### PR DESCRIPTION
This ensures compatibility going forward.

Currently this is problematic because there is no `ppx_deriving_yojson` version that is compatible but as soon as https://github.com/ocaml/opam-repository/pull/21523 is merged it should work